### PR TITLE
Adding FashionMNIST dataset code

### DIFF
--- a/CM4.ipynb
+++ b/CM4.ipynb
@@ -1,0 +1,4039 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "portuguese-patient",
+   "metadata": {
+    "papermill": {
+     "duration": 0.049526,
+     "end_time": "2021-04-26T04:07:19.257414",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:19.207888",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# <div align=\"center\">CM4</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "hired-watershed",
+   "metadata": {
+    "papermill": {
+     "duration": 0.048168,
+     "end_time": "2021-04-26T04:07:19.353966",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:19.305798",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4.1 Importing Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "honest-slovenia",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:19.463647Z",
+     "iopub.status.busy": "2021-04-26T04:07:19.463013Z",
+     "iopub.status.idle": "2021-04-26T04:07:25.858500Z",
+     "shell.execute_reply": "2021-04-26T04:07:25.857868Z"
+    },
+    "papermill": {
+     "duration": 6.456198,
+     "end_time": "2021-04-26T04:07:25.858645",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:19.402447",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/kaggle/input/asgn4fashionmnist/fashion_mnist_dataset_train.npy\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Handle table-like data and matrices :\n",
+    "import numpy as np \n",
+    "import pandas as pd \n",
+    "\n",
+    "\n",
+    "import os\n",
+    "for dirname, _, filenames in os.walk('/kaggle/input'):\n",
+    "    for filename in filenames:\n",
+    "        print(os.path.join(dirname, filename))\n",
+    "\n",
+    "        \n",
+    "# Modelling Helpers Libraries\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import confusion_matrix, classification_report\n",
+    "from sklearn.model_selection import GridSearchCV , KFold , cross_val_score\n",
+    "\n",
+    "# Deep Learning Libraries\n",
+    "import tensorflow as tf\n",
+    "from keras.utils import to_categorical\n",
+    "from keras.models import Sequential, load_model\n",
+    "from keras.layers import Dense, Dropout, Flatten\n",
+    "from keras.layers import Conv2D, MaxPooling2D, BatchNormalization\n",
+    "from keras.optimizers import Adam,SGD,Adagrad,Adadelta,RMSprop\n",
+    "from keras.preprocessing.image import ImageDataGenerator\n",
+    "from keras.callbacks import ReduceLROnPlateau, LearningRateScheduler\n",
+    "\n",
+    "# Resnet \n",
+    "import keras\n",
+    "from keras.layers import AveragePooling2D, Input, Flatten\n",
+    "from keras.layers import Dense, Conv2D, BatchNormalization, Activation\n",
+    "from keras.regularizers import l2\n",
+    "from keras.models import Model\n",
+    "import os\n",
+    "from keras.callbacks import ModelCheckpoint, ReduceLROnPlateau\n",
+    "\n",
+    "# Machine Learning Model\n",
+    "from sklearn.model_selection import GridSearchCV\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn import metrics\n",
+    "\n",
+    "# Visualisation\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Time library\n",
+    "import time \n",
+    "\n",
+    "\n",
+    "# Classification\n",
+    "from sklearn.metrics import accuracy_score,precision_score,recall_score,f1_score,confusion_matrix,classification_report\n",
+    "import itertools\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "quiet-finland",
+   "metadata": {
+    "papermill": {
+     "duration": 0.049437,
+     "end_time": "2021-04-26T04:07:25.958369",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:25.908932",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4.2 Extract Dataset\n",
+    "\n",
+    "- Dataset is in .npy file and after extract it converted into 0-D array.\n",
+    "- We converted 0-D array to dictionary and then created Dataframe using pandas library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "impaired-individual",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:26.065124Z",
+     "iopub.status.busy": "2021-04-26T04:07:26.064399Z",
+     "iopub.status.idle": "2021-04-26T04:07:29.377581Z",
+     "shell.execute_reply": "2021-04-26T04:07:29.376528Z"
+    },
+    "papermill": {
+     "duration": 3.369965,
+     "end_time": "2021-04-26T04:07:29.377727",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:26.007762",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "data = np.load('../input/asgn4fashionmnist/fashion_mnist_dataset_train.npy', allow_pickle=True).item()\n",
+    "data = np.array(data)\n",
+    "my_dict = data[()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "stainless-extraction",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:29.482717Z",
+     "iopub.status.busy": "2021-04-26T04:07:29.480987Z",
+     "iopub.status.idle": "2021-04-26T04:07:29.483346Z",
+     "shell.execute_reply": "2021-04-26T04:07:29.483746Z"
+    },
+    "papermill": {
+     "duration": 0.056394,
+     "end_time": "2021-04-26T04:07:29.483874",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:29.427480",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "features = my_dict.get('features')\n",
+    "target = my_dict.get('target')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "greater-conclusion",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:29.589741Z",
+     "iopub.status.busy": "2021-04-26T04:07:29.588002Z",
+     "iopub.status.idle": "2021-04-26T04:07:29.590333Z",
+     "shell.execute_reply": "2021-04-26T04:07:29.590742Z"
+    },
+    "papermill": {
+     "duration": 0.057413,
+     "end_time": "2021-04-26T04:07:29.590885",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:29.533472",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "farray = features.reshape(features.shape[0], (features.shape[1]*features.shape[2]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "chief-climb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:29.697712Z",
+     "iopub.status.busy": "2021-04-26T04:07:29.697004Z",
+     "iopub.status.idle": "2021-04-26T04:07:29.699281Z",
+     "shell.execute_reply": "2021-04-26T04:07:29.699654Z"
+    },
+    "papermill": {
+     "duration": 0.059351,
+     "end_time": "2021-04-26T04:07:29.699799",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:29.640448",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "column_names = []\n",
+    "[column_names.append(\"pixel\"+str(x)) for x in range(0, 784)]\n",
+    "f1 = pd.DataFrame(farray , columns = column_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "wrong-prototype",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:29.811336Z",
+     "iopub.status.busy": "2021-04-26T04:07:29.810679Z",
+     "iopub.status.idle": "2021-04-26T04:07:29.838585Z",
+     "shell.execute_reply": "2021-04-26T04:07:29.838982Z"
+    },
+    "papermill": {
+     "duration": 0.089881,
+     "end_time": "2021-04-26T04:07:29.839146",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:29.749265",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pixel0</th>\n",
+       "      <th>pixel1</th>\n",
+       "      <th>pixel2</th>\n",
+       "      <th>pixel3</th>\n",
+       "      <th>pixel4</th>\n",
+       "      <th>pixel5</th>\n",
+       "      <th>pixel6</th>\n",
+       "      <th>pixel7</th>\n",
+       "      <th>pixel8</th>\n",
+       "      <th>pixel9</th>\n",
+       "      <th>...</th>\n",
+       "      <th>pixel774</th>\n",
+       "      <th>pixel775</th>\n",
+       "      <th>pixel776</th>\n",
+       "      <th>pixel777</th>\n",
+       "      <th>pixel778</th>\n",
+       "      <th>pixel779</th>\n",
+       "      <th>pixel780</th>\n",
+       "      <th>pixel781</th>\n",
+       "      <th>pixel782</th>\n",
+       "      <th>pixel783</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.003922</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.466667</td>\n",
+       "      <td>0.447059</td>\n",
+       "      <td>0.509804</td>\n",
+       "      <td>0.298039</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.086275</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.003922</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.129412</td>\n",
+       "      <td>0.376471</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 784 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   pixel0  pixel1  pixel2  pixel3  pixel4    pixel5  pixel6  pixel7    pixel8  \\\n",
+       "0     0.0     0.0     0.0     0.0     0.0  0.000000     0.0     0.0  0.000000   \n",
+       "1     0.0     0.0     0.0     0.0     0.0  0.003922     0.0     0.0  0.000000   \n",
+       "2     0.0     0.0     0.0     0.0     0.0  0.000000     0.0     0.0  0.000000   \n",
+       "3     0.0     0.0     0.0     0.0     0.0  0.000000     0.0     0.0  0.129412   \n",
+       "4     0.0     0.0     0.0     0.0     0.0  0.000000     0.0     0.0  0.000000   \n",
+       "\n",
+       "     pixel9  ...  pixel774  pixel775  pixel776  pixel777  pixel778  pixel779  \\\n",
+       "0  0.000000  ...  0.000000  0.000000  0.000000  0.000000       0.0       0.0   \n",
+       "1  0.000000  ...  0.466667  0.447059  0.509804  0.298039       0.0       0.0   \n",
+       "2  0.086275  ...  0.000000  0.000000  0.003922  0.000000       0.0       0.0   \n",
+       "3  0.376471  ...  0.000000  0.000000  0.000000  0.000000       0.0       0.0   \n",
+       "4  0.000000  ...  0.000000  0.000000  0.000000  0.000000       0.0       0.0   \n",
+       "\n",
+       "   pixel780  pixel781  pixel782  pixel783  \n",
+       "0       0.0       0.0       0.0       0.0  \n",
+       "1       0.0       0.0       0.0       0.0  \n",
+       "2       0.0       0.0       0.0       0.0  \n",
+       "3       0.0       0.0       0.0       0.0  \n",
+       "4       0.0       0.0       0.0       0.0  \n",
+       "\n",
+       "[5 rows x 784 columns]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f1.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "governing-animal",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:29.952015Z",
+     "iopub.status.busy": "2021-04-26T04:07:29.951113Z",
+     "iopub.status.idle": "2021-04-26T04:07:29.955196Z",
+     "shell.execute_reply": "2021-04-26T04:07:29.955733Z"
+    },
+    "papermill": {
+     "duration": 0.065606,
+     "end_time": "2021-04-26T04:07:29.955898",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:29.890292",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>target</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   target\n",
+       "0     5.0\n",
+       "1     2.0\n",
+       "2     1.0\n",
+       "3     2.0\n",
+       "4     1.0"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "column_names = ['target']\n",
+    "t1  = pd.DataFrame(target , columns = column_names)\n",
+    "t1.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "animal-mileage",
+   "metadata": {
+    "papermill": {
+     "duration": 0.05169,
+     "end_time": "2021-04-26T04:07:30.066182",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:30.014492",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Note :**\n",
+    "- As we are going to apply One hot encoding on target variable we decrease target values by 1.\n",
+    "- Otherwise during One Hot encoding we faced error of IndexOutOfBound error for last target value in to_categorical."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "different-vertical",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:30.175866Z",
+     "iopub.status.busy": "2021-04-26T04:07:30.175266Z",
+     "iopub.status.idle": "2021-04-26T04:07:30.193949Z",
+     "shell.execute_reply": "2021-04-26T04:07:30.193069Z"
+    },
+    "papermill": {
+     "duration": 0.075491,
+     "end_time": "2021-04-26T04:07:30.194098",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:30.118607",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "f1['target'] = t1['target'] - 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "overall-newcastle",
+   "metadata": {
+    "papermill": {
+     "duration": 0.050614,
+     "end_time": "2021-04-26T04:07:30.295481",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:30.244867",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 4.3 Dataset overview \n",
+    "\n",
+    "1. Dataset contains 28*28 size 60000 images and one target feature as a label.\n",
+    "2. Compare to FashionMNIST original dataset instead of 10 this dataset contains only 5 labels.\n",
+    "3. Each label contains around 12000 images so images are equally distributed across labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "romantic-number",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:30.427104Z",
+     "iopub.status.busy": "2021-04-26T04:07:30.423592Z",
+     "iopub.status.idle": "2021-04-26T04:07:30.432606Z",
+     "shell.execute_reply": "2021-04-26T04:07:30.432121Z"
+    },
+    "papermill": {
+     "duration": 0.086331,
+     "end_time": "2021-04-26T04:07:30.432732",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:30.346401",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pixel0</th>\n",
+       "      <th>pixel1</th>\n",
+       "      <th>pixel2</th>\n",
+       "      <th>pixel3</th>\n",
+       "      <th>pixel4</th>\n",
+       "      <th>pixel5</th>\n",
+       "      <th>pixel6</th>\n",
+       "      <th>pixel7</th>\n",
+       "      <th>pixel8</th>\n",
+       "      <th>pixel9</th>\n",
+       "      <th>...</th>\n",
+       "      <th>pixel775</th>\n",
+       "      <th>pixel776</th>\n",
+       "      <th>pixel777</th>\n",
+       "      <th>pixel778</th>\n",
+       "      <th>pixel779</th>\n",
+       "      <th>pixel780</th>\n",
+       "      <th>pixel781</th>\n",
+       "      <th>pixel782</th>\n",
+       "      <th>pixel783</th>\n",
+       "      <th>target</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.003922</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.447059</td>\n",
+       "      <td>0.509804</td>\n",
+       "      <td>0.298039</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.086275</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.003922</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.129412</td>\n",
+       "      <td>0.376471</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 785 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   pixel0  pixel1  pixel2  pixel3  pixel4    pixel5  pixel6  pixel7    pixel8  \\\n",
+       "0     0.0     0.0     0.0     0.0     0.0  0.000000     0.0     0.0  0.000000   \n",
+       "1     0.0     0.0     0.0     0.0     0.0  0.003922     0.0     0.0  0.000000   \n",
+       "2     0.0     0.0     0.0     0.0     0.0  0.000000     0.0     0.0  0.000000   \n",
+       "3     0.0     0.0     0.0     0.0     0.0  0.000000     0.0     0.0  0.129412   \n",
+       "4     0.0     0.0     0.0     0.0     0.0  0.000000     0.0     0.0  0.000000   \n",
+       "\n",
+       "     pixel9  ...  pixel775  pixel776  pixel777  pixel778  pixel779  pixel780  \\\n",
+       "0  0.000000  ...  0.000000  0.000000  0.000000       0.0       0.0       0.0   \n",
+       "1  0.000000  ...  0.447059  0.509804  0.298039       0.0       0.0       0.0   \n",
+       "2  0.086275  ...  0.000000  0.003922  0.000000       0.0       0.0       0.0   \n",
+       "3  0.376471  ...  0.000000  0.000000  0.000000       0.0       0.0       0.0   \n",
+       "4  0.000000  ...  0.000000  0.000000  0.000000       0.0       0.0       0.0   \n",
+       "\n",
+       "   pixel781  pixel782  pixel783  target  \n",
+       "0       0.0       0.0       0.0     4.0  \n",
+       "1       0.0       0.0       0.0     1.0  \n",
+       "2       0.0       0.0       0.0     0.0  \n",
+       "3       0.0       0.0       0.0     1.0  \n",
+       "4       0.0       0.0       0.0     0.0  \n",
+       "\n",
+       "[5 rows x 785 columns]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f1.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "nearby-pasta",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:30.545351Z",
+     "iopub.status.busy": "2021-04-26T04:07:30.544581Z",
+     "iopub.status.idle": "2021-04-26T04:07:30.551965Z",
+     "shell.execute_reply": "2021-04-26T04:07:30.552435Z"
+    },
+    "papermill": {
+     "duration": 0.064058,
+     "end_time": "2021-04-26T04:07:30.552579",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:30.488521",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.0    12019\n",
+       "2.0    12011\n",
+       "3.0    11992\n",
+       "0.0    11989\n",
+       "4.0    11989\n",
+       "Name: target, dtype: int64"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f1['target'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "premier-cemetery",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:30.665837Z",
+     "iopub.status.busy": "2021-04-26T04:07:30.664871Z",
+     "iopub.status.idle": "2021-04-26T04:07:31.429492Z",
+     "shell.execute_reply": "2021-04-26T04:07:31.429046Z"
+    },
+    "papermill": {
+     "duration": 0.822692,
+     "end_time": "2021-04-26T04:07:31.429618",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:30.606926",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<seaborn.axisgrid.FacetGrid at 0x7f6cb5134090>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAUoAAADeCAYAAABbqUnkAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAAToElEQVR4nO3df5BdZX3H8feHhJ9FSICdFHeTJiMZO5EKwhZSM6OWtLAgshlBJ4yaFVO3HQOF1lHBdpoWpSPjDwQUnIyJJJQhxKBNpEiaCShTxgTCD4Ek0mxBzGaCWZIQUAYw+O0f51m4bvby3GTvj717P6+ZnT3nOc+553kmm8+cc59znqOIwMzMyjuk0Q0wMxvtHJRmZhkOSjOzDAelmVmGg9LMLGN8oxtQb11dXXHPPfc0uhlmNjppuMKWO6N8/vnnG90EM2syLReUZmYHykFpZpbhoDQzy3BQmpll1CwoJS2RtFPSkyVlX5X0C0mPS/qhpAkl266S1CfpKUnnlJR3pbI+SVeWlE+TtCGV3yHpsFr1xcxaWy3PKG8BuoaUrQVOjoh3A/8LXAUgaQYwF3hX2ucmSeMkjQO+DZwLzAAuTnUBrgWui4iTgD3A/Br2xcxaWM2CMiLuB3YPKfvviNiXVtcDHWm5G1geEa9GxDNAH3BG+umLiKcj4jVgOdAtScBZwMq0/1JgTq36YmatrZE3nH8KuCMtt1ME56D+VAawbUj5mcDxwAsloVtafz+SeoFegClTpuy3/fTPLTvw1jfAw1+dV3HdX139ZzVsSfVM+ZcnKq4768ZZNWxJ9Txw2QMV1fvp+95f45ZUz/vv/2lF9b712R/VuCXVcenXP3RA9RsymCPpn4B9wG31OF5ELIqIzojobGtrq8chzWwMqfsZpaRPAucDs+PNWYO3A5NLqnWkMsqU7wImSBqfzipL65uZVVVdzygldQGfBy6IiJdLNq0G5ko6XNI0YDrwIPAQMD2NcB9GMeCzOgXsfcBFaf8eYFW9+mFmraWWtwfdDvwMeKekfknzgW8BbwPWSnpM0ncAImITsALYDNwDLIiI19PZ4qXAGmALsCLVBfgC8I+S+ii+s1xcq76YWWur2aV3RFw8THHZMIuIa4Brhim/G7h7mPKnKUbFzcxqyk/mmJllOCjNzDIclGZmGQ5KM7MMB6WZWYaD0swsw0FpZpbhoDQzy3BQmpllOCjNzDIclGZmGQ5KM7MMB6WZWYaD0swsw0FpZpbhoDQzy3BQmpllOCjNzDIclGZmGbV8udgSSTslPVlSdpyktZK2pt8TU7kk3SCpT9Ljkk4r2acn1d8qqaek/HRJT6R9bpCkWvXFzFpbLc8obwG6hpRdCayLiOnAurQOcC7FK2qnA73AzVAEK7AQOJPiRWILB8M11fl0yX5Dj2VmVhU1C8qIuB/YPaS4G1ialpcCc0rKl0VhPTBB0onAOcDaiNgdEXuAtUBX2nZMRKxP7/heVvJZZmZVVe/vKCdFxI60/BwwKS23A9tK6vWnsrcq7x+mfFiSeiVtlLRxYGBgZD0ws5bTsMGcdCYYdTrWoojojIjOtra2ehzSzMaQegflr9NlM+n3zlS+HZhcUq8jlb1Veccw5WZmVVfvoFwNDI5c9wCrSsrnpdHvmcDedIm+Bjhb0sQ0iHM2sCZte1HSzDTaPa/ks8zMqmp8rT5Y0u3AB4ATJPVTjF5/BVghaT7wLPDRVP1u4DygD3gZuAQgInZL+hLwUKp3dUQMDhB9hmJk/Ujgx+nHzKzqahaUEXFxmU2zh6kbwIIyn7MEWDJM+Ubg5JG00cysEn4yx8wsw0FpZpbhoDQzy3BQmpllOCjNzDIclGZmGQ5KM7MMB6WZWYaD0swsw0FpZpbhoDQzy3BQmpllOCjNzDIclGZmGQ5KM7MMB6WZWYaD0swsw0FpZpbhoDQzy2hIUEr6B0mbJD0p6XZJR0iaJmmDpD5Jd0g6LNU9PK33pe1TSz7nqlT+lKRzGtEXMxv76h6UktqBvwc6I+JkYBwwF7gWuC4iTgL2APPTLvOBPan8ulQPSTPSfu8CuoCbJI2rZ1/MrDU06tJ7PHCkpPHAUcAO4CxgZdq+FJiTlrvTOmn77PQu725geUS8GhHPULzq9oz6NN/MWkndgzIitgNfA35FEZB7gYeBFyJiX6rWD7Sn5XZgW9p3X6p/fGn5MPv8AUm9kjZK2jgwMFDdDpnZmNeIS++JFGeD04C3A39EcelcMxGxKCI6I6Kzra2tlocyszGoEZfefwU8ExEDEfE74AfALGBCuhQH6AC2p+XtwGSAtP1YYFdp+TD7mJlVTSOC8lfATElHpe8aZwObgfuAi1KdHmBVWl6d1knb742ISOVz06j4NGA68GCd+mBmLWR8vkp1RcQGSSuBR4B9wKPAIuC/gOWSvpzKFqddFgO3SuoDdlOMdBMRmyStoAjZfcCCiHi9rp0xs5ZQ96AEiIiFwMIhxU8zzKh1RLwCfKTM51wDXFP1BpqZlfCTOWZmGQ5KM7MMB6WZWYaD0swsw0FpZpbhoDQzy3BQmpllVBSUktZVUmZmNha95Q3nko6gmAbthDSZhdKmYygzU4+Z2ViTezLnb4ErKGb5eZg3g/JF4Fu1a5aZ2ejxlkEZEdcD10u6LCJurFObzMxGlYqe9Y6IGyW9F5hauk9ELKtRu8zMRo2KglLSrcA7gMeAwRl6AnBQmtmYV+nsQZ3AjDQPpJlZS6n0PsongT+uZUPMzEarSs8oTwA2S3oQeHWwMCIuqEmrzMxGkUqD8l9r2Qgzs9Gs0lHvn9a6IWZmo1Wlo94vUYxyAxwGHAr8NiKOqVXDzMxGi4oGcyLibRFxTArGI4ELgZsO9qCSJkhaKekXkrZI+gtJx0laK2lr+j0x1ZWkGyT1SXpc0mkln9OT6m+V1FP+iGZmB++AZw+Kwn8C54zguNcD90TEnwKnAFuAK4F1ETEdWJfWAc6leBXtdKAXuBlA0nEULyg7k+KlZAsHw9XMrJoqvfT+cMnqIRT3Vb5yMAeUdCzwPuCTABHxGvCapG7gA6naUuAnwBeAbmBZuodzfTobPTHVXRsRu9PnrgW6gNsPpl1mZuVUOur9oZLlfcAvKQLsYEwDBoDvSTqFYrKNy4FJEbEj1XkOmJSW24FtJfv3p7Jy5fuR1EtxNsqUKVMOstlm1qoqHfW+pMrHPA24LCI2SLqeNy+zB48Xkqr2FFBELAIWAXR2dvrpIjM7IJVO3Nsh6YeSdqafOyV1HOQx+4H+iNiQ1ldSBOev0yU16ffOtH07MLlk/45UVq7czKyqKh3M+R6wmmJeyrcDP0plBywingO2SXpnKpoNbE6fPzhy3QOsSsurgXlp9HsmsDddoq8BzpY0MQ3inJ3KzMyqqtLvKNsiojQYb5F0xQiOexlwm6TDgKeBSyhCe4Wk+cCzwEdT3buB84A+4OVUl4jYLelLwEOp3tWDAztmZtVUaVDukvRx3hxRvhjYdbAHjYjHKEbOh5o9TN0AFpT5nCXAkoNth5lZJSq99P4UxRnec8AO4CLS7T1mZmNdpWeUVwM9EbEH3rjZ+2sUAWpmNqZVekb57sGQhOL7QeA9tWmSmdnoUmlQHlL6eGA6o6z0bNTMrKlVGnZfB34m6ftp/SPANbVpkpnZ6FLpkznLJG0EzkpFH46IzbVrlpnZ6FHx5XMKRoejmbWcA55mzcys1TgozcwyHJRmZhkOSjOzDAelmVmGg9LMLMNBaWaW4aA0M8twUJqZZTgozcwyHJRmZhkOSjOzjIYFpaRxkh6VdFdanyZpg6Q+SXekF48h6fC03pe2Ty35jKtS+VOSzmlQV8xsjGvkGeXlwJaS9WuB6yLiJGAPMD+Vzwf2pPLrUj0kzQDmAu8CuoCbJI2rU9vNrIU0JCgldQAfBL6b1kUx1+XKVGUpMCctd6d10vbZqX43sDwiXo2IZyheZ3tGXTpgZi2lUWeU3wQ+D/w+rR8PvBAR+9J6P9CeltuBbQBp+95U/43yYfYxM6uaugelpPOBnRHxcB2P2Stpo6SNAwMD9TqsmY0RjTijnAVcIOmXwHKKS+7rgQmSBmdc7wC2p+XtwGSAtP1YYFdp+TD7/IGIWBQRnRHR2dbWVt3emNmYV/egjIirIqIjIqZSDMbcGxEfA+4DLkrVeoBVaXl1WidtvzciIpXPTaPi04DpwIN16oaZtZDR9MrZLwDLJX0ZeBRYnMoXA7dK6gN2U4QrEbFJ0gqK9/jsAxZExOv1b7aZjXUNDcqI+Anwk7T8NMOMWkfEKxSvxx1u/2vwa3PNrMb8ZI6ZWYaD0swsw0FpZpbhoDQzy3BQmpllOCjNzDIclGZmGQ5KM7MMB6WZWYaD0swsw0FpZpbhoDQzy3BQmpllOCjNzDIclGZmGQ5KM7MMB6WZWYaD0swsw0FpZpbRiPd6T5Z0n6TNkjZJujyVHydpraSt6ffEVC5JN0jqk/S4pNNKPqsn1d8qqafcMc3MRqIRZ5T7gM9GxAxgJrBA0gzgSmBdREwH1qV1gHMpXkU7HegFboYiWIGFwJkULyVbOBiuZmbV1Ij3eu+IiEfS8kvAFqAd6AaWpmpLgTlpuRtYFoX1wARJJwLnAGsjYndE7AHWAl3164mZtYqGfkcpaSrwHmADMCkidqRNzwGT0nI7sK1kt/5UVq7czKyqGhaUko4G7gSuiIgXS7dFRABRxWP1StooaePAwEC1PtbMWkRDglLSoRQheVtE/CAV/zpdUpN+70zl24HJJbt3pLJy5fuJiEUR0RkRnW1tbdXriJm1hEaMegtYDGyJiG+UbFoNDI5c9wCrSsrnpdHvmcDedIm+Bjhb0sQ0iHN2KjMzq6rxDTjmLOATwBOSHktlXwS+AqyQNB94Fvho2nY3cB7QB7wMXAIQEbslfQl4KNW7OiJ216UHZtZS6h6UEfE/gMpsnj1M/QAWlPmsJcCS6rXOzGx/fjLHzCzDQWlmluGgNDPLcFCamWU4KM3MMhyUZmYZDkozswwHpZlZhoPSzCzDQWlmluGgNDPLcFCamWU4KM3MMhyUZmYZDkozswwHpZlZhoPSzCzDQWlmluGgNDPLcFCamWU0fVBK6pL0lKQ+SVc2uj1mNvY0dVBKGgd8GzgXmAFcLGlGY1tlZmNNUwclcAbQFxFPR8RrwHKgu8FtMrMxRsVrs5uTpIuAroj4m7T+CeDMiLh0SL1eoDetvhN4qg7NOwF4vg7HqSf3afQba/2B+vbp+YjoGlo4vk4Hb6iIWAQsqucxJW2MiM56HrPW3KfRb6z1B0ZHn5r90ns7MLlkvSOVmZlVTbMH5UPAdEnTJB0GzAVWN7hNZjbGNPWld0Tsk3QpsAYYByyJiE0Nbtagul7q14n7NPqNtf7AKOhTUw/mmJnVQ7NfepuZ1ZyD0swsw0E5QrlHKCUdLumOtH2DpKkNaGbFJC2RtFPSk2W2S9INqT+PSzqt3m08EJImS7pP0mZJmyRdPkydZuvTEZIelPTz1Kd/G6ZOU/3dDZI0TtKjku4aZlvD+uSgHIEKH6GcD+yJiJOA64Br69vKA3YLsN8NtyXOBaann17g5jq0aST2AZ+NiBnATGDBMP9GzdanV4GzIuIU4FSgS9LMIXWa7e9u0OXAljLbGtYnB+XIVPIIZTewNC2vBGZLUh3beEAi4n5g91tU6QaWRWE9MEHSifVp3YGLiB0R8UhafoniP2H7kGrN1qeIiN+k1UPTz9BR2ab6uwOQ1AF8EPhumSoN65ODcmTagW0l6/3s/5/wjToRsQ/YCxxfl9bVRiV9HpXSpdp7gA1DNjVdn9Il6mPATmBtRJTtUxP93X0T+Dzw+zLbG9YnB6W1BElHA3cCV0TEi41uz0hFxOsRcSrF02hnSDq5wU0aEUnnAzsj4uFGt2U4DsqRqeQRyjfqSBoPHAvsqkvraqPpHhuVdChFSN4WET8YpkrT9WlQRLwA3Mf+3ys329/dLOACSb+k+ArrLEn/MaROw/rkoByZSh6hXA30pOWLgHujue/yXw3MSyPFM4G9EbGj0Y0qJ32HtRjYEhHfKFOt2frUJmlCWj4S+GvgF0OqNdXfXURcFREdETGV4v/RvRHx8SHVGtanpn6EsdHKPUIp6WpgY0SspvhPequkPopBkrmNa3GepNuBDwAnSOoHFlIMFhAR3wHuBs4D+oCXgUsa09KKzQI+ATyRvtMD+CIwBZq2TycCS9NdF4cAKyLirmb+uytntPTJjzCamWX40tvMLMNBaWaW4aA0M8twUJqZZTgozcwyHJTW9CRNkPSZOhxnjt8b35oclDYWTAAqDsp0Y/nB/O3PoZglylqM76O0pidpcNampyge53s3MJHiRvl/johVaUKMNRQTYpxOcYP5PODjwADFZAsPR8TXJL2DYvq8Noob0D8NHAfcRTERw17gwoj4v3r10RrLT+bYWHAlcHJEnJqeAT4qIl6UdAKwXtLgY6XTgZ6IWC/pz4ELgVMoAvURYHBChkXA30XEVklnAjdFxFnpc+6KiJX17Jw1noPSxhoB/y7pfRTTdbUDk9K2Z9N8k1A82rgqIl4BXpH0I3hjlqH3At8vmerw8Ho13kYnB6WNNR+juGQ+PSJ+l2ajOSJt+20F+x8CvJCmMDMDPJhjY8NLwNvS8rEU8xr+TtJfAn9SZp8HgA+l988cDZwPkOaqfEbSR+CNgZ9ThjmOtRAHpTW9iNgFPKDihWinAp2SnqAYrBk6/djgPg9RTNv1OPBj4AmKQRoozkrnS/o5sIk3X++xHPhcevnVO2rUHRuFPOptLUvS0RHxG0lHAfcDvYPv1zEr5e8orZUtSjeQHwEsdUhaOT6jNDPL8HeUZmYZDkozswwHpZlZhoPSzCzDQWlmlvH/r7MXspE0hF8AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 324x216 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import seaborn as sns\n",
+    "sns.catplot(x='target', data=f1, kind='count', height=3, aspect= 1.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "accredited-jewelry",
+   "metadata": {
+    "papermill": {
+     "duration": 0.053422,
+     "end_time": "2021-04-26T04:07:31.536753",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:31.483331",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### 4.3.1 Fashion MNIST images with 10 labels \n",
+    "![](https://www.researchgate.net/profile/Greeshma-K-V/publication/340299295/figure/fig1/AS:875121904476163@1585656729996/Fashion-MNIST-Dataset-Images-with-Labels-and-Description-II-LITERATURE-REVIEW-In-image.jpg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "indie-alcohol",
+   "metadata": {
+    "papermill": {
+     "duration": 0.052349,
+     "end_time": "2021-04-26T04:07:31.652465",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:31.600116",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4.4 Visualization of Dataset "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "removed-bidder",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:31.762684Z",
+     "iopub.status.busy": "2021-04-26T04:07:31.762155Z",
+     "iopub.status.idle": "2021-04-26T04:07:31.765930Z",
+     "shell.execute_reply": "2021-04-26T04:07:31.765440Z"
+    },
+    "papermill": {
+     "duration": 0.060743,
+     "end_time": "2021-04-26T04:07:31.766072",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:31.705329",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "clothing = {0 : 'T-shirt/top/pants',\n",
+    "            1 : 'coat/trouser',\n",
+    "            2 : 'Dress',\n",
+    "            3 : 'Sandal/Boot/pullover',\n",
+    "            4 : 'Sneaker/Bag/Ankle Boots'}\n",
+    "\n",
+    "clothing2 = {0 : '1',\n",
+    "            1 : '2',\n",
+    "            2 : '3',\n",
+    "            3 : '4',\n",
+    "            4 : '5'}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "specific-dodge",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:31.950115Z",
+     "iopub.status.busy": "2021-04-26T04:07:31.933991Z",
+     "iopub.status.idle": "2021-04-26T04:07:34.510983Z",
+     "shell.execute_reply": "2021-04-26T04:07:34.511414Z"
+    },
+    "papermill": {
+     "duration": 2.691704,
+     "end_time": "2021-04-26T04:07:34.511556",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:31.819852",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA04AAANNCAYAAACgNC4vAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAB+XUlEQVR4nO3deZhlZXnu/2fRXWPX2ENV9TzSA91CQyPIJC0gg61GjSgoitFDkISQIOZwRT1qEBWTmBg5iXGMqCjRE8UBGgcmGWWSobEH6Hmo6u6q7uqaq6ub/fsD8zu5znnu5z1rp+hdXfX9XJd/5F6sd629a71r7Zcd7p0VCgUDAAAAAGjHlPoEAAAAAGCkY+EEAAAAAAksnAAAAAAggYUTAAAAACSwcAIAAACABBZOAAAAAJDAwgkAAAAAElg4lUiWZfdlWTaQZVnP7/+3vtTnBIxWWZYd+/v59p1Snwsw2mRZVpFl2dezLNuaZVl3lmVPZ1l2UanPCxiteKaVDgun0rq6UCjU/P5/i0p9MsAo9k9m9nipTwIYpcab2XYzO9vM6s3sY2b2/SzL5pTypIBRjGdaibBwAjCqZVl2iZl1mtndJT4VYFQqFAq9hULhk4VCYUuhUHipUCj8zMw2m9mKUp8bMNrwTCstFk6l9dksy9qzLHsoy7KVpT4ZYLTJsqzOzG4wsw+V+lyAsSLLsmYzW2hmz5f6XIDRhGda6bFwKp3rzWyemU03s6+Y2U+zLJtf2lMCRp1PmdnXC4XCjlKfCDAWZFlWZma3mtkthUJhXanPBxhleKaV2PhSn8BYVSgUfvOf/s9bsiy71MzeYGY3l+iUgFEly7LlZnaemZ1Y4lMBxoQsy44xs2+b2UEzu7rEpwOMKjzTRgYWTiNHwcyyUp8EMIqsNLM5ZrYtyzIzsxozG5dl2XGFQuGkEp4XMOpkL0+yr5tZs5m9oVAoDJX4lIDRZqXxTCu5rFAolPocxpwsyxrM7FQzu9/MDpnZO+3l/3e9EwuFwoYSnhowamRZVm1mdf8p+rC9/NC5qlAo7C3JSQGjVJZl/2Jmy83svEKh0FPi0wFGHZ5pIwPfOJVGmZndaGaLzeywma0zs7ewaAKGT6FQ6DOzvv/4v7Ms6zGzAR4wwPDKsmy2mV1pZoNm1vb7fxtuZnZloVC4tWQnBowiPNNGBr5xAgAAAIAEWvUAAAAAIIGFEwAAAAAksHACAAAAgAQWTgAAAACQELbqZVlW0uaIY47x13Wq0OI/Nfn8P+8TlWOo47/00ktyH2XatGluvmjRIjcvLy+XY23ZssXN169fn/u8xoJCoTDifx+r1HOt1N75zne6+Xvf+143nzlzphyroqLCzdV8bmtrk2OtXbvWzZ955hk3/6d/+ic51lgw0ufaWJ9nyrhx49z8r/7qr+Q+6hk1NOT/fJM6hpnZJz/5SX1y+L8wz4BXnppnfOMEAAAAAAksnAAAAAAggYUTAAAAACSwcAIAAACABBZOAAAAAJCQRa1yR1szimrNMtNNeGVlZXIf1Q5UVVXl5lGj1gsvvODmTz31lNxHmTt3rpuffPLJbv5v//Zvcqxf/vKXbh41FCrRtVRKI72ByGzkzrXx4/3izUOHDuUe6+c//7nc9upXv9rNDx48mPs4ap/Dhw+7+eTJk+VYvb29bq6u9U2bNsmxzjjjDLnNo957s+Le/yNhpM+1kTrPhtOcOXPktqVLl7r5P/zDP7j56tWr5Vh//ud/nuu8fvjDH8ptag5eddVVbh41YXZ0dOQ6r6MR8wx45dGqBwAAAABFYuEEAAAAAAksnAAAAAAggYUTAAAAACSwcAIAAACABBZOAAAAAJAwqurIi6nvXbBggdynsrLSzT/2sY/lys3MXnzxRbntlXbttdfKbVOmTHHzj3zkI7mPM27cODdXNdBHykivbjUb3rmmquQTcz33Poq6DtauXSv3KS8vz3Ve0VxXJkyY4OZ9fX1yn23btuU6/uDgoBzrvPPOc/P+/n65j6J+ekH97MKRMtLn2tH2TCuG+okJM32/V3M2kncORMfo7OzMdezW1la57R3veEeusY5GzDPglUcdOQAAAAAUiYUTAAAAACSwcAIAAACABBZOAAAAAJDAwgkAAAAAEkZVq17U2qOa3S644AK5z0UXXeTmH/rQh9w8arSqqKjIdV4R9TdTY0Xvy4MPPujmd955p5t/6lOfSpzd/001o5kV19qW10hvIDI7Mq160XWgWidbWlrc/NZbb5VjzZw5081Vq51Z/pY49c+b6devGsXa29vlWHmvz+i8BgYG3Py5555z86uuukqOpdr+ouMfica9kT7XjrZnWqSpqcnNb7vtNrlPb2+vm6trs6ysTI41Z84cN1fPoc2bN8uxFHXPqKqqkvucf/75bn7w4MHcxx+pmGfAK49WPQAAAAAoEgsnAAAAAEhg4QQAAAAACSycAAAAACCBhRMAAAAAJByVrXqqNStqb1ONUj//+c/lPitWrHDzN7/5zW7+8MMPy7HKy8vdvJimn7wNZKeffroc65vf/KabV1ZWuvlJJ50kx1LtZOPHj5f7qDa34TTSG4jMjkyrXjENho888oibz5gxQ+6zb9++XOdlpueH2ke1VJrp61DtU19fL8caHBx0czUHo+u5u7s71/HVP29m9rrXvc7NDxw4IPdRrYrFNHsqI32ujdRnWjFWrVrl5l/60pfkPmpudHR0uPn+/fvlWPPmzXPzrq6uXMc20y151dXVbj537lw51iWXXOLmjz32mNznaMM8QzHP+eXLl7v5ggUL3Pzee++VY6l7xnCKPjNE2zzFtMrSqgcAAAAARWLhBAAAAAAJLJwAAAAAIIGFEwAAAAAksHACAAAAgAQWTgAAAACQoHuiRzBVt1hM3fIPf/hDuU3V9z755JO5jzM0NOTmqtY4qlrM+zqjmvTPfvazbn7eeee5eVQpqxTzd0HxVLW3qtY2M/vYxz7m5i0tLW6+a9cuOZaqEI7qQNX8UPv09fXJsdTrVFXh/f39ciw1P1UVa2dnpxxLVb6qOdXU1CTHuummm9z8qquukvsMZ+04Sm/KlCluHs2zqVOnuvkvfvELN4+eQ6oSXP3ExosvvijHUnPj1a9+tZtHtfvq/geMJurZFN3n3/e+97n5kiVL3Fz95IGZ2cDAgJtHz6C8os+OeT9XqvfLLH9VOd84AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIIGFEwAAAAAkHJWtesr48frlqEatrq4uuc9DDz3k5g0NDW6+e/duOdZwNgEOpyuvvNLN77vvvmE7Rqlf41gTtecpS5cuzTVWNNeUqKFLNXEVo6KiItc/r9ozzXTbzuTJk91c3RvMzMrKytxcvS89PT1yrBNOOEFuw9jwzW9+M1duZvatb33LzVV7XdSeqai5XFlZKfdR8+mOO+5w8w984AO5zwsYTYppSZ05c6ab79mzJ/dY5557bq787rvvzn2M4ZS3OS/CN04AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAmjqlVPNedFNm3aJLd997vfdfM1a9a4+Q9+8IPcx58+fbqbHzhwIPc+69evz338hQsXuvn999+feywlajNRjWbFNMagePX19W5eXl7u5kNDQ3Ksuro6N29tbZX7VFVV5TpO1ISn7gOqbS9q+1PHP+YY/985RW2Dah6o40dzoKWlxc1ramrkPlFLH8YG1XinrqeodVbNAdXcFV3PCxYscPPVq1fLfYCxQM0z9Ty56KKL5Fjq2aw+B0ZzVn3efP/73+/m7373u+VYs2bNcvOokbm6utrN29ra3Pyyyy6TY/X398ttHr5xAgAAAIAEFk4AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAmjqo785JNPltv6+vrc/De/+Y3c57777nPzv/qrv3LzqI78+uuvd/PrrrvOzXfv3i3H6u3tdfPPfOYzbv6Tn/xEjrVx40Y3f/zxx+U+yoUXXujm9957r9xncHAw93Ew/CZPnuzmlZWVbq6qvc3MOjo63LyYqu5iqApxdXxVuW6m61hVhXhUk67GUlXs0Vi1tbVufvzxx8t9Hn74YbkNR5+8NcVm+mcuVB1vVAesxlI/BxCNNTAw4OadnZ1yH0XNzej4QCmpuWyW/9l45513ym0//OEP3Vw95xsaGuRYS5YscXM1/6Lnv9onqglX9x/1cwiqvjx1HA/fOAEAAABAAgsnAAAAAEhg4QQAAAAACSycAAAAACCBhRMAAAAAJByxVr3hbLp585vf7Oaq7c7MbNGiRW6+f/9+uY9qtVINKDfddJMca9WqVW7+wAMP5Dq2mW46+eAHP+jm06ZNk2Op16IaAu+55x45ljrOHXfcIfe57bbb3PyJJ56Q+6A4UROeamlTJkyYILft3bvXzdU9wEw37qh9orHq6+tz7XPw4EE5lpqH6r5VTDvgxIkT3TxqnFTHV/c5M1r1RptoDijr16938/e///1u3tjYKMdS7a5qDkyfPl2O1dLS4uZR661Cqx6ONsPZKvvkk0/KbV1dXW6+cuVKN9+yZYscq7u7281Vq230nFWfTaLPGeo46pmt2j6LwTdOAAAAAJDAwgkAAAAAElg4AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIOGI1ZGr2uvDhw/LfVS99sUXX+zmUVX2V77yFTevrKyU+6ha47KyMjefOXOmHGvHjh1ufsIJJ7j5iy++KMdS9cV79uxx8zPOOEOO9a//+q9u/s1vftPNowpcVZ982mmnyX2++MUvurmqx123bp0cCzFVY29mVl1d7eaqwre8vFyOpeZUX1+fPjlB3R9UfbmZrnZVNaXRNa22qbGiWll136iqqnLzqI5c3U9nz54t9wFaW1vdXM3ZqMJX3QPUHFD3GDM9n6MKY4XacRxtomeQup7VnI3mjJqb27Ztc/Po87l6nqm5XFNTI8dSz7ronqFei/pplQ0bNsixmpub5TYP3zgBAAAAQAILJwAAAABIYOEEAAAAAAksnAAAAAAggYUTAAAAACQMe6ueageJ2jmUv/iLv3DzgYEBN3/Na14jxzrrrLPcvLu7W+6jmj727dvn5rNmzZJjqSY81XI0ffp0OZZqJ1uyZImbRy1DU6ZMcXPV2KLaxMx0m0rUpqaul1tuucXNTz31VDkWYscee6zcplraVHON+ufN9N+0oqJC7qOuK3WcqFVP3R/UPCimoU81Cg0NDcmxVEOZeo3RvFXbpk2bJvfB6FLMM/WP//iP3fz55593861bt8qx1LWm7vfR3Ghvb3fza665xs3/5E/+RI5Fqx5GqrzP2chtt93m5tHn4PXr17v5c8895+bRM1s9A1V7b/SZQTXLRtR7pp7na9euzX0MhW+cAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkMDCCQAAAAAShr1Vbzht2rTJzWfMmOHmUTOHavSYNGlS7n1UE93kyZPlWKo1TDVtlZeXy7E6OzvdvLq62s1V+4mZWX19vZtHTXhKb2+vm0evRb3+qO0QxVm6dKncpppoVLNk1ER38OBBN48aGVUTlmroi1qIhnMstU01mkUtRF1dXW6uGiyLMW/evGEbC6NPS0uLm6tnXWNjoxxrx44dbl5XV+fm6vlkpufZsmXL5D5AKUWfq1SDZDHteddff72bn3LKKW5+1VVXybGamprcfPny5W6+cOFCOZZqz1Of6dTnAjPdhBt9DlTb1Gfap556So6VF984AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIIGFEwAAAAAksHACAAAAgIRhryNXVcDFaG9vd/OZM2e6uarDNtOVv1FFsqpiVlXdUR26qilWFY3R+6jOWb1+VRtpZtbf35/r+FGdZjG1yqqqPKrBRXGmTZsmt6k6YlUtqnIzXcUa1beq601d66pa3ExfU2qfaCz1vijFVK6r+4mqPDfT56x+KgFjR1ThPXHiRDfft2+fm6tqXzOzAwcO5NpnwoQJciz17FJjRc809XMdwHBSz7nIihUr3PzSSy+V+6h68csuu8zNzzzzTDnWa17zGjdXP2MRvUZVB66eZ9FzVh0nOr76LKr2ufzyy+VYH/rQh+Q2D984AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIIGFEwAAAAAkDHurnmqhUg0YLS0tcqzXve51bt7R0eHmxbR2Rc1VimoHiZrGVAuQei3FnJfaR7WMmekGEvV3jJpR8jajRYpp6EOsrq4u9z7qbxpdB2oeRPMzmjt5jR/v39aKeS2Kup9Fr1FtK6adSb2WPXv25B4Lo8uqVavktoGBATdXTXSqIcvMbO/evW5eXV3t5jt37pRj1dTUuLl6dpx44olyrHvvvVduAzzFfK6JGkxvvPFGN3/729/u5t/97nflWB/84Afd/Pzzz3dz9bnZzKy2ttbNVYN1RH3eVO9XMc/46HNg3s+Imzdvzn18hW+cAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkMDCCQAAAAAShr1VT7VNKd///vflNtX00d/f7+ZRe5tq+lC5mX4tqgUrasJT7USDg4NuHjWGdHV1ublqM4rO6+DBg26umviiv69qpola/YppNENxZsyYIbepa0S1K0ZtW8P5N1XzM7oO87b3RPcN9fpVHs01dRx1vsW0Uap2MowdZ599ttym7sWTJ0928+g5NGHCBDefNWuWm6vnlpmez6oF7KyzzpJj0ap3dMp7r43kbVGOPgcq11xzjdymWh//+q//2s2jxts/+IM/cPPTTjvNzaNno2pxLub1q33U59Bimnjr6+vlPgcOHHBztT6IGrzz4hsnAAAAAEhg4QQAAAAACSycAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkDDsdeTKxIkT3XzhwoVyn3Xr1rm5qihU9eVmZo2NjW7e2dkp91HVlXlrys10tXBZWZmbF1PprKrNVaWrma76VMePzkuNpWprzcza2trcXFXaRnXLPT09chvMmpqa5DZVLaquW1X5aaav6agmVR1fXW9RRa3aJ+9rjPZRotc4frx/u1X3GfU+RudVUVERnB3GOlXhu2fPHjeP6sj379/v5uq6VT99YaavZ/VMU5XHOHqpe2fen7gZbpdffrmbL168WO7zve99z82XL1+ee6ypU6e6ufq8E/1UiKKeQdHnPfXTBuoZtHfvXjmW+qmC6Pmr7k0DAwO5/nkzswULFshtHr5xAgAAAIAEFk4AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIOGKtep/5zGfcPGrHUU0fkydPdnPV0GamWztUQ5+ZbtyLGr0U1binmoZU+5GZbudSLUfNzc1yLNWacujQoVzHNtN/S/Xem+n3WLXMqHZGM1r1UqLrQF2fqnFOzc1oW7SPas8ppglPtQqptp9iWvXUPIgaoNRcV3Mtujeq1xg18WFsOO644+S2vE14UROVmgMNDQ25jm2m2/NUI6tqJ8Pos3TpUjePGtfUfVi18l588cVyrGnTprm5um+bmb32ta9183nz5rm5uv7NzHbv3u3mav6ptjsz/ayL9lHytupFz0b1uS56nqnx1GuMPrere5bCN04AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAlHrFXvyiuvdPNt27bJfVRzlGrHmDVrlhxr06ZNbh41s6jGvbztWGZm8+fPd/M5c+bkOraZ2cDAgJu3t7e7edQmUlVV5eb9/f1uHjWjqONETXyqtUkdp7a2Vo6F2L59++S2qVOnurlqqFHXh5n+20VzTW1TrY9RE57ap5h/Xl3TqoUwGku9xrz3GTPdUBjNNYwu6trcvn273Ee11KnrKXoOqetTNZepOWOmn53qGDwHRp/vfve7br5r1y43j55Bqo1N5Q8//LAc65577nHzj3zkI3KfmTNnuvmaNWvcvK6uTo41ffp0Ny+mQVW9Z1HzsZK3va6Y840+U6vPruo529HRIceK7pkevnECAAAAgAQWTgAAAACQwMIJAAAAABJYOAEAAABAAgsnAAAAAEhg4QQAAAAACcPeXXvyySfn+uejGsSGhgY3L6YOfMqUKW7e1tYm9+nu7nZzVaGtaiPNzN773ve6uapuVudrpmsYH3/8cTdvbGyUY33hC19w861bt7r5pEmT5FhqW2trq9xHVUcODg66+bHHHivHev755+U2mFVUVMhtau6omtTe3l45lqo2juankrcO3ExXcqv6VHW+0fHVMaK6flVVfuDAATePKpfVcagjHztUtXg0z9W8VT9xET0f9+/f7+bq+ayep2Z6DqrnQ3l5uRwLI9fll18ut6lnu7pv7tixQ46lar8nTpzo5qeeeqoca9WqVW6uavfN9HNTfUaK7vVqbqh5Fj0b1Xyqrq7O9c9H56WemeoeE+0TPZvVNnW9RJXv0edtD984AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIIGFEwAAAAAkDHsF04UXXpjrn3/44YflttNPP93Ne3p63Fw1sZnpdpCoJU6156lmlnnz5smxOjo63HzLli25jmGmW1NUa0l9fb0ca9q0aW6umplU+0l0XtHfRbWAqbbFhQsXyrEQU22MkbKyMjcf7va2vC11qjlnuKn7RjHHV+/l6tWr3fySSy7JfYxofqrmpL6+vtzHQempJq5XvepVch/1vFENfVHbl2qpmj17tptv375djqXuTWr+qfM108+u6DmEI+MNb3iD3KZaGufMmePmUcPuFVdc4ebqelKf9czMOjs73Vy12pnlb3yLmvDUcYppr1XPWXWMqKFTUe2ZUQuhEr3H6nWqllp1HZmZnXTSSbnOi2+cAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkMDCCQAAAAAShr1V78wzz3TzNWvWuPl9990nx3rnO9/p5hs2bHDzqOlq3Lhxbh61g6mWOtUO1NbWJsd673vf6+YbN25084aGBjmWei3t7e1ufsIJJ8ix9u7d6+aqSSZqnykvL3fzqOVFNY2pv+X06dPlWHiZalFUfx8z3camWm3Wr18vx2pubnbzqDlIHV9dB6ptLxpLNSpF1Fiq0UjdM8zMWlpa3Px3v/udm0ctRKqBKnpfmpqa3Fw1rWFkU413O3fulPuobbt27XJz1bpqpu/rap5v27ZNjtXY2OjmqtVLPevMdCNta2ur3AfD6zWveY2bRy2Nqkk3uqcq6vOLahaNPjuq61x9DjPTn5PU8zR6Nqqx1Gcn1XZppj/vzp071803b94sx1JN0eo5F30+Vq8x+ruobeq5GbXHqiZAhW+cAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkMDCCQAAAAASWDgBAAAAQMKw15GrikZVBRjVS6uKwrwVwWZmg4ODbh7V96rqSHWcSZMmybFUffMjjzzi5lEVsbJjxw43jyodVX28qrqMKjhVbad6H830daGqo6Ox8DJVLar+pmb6GlF/U1VfbGZ23HHHuXlU+alqUqNrV1HnXMw1ra5DlUeV75MnT3ZzVeuqKnXN8te3m+maZurIj06LFy928/nz58t9Dhw44ObqeRNVG6vrdsKECW6uKsfNdO24+mkF9ZMHZvr+Qx35kTNr1iw3j/5uqip83759uY+vPtep+7a6n0bnpT5TmulqdTVW9GxWc0Pd6++66y451urVq938sccec3M1x830TxX8/Oc/d/Pop3/UMzh6jxW1j/p8bBavHTx84wQAAAAACSycAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkDDsrXrf//733fyaa65x8xNPPFGOpVpwVGtWb2+vHEttq62tlfuoBhjV9heNddlll7n5+973PjePWl5UE13ehjoz3T6jWk6iBjLVKKbeLzOzrVu3urn6e7W1tcmx8LI5c+a4eXRN5W3DjBryenp63HxgYEDuo64ddc7Rdai2RQ2aSt5Wv6GhIblN3bfUe7lmzRo5lmoO6+/vl/uohjIcnVRLVXSPVHNQNZepFjAz3bin5mz0HFCtfmrORm1fqtUPR476HHjPPffIfS6++OJc+bHHHivHamhocPNi2or37NmT6xhmutlNHf+FF16QYy1cuNDNZ8+e7ebbtm2TYw0n1aq3bNkyN7/33nvlWGqen3766XKfDRs25BpLtZCaxX9LD984AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIIGFEwAAAAAksHACAAAAgIRhryNfu3atmzc1Nbn5q1/9ajmWqu9V1YFRdaraJ6ohVLWmURWysmDBAjdX9cGqAtNMV8qq8zp8+LAc69lnn3VzVQ9dUVEhx1J17JMmTZL7zJo1S27zHKmqzaOZqp2OrltVbazq4qM64CVLlrj5pk2b5D6KqveOasLVfUDVlEbzQ71n6vhRFbL6WQA1p5555hk51vLly908qiOP5iGOPjNnznRzVYVspn9eIPopDWX37t1urp4d0T0j78+FRNXm06dPl9tQWu3t7XLbl770pVx5pKqqys1Xrlzp5tF9c//+/W6ufkrGTH9Oefrpp91czRkzPc+K+SxUVlbm5up5dvDgQTmWqlC/9NJL3fyJJ56QY6mfUHjrW98q9zlw4ICbq5/3iD7//OpXv3LzW265xc35xgkAAAAAElg4AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIGHYW/WmTZvm5qoZRDVgmOmmDdWEp5pUzHRzVtQaolr9imn6Um1b6hiTJ0+WY82dO9fN1WtUbWJmZi0tLW6umvvUazfT72XUWjZ//nw3r6urc3PVCoX/7Zhj8v/7EHWNqIa6G264QY6lmvjOO+88uY+aH+r6jNodN2zY4ObqmpoyZYoca+/evW6ursPo+lQtQL/4xS/c/IwzzpBjRXNKKaYNFCOXapZTLWBmullRtbjW1NTIsRYtWuTmPT09ch9FNYGqtjHVwmcWt+tibFAteatXrx62Y1x77bXDNtaREn1+y0s9z2677bZhO8a3v/3tYRtrOPGNEwAAAAAksHACAAAAgAQWTgAAAACQwMIJAAAAABJYOAEAAABAwrC36u3atcvNlyxZ4uZRC5Vqz1ONWqqZp1iqhUq1lkWtfuPH+2+1GuvBBx+UY6lt6nxVc5+ZPmfVvqT+Jma6tSxqG7z//vvd/JZbbnHz6H3By5YtW+bmqoXLTF+fc+bMyX189bdTOXwrVqzIvU/UNrh8+XI3/7d/+7fcx0HprVq1ys2nT58u91HPW9VEF7XeqmY71VJZVlYmx1KtmqrtM7rOTz/9dDf//Oc/L/cBgP9XfOMEAAAAAAksnAAAAAAggYUTAAAAACSwcAIAAACABBZOAAAAAJDAwgkAAAAAEoa9jlzVRasqZFVTbqYrSlUltqpUNtNV2VGtaaFQyHWcqHb78OHDbn7w4EE3v/XWW+VYQOTxxx9381NOOUXuo2rp77vvvtzHV/NDzQEzPdfGsieeeEJumzVrlpt3dHTIfZ5++un/6ilhBPm7v/s7Nz/11FPlPqpeXM2/hQsXyrEuvvhiN3/sscfcPLqX5H2mque5mdmvfvUruQ0A/qv4xgkAAAAAElg4AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAICGjzQoAAAAAYnzjBAAAAAAJLJwAAAAAIIGFEwAAAAAksHACAAAAgAQWTgAAAACQwMIJAAAAABJYOAEAAABAAgsnAAAAAEhg4QQAAAAACSycAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAksnAAAAAAggYUTAAAAACSwcAIAAACABBZOJZJl2X1Zlg1kWdbz+/+tL/U5AaMN8wx45WVZVpFl2dezLNuaZVl3lmVPZ1l2UanPCxhteKaVHgun0rq6UCjU/P5/i0p9MsAoxTwDXlnjzWy7mZ1tZvVm9jEz+36WZXNKeVLAKMUzrYTGl/oEAADA0atQKPSa2Sf/U/SzLMs2m9kKM9tSinMCgFcC3ziV1mezLGvPsuyhLMtWlvpkgFGKeQYcQVmWNZvZQjN7vtTnAoxCPNNKKCsUCqU+hzEpy7JTzex3ZnbQzC4xs/9pZssLhcLGkp4YMIowz4AjK8uyMjNbbWYbC4XClaU+H2A04ZlWeiycRogsy+4yszsKhcLNpT4XYLRingGvnCzLjjGz75pZnZn9QaFQGCrxKQGjGs+0I4//xmnkKJhZVuqTAEY55hnwCsiyLDOzr5tZs5m9gUUTcETwTDvC+G+cSiDLsoYsyy7Isqwyy7LxWZa928xea2Z3lfrcgNGCeQYcUV8ysyVm9qZCodBf6pMBRhueaSMD3ziVRpmZ3Whmi83ssJmtM7O3FAqFDSU9K2B0YZ4BR0CWZbPN7EozGzSztpe/fDIzsysLhcKtJTsxYHThmTYC8N84AQAAAEAC/696AAAAAJDAwgkAAAAAElg4AQAAAEACCycAAAAASAhb9bIsozkCR71CoTDif+PgaJtrF154odw2depUN29ubpb79Pf77cVdXV1u3tfXJ8eqqKhw87q6OjdvamqSY6l9hob8n6iJynb279/v5o888oibP/zww3KsgwcPym15HXOM/+/PXnrppdxjjfS5drTNs+H2pje9yc3nz5/v5t/97ndzH0NdmxMmTJD7nHTSSW5+1llnufl//+//Pfd5jSbMM+CVp+YZ3zgBAAAAQAILJwAAAABIYOEEAAAAAAksnAAAAAAgIYv+Y2b+Az+MBiP9P6Q1K26uZVm+lxXNdVXc8IMf/MDNKysr5Vjjx/udM9H5qn1UcYHKzXSpgfqP1g8fPizHUqUVhw4dyn1e9fX1bl5WVubmg4ODcqxf/epXbl7MfzSvjq8KMCIjfa4dbc+0hQsXym0XX3yxm0fFLYsWLXJz9bdubGyUY40bN87N1TxX15mZ2cDAgJtv2LDBzSdOnCjHuvfee938wQcfdPMf//jHcqzdu3fLbaXEPANeeZRDAAAAAECRWDgBAAAAQAILJwAAAABIYOEEAAAAAAksnAAAAAAggYUTAAAAACRQR45Rb6RXt5rpuRZVeEdzN68HHnjAzVXt9tSpU+VYqqY4ca9x86jCOO9YKlfnW8xYqlbdzKyvr8/NVU26qmg20+e8Y8cOuc/5558vtw2XkT7XSv1M+8QnPuHmf/iHf+jmUVW+qr7v7e2V+6htqo48+tmBiooKN1dzI5r/3d3duc6rqqpKjlVTU5NrH/WTA2ZmbW1tbv6Wt7xF7nMkMM+AVx515AAAAABQJBZOAAAAAJDAwgkAAAAAElg4AQAAAEACCycAAAAASKBVD6PeSG8gMituri1fvtzNV61a5ebnnHOOHGv//v1uPm/ePDeP2u5UE5hqATOL2wPzio7jeemll+Q2dX9U7XlRQ58aS51v9DrUOUf7fPKTn3Tz73znO3KfvEb6XDsSz7Tbb79dbluyZImbq/Y21SpnpudZdD2r66O6utrNBwcH5ViqDTI6Z0U19JWXl7t51DipmkCV6N4zffp0N4+aC88666xcxy8G8wx45dGqBwAAAABFYuEEAAAAAAksnAAAAAAggYUTAAAAACSwcAIAAACABFr1MOqN9AYis+Lm2he/+EU3nz17tpu3tLTIsTZu3OjmqokvapWKmuUU1WyVNzfT7XXFGM62v7yi16HeY9XOZma2Z88eN584caKbn3rqqcHZ+Ub6XBvOZ5p6f7761a/KfdTfR7U0FqOYVr2uri43j1r1pkyZ4uaqba+/v1+OpZrwVHtnVVWVHEu1DRZzX1KvRb12M7MvfOELbn7bbbflPr4yluYZUCq06gEAAABAkVg4AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIIGFEwAAAAAkDF8HKoBhd8opp8htPT09br537143nzp1qhxr/fr1br5s2TI3P3DggBxL1QGXl5fLfRRVIRzVhOfdp5ixiqk8V1XQqopa/fNmZvX19W6+ZcsWuU9DQ0Ou4yN21llnuXl0PVVWVrq5qv2OrrOhoSE3r6iokPuo8dQ5V1dXy7G2b9/u5s8++6ybn3zyyXIsVaGurs3omo0q1D3qfhUdJ6p8v+iii9x8OOvIAZQO3zgBAAAAQAILJwAAAABIYOEEAAAAAAksnAAAAAAggYUTAAAAACRQpwSMYCtXrpTbli5d6uZNTU1uHrXqfe1rX3Pz22+/Xe6jqLav2tra3GOptq+ocU4ppiFLNReqtrGo7Uuds2rui85LNYHt3LlT7nPjjTe6edSQCG327NluHjXh1dXVuXl/f7+bR3+badOmuXk0N9ra2nLtMzAwIMdSc2DKlCluHrUNqn1UQ15vb68ca+bMmW7e2dnp5n19fXKssrIyN4+a+ObNmye3ATj68Y0TAAAAACSwcAIAAACABBZOAAAAAJDAwgkAAAAAElg4AQAAAEACrXrACKYa18zM5s6d6+Zbt25182XLlsmxZsyY4eaTJ09286jxTbWKlZeX595HiRq6VOOVOn5FRYUca/fu3W6u3pdorLznpRr9zHRzYUQ1kb3jHe9w8+uuu06O9fnPfz738UebxYsXu/mhQ4fkPqqlTc2/hoYGOdYLL7zg5ldccYXcZ9GiRW7e1dXl5qqJzkzfm97whje4+c033yzHOvfcc9380UcfdfOJEyfKsVpaWtxcXc/RvUzN86jVLzo3jB5qLpvpe4B6bkXXoHLBBRe4+ate9Sq5z/e+9z03V+2dUeNk3nOOntl5n/+lxjdOAAAAAJDAwgkAAAAAElg4AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIIE68iNEVbeqiuJiqHrMpqYmuc/OnTuH7fjKMcfo9XkxNZxjyd69e+W2jo4ONx8cHHTzqqoqOZaqHVYVolHt9vjx/m0lqmlW86CY2u3Kyko3V7XfjY2Ncqz+/v5cxx4YGJDb1GtU70tUeaz+LlF9vdpHzc/ovgGzgwcP5srN9Hutrs2oDnjt2rVurq5/M7NJkya5uaojr6+vl2Op62nmzJlyH6W6utrNVbV4dJ3fe++9bv7Wt77VzVVFu5lZTU2Nm3d3d8t91E8YqJryffv2ybEwckXPM1WvXUzt9mWXXebmf/RHf+Tm69evl2Odf/75bq7m/5133inHyvtsLEZUYd7c3Ozm6mc8hrNanW+cAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkMDCCQAAAAASaNULFNMOpuRtz/vUpz4lt51xxhlurtpUzj33XDnWwoULc51XMQ15UWOJalPKe15mZk8//XTufUY61RBlZvb5z38+1z5RC45q4lMtcWpuRPtEjUJqTqlrJ7oOFdU6uWPHDrmPai5UY0UtQOq1qIaw6O9VzL1JtSqq5sIvfvGLcqyxZNq0aW4+ffp0N4/u9aqNsq6uzs2jJijVkPXoo4/KfdTcVA190XNI7fPEE0+4edTg2t7e7uaqcW7y5MlyLDUH1N9r/vz5ciz1/qsWRDP9TJs1a5ab06p3dCqmIW/KlCluHl2Dah91bS5evFiOtWTJEjdXnyn/+I//WI61ZcsWN3/qqafcXDX3RebOnSu3qXl24YUXuvm73vUuOdZf/uVf5jovvnECAAAAgAQWTgAAAACQwMIJAAAAABJYOAEAAABAAgsnAAAAAEhg4QQAAAAACdSRB4qpHVeWL1/u5n/zN3/j5qeeeqocS9UnV1ZWuvnevXvlWKoGV1VHRtXixfjkJz/p5qoec9OmTXKsr371q8NxSiPKxo0b5bY///M/d/MVK1a4+Zo1a+RYN9xwg5u//e1vd/PW1lY5Vk1NjZtH9a2qwlnVe0d1wN3d3W4+nHX5aq6pWnczXaGuXuPBgwflWBMnTnRzVQVtZtbb2+vm6mcMovrosUTVSKtq8d/97ndyrDe84Q1u3tbW5uaPPPKIHEvNzQceeEDuoyru3/zmN7v58ccfL8datGiRm6tz/sEPfiDH2rVrl5urKvhvfetbcix1n2lubnbz6B47YcIEN9++fbvcR9VHD+fniaNV9HMNw6mYqvDh9Ld/+7durj4HNjY2yrFqa2vdXM3zVatWybHuvPNON1fP7M997nNyrK985StuvmzZMjdXzx8zs/r6ejdXP1NgZtbS0uLm6nNRdF+OfpLEwzdOAAAAAJDAwgkAAAAAElg4AQAAAEACCycAAAAASGDhBAAAAAAJR6xVT7WpRC0raptq4BpukyZNcvMlS5a4+ac//Wk51ty5c918aGjIzX/961/LsVQ7l2pfUS1jZmY/+clP3Pyf//mf3fz73/++HEs5//zz5TbVWHXgwAE3V81IZmZve9vb8p3YUW7evHlurt7vqKFGUc1ufX19ch/VLFdMo5Lap6ysTO6j5kfeVjszfa/p6elx82JaJ4tp2+rs7HRz9RrNdAtctA/MHn30UTdXz4HhFD1Txo0b5+aTJ0+W+9x2221urlqtHnzwQTnWjBkz3Fw10aljmOln1znnnOPm119/vRzr/e9/v5tv2bLFzd/0pjfJsTC8St12N5wWL14st6lmOdWEp5pwzczOPvtsN58+fbqbr1u3To514YUXuvnq1avdPGppVe196jW++OKLcizVqhl9dv3Upz6V6/jvec975FjqXqrwxAQAAACABBZOAAAAAJDAwgkAAAAAElg4AQAAAEACCycAAAAASAhb9VTbVNRAoRqiVJvKcLasVFVVyW1/+Zd/6eYrV66U+5x88sluXllZ6ebPPfecHGvjxo1uvmnTJrmPUldX5+aqNau3t1eOpd6zL3/5y27+iU98Qo61detWN4/alKqrq91cXWNTp06VY91yyy1y22i0fv16N29oaHDzbdu2ybHU30FdO1GzpdqWt7mmWOqeotrjoiY89fpVq1/U9qeOk/eeaaZfS9TQp+b6/fffL/dBaUXPtB07drj5d7/7XbmPasNULaatra1yLNXeNW3aNDd/+OGH5VjqWj/llFPcvKurS471kY98xM2bmprkPjgyomfAaaed5ubHHXecm6tGYjN9nQ8MDLi5+uxkZnbBBRe4+bnnniv3UQ226l6r2oXNzLZv3+7mqqlZtcqZ6c+Oxx57rJtH7c7f/OY33fyiiy5yc9XCZ6bXGqo52Mzs9ttvd/M/+qM/cnPV3GlmtmDBArnNwzdOAAAAAJDAwgkAAAAAElg4AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAICGsI1cVoVHlbV6qHtFMVxEuWbLEzf/sz/5MjjV58mQ3jyotH3roITdfs2aNm7e0tMixlIkTJ7q5qmE10+//b3/7WzdfsWKFHKutrc3Nf/7zn7t5VC2+bNkyNy8vL5f7qPpmVSeqaitT20ajxx9/3M1VVW9UuarqOFVNcfRejx/v31ZUhbaZrupW+0RV3Xl/4iCqyM37WqKx1D7qvTx48GDusaLjq5p4VWuP4af+1uqajX5CQNU379u3T+6Tt5L/4osvlmOpn3+48cYb3fwtb3mLHOvqq6928927d7t59NzOO8+KUcy9DGY/+MEP5LYpU6a4+dNPP+3mUYX3jBkz3LympsbNN2/eLMdS1+BvfvMbuc/8+fPd/JprrnHzqF5/165dbr5w4UI3jz7vPf/8824+adIkN3/1q18tx1L3JlW5/rOf/UyOparK3//+98t9VFV6Y2Ojm0eV47Nnz5bbPHzjBAAAAAAJLJwAAAAAIIGFEwAAAAAksHACAAAAgAQWTgAAAACQELbqKTNnzpTbzj33XDdX7RyqzcNMt0Cpdpw77rhDjqXapv7gD/5A7qNaOAYHB3Mdw8xswoQJbt7c3OzmqknFTLejLV261M03bdokx1LtRFOnTnVz1XRopl9j1A42MDDg5uo9Vi1nqeOMRhs2bHBz1aoVNSJWV1e7uWqIUnPTrLgmvLxNWNFY0TXiiV6Lan0s5jUqeRsFi6XmmmqNwvDLe32o1lMz3Vba29sr96mqqnLznp4eN4/axi644AI3f/3rX+/mai6Z6XuWmhvqWjbTnym2b9+e+7yi9j7kF11Pxx9/vJur5uUtW7bIsVTzsfpbL168WI6lGtfa29vlPqqNtqmpyc2j9rqdO3e6eWtrq5tHjcwnnnii3ObZv3+/3ParX/3KzU844QQ3j57LqqHwvPPOk/u89a1vdXP1OVw1NZvpz+EK3zgBAAAAQAILJwAAAABIYOEEAAAAAAksnAAAAAAggYUTAAAAACSE9VPXXXedm6v2EzPdUKUaz6IGoIkTJ7r55MmT3bylpUWOFTXeKaoZ5bjjjnPzp556So6lGlhmzJjh5tH5VlZWurlqRlNNLma6uWv+/PluHjUQqb+9Ot/o+KpNSbVCmek2l7FGvafRe9fd3e3mqqGqv79fjqWu3ai9Tu1TTEudOo46RtRep45fTBOe2kc1Bw7nWGZmjY2Nbv7CCy/IfTC88rZEFtNeGV036jmsGq+iptK812AxY6k5G4116NAhN1etr1HbF616xamtrXVz9ZnSzOzrX/+6m3/1q1918+XLl+c+r7Vr17r5PffcI/dRjWvR81S1D6v2yKj5WH2u3bp1q5t/73vfk2M9/PDDbv7LX/7SzaNWTzU33vOe97i5+txsZjZnzhw3j57/6j6j7pkNDQ1yLNVQqvCNEwAAAAAksHACAAAAgAQWTgAAAACQwMIJAAAAABJYOAEAAABAAgsnAAAAAEgI68gHBgbcfNq0aXIfVRGo6imjisCamho3V3WjUXWhqsQupm5U1aGr+nQzs87OTjevqKhwc/V+memadFXdGp2Xot7L/fv3y33Ue7l79265z86dO9386aefdvPofbn//vvd/CMf+YjcZzT61re+5ebXXnut3EfNKZWr69ZMXwdRlb263qJ6bUXtU8xYeRVTn17Meak65qj6X1XIq1pbDL+8deTR80nd76PrSc3nYuZM3ms9qlZXdeSqJjiqD1bX+ZQpU9w8upepsY7EveRoNjg46OYnnXSS3Ec988844ww3nzlzphzrpptucvNLLrnEzc8++2w51rPPPuvmUY29mpvq84s6hpmuQ1fX7RVXXCHHUvNfVbsvWrRIjqVev/pMd+aZZ8qxli1b5uYdHR1yn7w/FaI+g5uZfeUrX3Hzd7zjHW7ON04AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAlZ1IyTZZm7UbXKmZlddtllbn7uuee6edSMUl9f7+aqbS9q7VEtL1Ezyu233+7m27Ztc/OVK1fKsVR74BNPPOHmDz/8sBzrt7/9rZtv3rzZzVUDV6SYdrCRqlAojPgKJDXXVDuPmb7e58+f7+arV6+WY6mmxurqajeP2tt6e3vdPGqvUk04SnR9qvdM5Yl7YK68GMXMNXXf6u7ulvusXbvWzVVzUDFG+lxT8+xIOeYY/99Vquv//PPPl2N94QtfcPPt27fLfdR8Vm1beeelWXENmXlb9SJ9fX1uPmPGDDc/77zz5FiqEbaY+/JwOlrnmbr+zcyWLFni5uq9XrNmjRxLXU/q+N/4xjfkWO95z3vcPGojVcdXzbJR87D6HLxw4UI3v/nmm+VYP/rRj9xctf2pZ7mZvs7VvWTBggVyLPW+vPjii3Kf1tZWN+/q6nLzXbt25T7+wYMH3XnGN04AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAm6Ui7Q3t4ut6mmH5VHVKOOagCJ2uOitqnh8rnPfe4VP0akqqrKzdX7FYnab5ThbC1TDWxRm1sxDUwjXTGtVv39/W6u2m7M9N97YGDAzaM2SnUdRm1T6joopnFuOBsh855X1ByWt4kvau5Sf8vo7xI1N+HIyHsNNDY2ym3FtLflbfUrpj1yOOfs0NCQm9fV1cmxVKvWcDb3Iaaum+h59vzzz7v5pEmT3Py4446TY6nPDxs2bHDz973vfXKsm266yc0vvfRSuc+cOXPcXLW3rV+/Xo6lGm9VU/Tdd98tx1JNgC0tLW4ezeUpU6a4uWrie/DBB+VYxTz/864Pli5dKsdSn3MUvnECAAAAgAQWTgAAAACQwMIJAAAAABJYOAEAAABAAgsnAAAAAEhg4QQAAAAACUXVkR8pql5c1TNG9b01NTW58mibqvyNqhNVdayqh1W1lZGenh43jyplVb23qnqMxlIVydHfRb0vqtIyqknfsWOH3Ha0KqaSWlVrRn+7vDXFqgrVTNfHdnZ2yn3U9a7mVFStnrcWv5gK8eGsXC6mcj66LhRVU4+RK6rKVnMgukeq+626NqPrXB1nOOdZMc+UvD+tQB35yKD+bh0dHW6+b98+OZb6XDNz5kw3nz9/vhxr+/btbv7pT39a7qOuW3WvV/XpZvonCdT1PG3aNDnWySef7Oaq9j+as+ozQHV1tZsvXrxYjpX3s7aZvgeo90V9PjYz27x5s9zm4RsnAAAAAEhg4QQAAAAACSycAAAAACCBhRMAAAAAJLBwAgAAAICEEd2qp6jGkqhpSzWARE0bQKkV096mGnKiFiLV9tPc3OzmUaue2hY1B+VtCItataImoOH456PjR2PlbRsbzkYzM+51R6Ouri65TTXkRdQ8L6YJT12Dai5H16Y6jrqXqcbdaCx1XtF9CcUp5rmlrk3194yuTdUgumHDhtznpZrdmpqa5D55W0+j90td6+q63b17txxr69atuc4reh3qPVZ/l2ieqdev5n+0rZiW2rz4xgkAAAAAElg4AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIOGobNUDxopi2om6u7vdXLVgmZmVlZW5uWrVKS8vz338iRMnyn3yNuSopqNIMe1MattwtuoN1z+fOn5nZ2fu8TByqZa4Yq7BYhrnimmjzDtWMQ1Zec8rauhD6alrtpj7YzHU3Ni1a9cROf5oMZrmGd84AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIIGFEwAAAAAksHACAAAAgATqyIERrJg6XuXFF1+U25YtW+bmfX19bh5Vm6uq8KiOtLq62s0HBwfdPKqiVeemaoqj11JK0WtU10VUxXzgwIH/8jnhyDp8+HDubcXcM1S9fnQNDmcddN6fCujv7899DPV+DQwM5B4LwNg1Mj8xAAAAAMAIwsIJAAAAABJYOAEAAABAAgsnAAAAAEhg4QQAAAAACbTqAUcp1YSl2qN27twpxzrhhBPcvLa21s07OjrkWFVVVW6uGvLMzMrLy918OJu7lOgYqtVL7RM1mqm/i2r1i85raGjIzdU1YWbW1dUlt2FkKubajK7BqHUx7/HVtrxzxkyfs2roPHTokBxLUftEcwYA/k984wQAAAAACSycAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkMDCCQAAAAASqCMHxogdO3bIbXnrtWtqanKPpeq4zcwOHjzo5qqmvL+/X46lKoyVYiqX8+ZmuvZYvceqctxMvy9RTfODDz4ot3mi97GYOmjkr9cvplpc1dubmZWVlbm5mn/R8dX1rI4fjaUUU7mu5K08BwAP3zgBAAAAQAILJwAAAABIYOEEAAAAAAksnAAAAAAggYUTAAAAACRQJwOMET/72c/ktne9611uPmPGDDffv3+/HEs1rkVNWAMDA26uWsAqKyvlWKrtqxiq1StvC6GZPi/V6hW1fbW0tLj5t771LbnP3r175TYPzXmlF11P6u8TtVf29va6ubrOo7mkjl/M3Mi7T/Qa1TkX0/YJAP8nvnECAAAAgAQWTgAAAACQwMIJAAAAABJYOAEAAABAAgsnAAAAAEigVQ84SuVtg9qyZYvc9t/+239z81tvvdXNo1a7+vp6N6+urpb7qIauSZMmyX3yjnXMMf6/J1JtW5G8bXvRto0bN7p5T0+PHGvdunVuftVVV8l9FNVCRttY6UXzrKKiws2jv1tdXZ2bq2szanZUx1FNeFGrntqmXqNq4TQz6+vrc/Py8nI3nzBhghxLUfcSM+YNMNrxjRMAAAAAJLBwAgAAAIAEFk4AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIoI4cOEoVU4mt/O53v3PzE088MfdYV1xxhZvPmjVL7vPYY4+5uapjvvfee+VY+/btc/Oamho3L+b9UnXEUeWyqlAeGhrKffzhFJ0zhlfea62trU1u6+jocPMNGzbIfVQltxLVkR88eNDNh/N6UnMmqvxW29T9p729Pfd5FXPPADA68I0TAAAAACSwcAIAAACABBZOAAAAAJDAwgkAAAAAElg4AQAAAEBCRjsMAAAAAMT4xgkAAAAAElg4AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIIGFEwAAAAAksHACAAAAgAQWTgAAAACQwMIJAAAAABJYOAEAAABAAgsnAAAAAEhg4QQAAAAACSycAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAksnAAAAAAggYVTiWRZ9p0sy1qzLOvKsmxDlmX/rdTnBIxWWZYdm2XZQJZl3yn1uQCjTZZlFVmWfT3Lsq1ZlnVnWfZ0lmUXlfq8gNEmy7L7fv8s6/n9/9aX+pzGGhZOpfNZM5tTKBTqzOzNZnZjlmUrSnxOwGj1T2b2eKlPAhilxpvZdjM728zqzexjZvb9LMvmlPKkgFHq6kKhUPP7/y0q9cmMNSycSqRQKDxfKBQG/+P//P3/5pfwlIBRKcuyS8ys08zuLvGpAKNSoVDoLRQKnywUClsKhcJLhULhZ2a22cz4l4EARhUWTiWUZdk/Z1nWZ2brzKzVzO4s8SkBo0qWZXVmdoOZfajU5wKMFVmWNZvZQjN7vtTnAoxCn82yrD3LsoeyLFtZ6pMZa1g4lVChUPgTM6s1s7PM7IdmNhjvASCnT5nZ1wuFwo5SnwgwFmRZVmZmt5rZLYVCYV2pzwcYZa43s3lmNt3MvmJmP82yjP9vpSOIhVOJFQqFw4VC4UEzm2FmV5X6fIDRIsuy5WZ2npn9Q4lPBRgTsiw7xsy+bWYHzezqEp8OMOoUCoXfFAqF7kKhMFgoFG4xs4fM7A2lPq+xZHypTwD/v/HGf+MEDKeVZjbHzLZlWWZmVmNm47IsO65QKJxUwvMCRp3s5Un2dTNrNrM3FAqFoRKfEjAWFMwsK/VJjCV841QCWZY1ZVl2SZZlNVmWjcuy7AIzu9T4j9eB4fQVe/lfRiz//f/+xczuMLMLSndKwKj1JTNbYmZvKhQK/aU+GWC0ybKsIcuyC7Isq8yybHyWZe82s9ea2V2lPrexhG+cSqNgL/+/5f2Lvbx43Wpmf1EoFH5S0rMCRpFCodBnZn3/8X9nWdZjZgOFQmFv6c4KGH2yLJttZlfay/+dbtvvv+E1M7uyUCjcWrITA0aXMjO70cwWm9lhe7lY7C2FQmFDSc9qjMkKhUKpzwEAAAAARjT+X/UAAAAAIIGFEwAAAAAksHACAAAAgAQWTgAAAACQELbqZVk2ppsjmpqa3PyKK65w86VLl8qxqqur3fyYY/y169atW+VYd955p5uvXr1a7qOMH+9fAocOHco91khVKBRG/G8cjPW5htFhpM815lk+b3zjG+W2U0891c37+vrcPCqiuummm3Kd17hx4+S2w4cP5xrraMQ8A155ap7xjRMAAAAAJLBwAgAAAIAEFk4AAAAAkMDCCQAAAAASsug/2Dza/gM/VbRgZvbSSy+5+cUXXyz3+ehHP+rmlZWV+U7M9Lmp9z/6j1/r6urc/J577nHzSy65JHF2/7cs8//b0+h6GalG+n9Ia3b0zTXAM9Ln2tE2z1R5j9nwFvio4/T09Mh9fvrTn7p5RUWFm8+cOVOOtWXLFjd/61vfKvcZLkdj0QTzDHjlUQ4BAAAAAEVi4QQAAAAACSycAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkHBU1pEXU5Wt9nnkkUfkPqr2W9XAqspzM7MJEya4+dDQkJtH1epqH3X8Cy+8UI7V2trq5qqedjgrcI+UkV7dajZy5xqQx0ifayN1nh2pn3945zvf6eZXX321m8+YMUOOtXnzZjevrq528+j5OHXqVDd/5pln3PxrX/uaHOtnP/uZ3JbXSP1ZDuYZ8MqjjhwAAAAAisTCCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAlHZaveuHHj3Pzw4cO5x3ryySfltp6enlzHqampkWOp91m19kSvpb+/380nT57s5p///OflWLfccoubq2akvr4+OdZINdIbiMxG7lwD8hjpc+1om2dnn3223Pa+973PzRsbG+U+FRUVufaZPn26HKu9vd3N9+/f7+bTpk2TY6nn45o1a9xcPZ/MzAYGBtx806ZNbv7Rj35UjnXw4EE3V59BzIr7HJIX8wx45dGqBwAAAABFYuEEAAAAAAksnAAAAAAggYUTAAAAACSwcAIAAACAhPGlPoFijB/vn3bUZjNp0iQ3j5rwXnrpJTdXTXiq7c5Mt/BMmDDBzYeGhuRYqunn0KFDbr5gwQI5lqLa8445Rq+11fsFAGOFej6Y6fY41Tj3iU98Qo5VWVnp5hs3bpT77Nq1y83VvXvq1KlyLNWqp9poq6qq5FjNzc1u3tbW5uYTJ06UY6ln6tve9jY3jz4DXHXVVW4efdZQz0iej8DowDdOAAAAAJDAwgkAAAAAElg4AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIGFE15GrCu/BwcHcY1188cVuruphzXTtucqjOvIdO3a4+ZIlS4btvCoqKtw8qiOfNWuWm2/bts3No0pV9feKqluB4Za3DjiqST733HPdXFX/79+/X45VXV3t5vX19W6+d+9eOdaBAwfcvLu7W+6jfmJg3759bs68LU5071b+7u/+zs1V5beZvt/X1tbKfcrLy91cXU8//OEP5Vjqelq+fLmb/6//9b/kWNOnT3dzVbmuatXNzObOnevmW7dudfMZM2bIsVatWuXmd9xxh9wHyCv6CQP1uUrto/55M/1sVPeSuro6OZY6vrrHqM+tZmZlZWW5jmFmNmfOHDf/7W9/6+Zq/heDb5wAAAAAIIGFEwAAAAAksHACAAAAgAQWTgAAAACQwMIJAAAAABKyqAEoy7L89UBHgGr6+Pd//3e5z+TJk928q6tL7qPatopp1VMNVTU1NW4eNQf29va6uWpTUc1EZrrpa/369W7+rne9S46lmsZKrVAo6GqWEWKkzrWjUd52x2XLlsmxPv3pT7v5T3/6UzefN2+eHGvmzJlu3tPT4+aqacxM34OGhobkPgcPHnTziRMnuvn1118vx3riiSfcfKTPtZE6z1R73cDAgNxHtaWqplYz/VxRzzr1dzYz27x5c66xdu/eLcc666yz3LypqcnNo/dFzSfVHBg1Yao23D/90z+V+xwJR+s8U61uZnFjr+fd73633PZnf/Znbq4aRNV1ZqbvtdHnHbWPeo3RZ0d13857jGgs1YQ3nH+viFqHdHZ2yn3U+79o0SI3X7lypRyro6NDnZc7z/jGCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAksnAAAAAAgwa/lGOFuvPFGN49aqFpbW928oaFB7qO2qSa6qDUob6NV1I41a9YsN1dtQnv27JFjtbW1ufmxxx7r5p/4xCfkWP/jf/wPuQ0YqVTbnZmeh8cff7ybR41mqkFTNVg2NjbKsdS9JmrjVE1k6r4RNT2hOIsXL3bz+vp6Ny8rK5NjVVRUuPnPf/5zuY96pqlWK3XNmpm1tLS4ubrOTjjhBDmWej6r5jD13DIzmzZtmpur9ytqDps/f77cBq2YJjrl6quvdvPLLrtM7qPaEFWLcnd3txxLnXP0WtQ21fiaZbokUT2D1Fjqs6aZfp2qdTp6japVT83/aKzo9SuqCVA9t26++WY5VtQW7eEbJwAAAABIYOEEAAAAAAksnAAAAAAggYUTAAAAACSwcAIAAACABBZOAAAAAJBwVNaRq1rRqMJbVfuqGsaIqm5VlbJmZu3t7bnGmjBhghxL1TqqmnRVG2tmtm3bNjc/cOCAmzc1NcmxgJHg8OHDuf75FStWyG2qJnXKlClurupuzXSFcnNzs5urulczXfe7ZcsWuY+qaVb3wM2bN8uxUJylS5e6eWVlpZur54OZvgbUz1WYmXV0dLi5quR+8MEH5Viqdlj9xIaqTzYz27hxY648qjZWx6mqqnJz9XnCTFcbR8969ewcS4qpHf/MZz7j5h/84Afd/Nlnn5Vjqb+BejZE91o1N6Iae/UzAmqeR3NDnVvemnIzfa2rz47qHmOma8/VPOvr65NjqfmkauXNzGpra91cvS/333+/HOujH/2o3ObhGycAAAAASGDhBAAAAAAJLJwAAAAAIIGFEwAAAAAksHACAAAAgISjslVPtfZEJk2a5OZRA4lqYFFNW6plyMxs+vTpbq7aX6LzUsdXysvL5TbV/qLanNT7CIx0qj1u4cKFch81d9Q96LnnnpNjqZa6c845x82jFiLVglRXVyf32bVrl5urpqXo+CiOutbUPV01VJnpVqnu7m65j/qbNjQ0uHnUOtvT0+Pm6rnZ2toqx1Ktt2os1XZnpp9RqgUtasJU82z27Nlyn6jtbayLPj+8733vc/NvfOMbbq4+U5nplradO3e6eXTfVK12UXurms/qc1XUnqmOo65ndc2a6XkzODgo91FUq556v6LPrepeEr0W1Tytxtq6dasc65RTTpHbPHzjBAAAAAAJLJwAAAAAIIGFEwAAAAAksHACAAAAgAQWTgAAAACQwMIJAAAAABKOyjpyVZEaVZSqulVV6WhmNjQ05OaqKlzVDZuZLViwwM1VhbmqZzXTlbLqvKIayJqaGjdXlY5RPS4wkl1++eVu3tTUJPdRNbFtbW1uvnLlSjnWCSec4Ob79+938+bmZjmWqtWN5md7e7ubq59EwPBTzy51namqeDNd+xv9/ISqaVbPjpkzZ8qxtm3b5ubqmRqNpa5n9fqjZ5qaA+qnN1Rupl/LSSedJPehjly7+uqr5ba1a9e6+Yc//GE3v+mmm+RYZ599tpurSvzoc6ASVYiruXno0KFc/7yZnpvjx/sf36PzUiorK91cVX6b5a8wj55Nqto82kd9dlbvy6c+9Sk51mWXXebmV1xxhZvzjRMAAAAAJLBwAgAAAIAEFk4AAAAAkMDCCQAAAAASWDgBAAAAQMKIbtVTzTmqNUM1c0RjRY06eRtQ5s6dK8dSzVl5X2N0fJVHzSiqbVC16kUtT+qc1fsIvBJUc9gpp5zi5nv37pVjTZo0yc27u7vd/K677pJjtbS0uPm0adNyHcNMNycdPnxY7qOak6ZMmeLm6n00o4mvWOp6UvfuqFVK3VejhjB1j1b7RPd7da2ptquo7Us9B4t5jb29vW6uWiqLae6aP3++3Afam970JrntxRdfdPPFixe7eTFNeLW1tW4eXQPqM6K6n5rlvz9HDXVRS6Yn+hysxlKvpZhnUHV1da5jm+l5HjVlq7+/+lv++7//uxxLXXvy2Ln+aQAAAAAYg1g4AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIGFEt+pNnDjRzVU7h2omMjPbvn27m7/qVa+S+6jWENVaotqxonOrq6vLdQwz3XSkzjdqn2ltbXXzYt5j1VijGgWB/6Cu0eh6U9773ve6+c6dO908ao9TLUiqhWjJkiVyLNWcpJqD+vr65Fj79u1z86iNs6amxs3Va1TtSGa06hVLNRiqe3fU9qWeA1ETlWqvUq120TWo5oAaK3otXV1dcptHPWvMdBPecDbrTp8+PTg7LFiwwM1nzZol9/nRj37k5ldeeaWbT548WY6Vt41x3LhxcizV0jg0NCT3Ude6uj+ra9NMvxb1GTFqwlSf69SzKXr+queJeo+j5kAlei3q/VfPra1bt+Y+vsI3TgAAAACQwMIJAAAAABJYOAEAAABAAgsnAAAAAEhg4QQAAAAACSycAAAAACBhRNeRq8pRVd0YVTref//9br5s2bL8JyZEdYudnZ1uPmHChNzHUdW1qlJT/fNmZo888oibn3322bmOYaar1akjh1lcla0qV5U//MM/lNuamprcvLm52c1VRbSZ2Y4dO9xc1aRG95PHHnvMzVW1eHQ/Ue+lqmI2M+vu7nbzOXPmuPmkSZPkWOpnDBBTVbnqvhrdb1WNfDSXVL2wqhaPKunVM009h6NnnTq+umajZ716jT09PW4evUZV+Txv3jy5D8xOO+00N49q57/97W+7+Y033pj7+Oo+qD5TRteAmmeqjjui5mY0Z1W9d0NDg5tHz1lFzb+ocl1RP4cQ/cSOEtWh5/3Zg2I+ayt84wQAAAAACSycAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkDCiW/VUS5tqGooaOJ588kk3j9p5oja6vGPlbTpRTSpmuulEHSNqZtq4caObn3POObnHUo01eGWoayS6DvPKOwfM9DzM25xnZnbxxRe7+RlnnCH3Ue9Lb2+vm2/dulWOpa5pNdYDDzwgxyovL3dz9R5PnDhRjqXey/r6ermPuj+ov9f8+fPlWGvWrJHboKnrSV2z0TOtmJYq9exobGx08/b2djmWavVSbXvR+ap7VvS8UVSr1kMPPeTmp556qhxLNXGVlZXlPq+xZNq0abn32blzp5ur60y1JJrp1lN131T380j0GU0dR13n6nyj46h9omd23lbN6LOEan1V5xXNGfVsiloY1b0s72ssBt84AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIIGFEwAAAAAkjOhWPdWmokyaNElua21tdXPVdGVmNjAw4Oaq6aeY1pBi2pQU1aYSjbV58+Zc5zWczYH4rynmGimlqKXtrLPOcnPVavXoo4/KsU444QQ3V21bJ554ohxr+/btbn7aaae5+d69e+VYW7ZscXPVHtrf3y/HUo1CUQuZmp+qUWrRokVyLGhTp06V29QzophGVNXcVcx9WN3Xo4aumTNnuvm+ffvcPHrWqueNasJScznapuZT9H6p9z96Ds6bN8/NN23aJPcZbWpqatz817/+tdzn8OHDuY4R/d3UPU3NGfVZz0w/g6KWWNU4Vwz1nO/u7nbzYubZ/v373Tx6HXnb/oppyIzaBtUz8EjgGycAAAAASGDhBAAAAAAJLJwAAAAAIIGFEwAAAAAksHACAAAAgAQWTgAAAACQMKL7o6urq91cVYFG9cxdXV1uHlU35q17VvWMZrrWVVVwRnWrihorqknv7Ox08ylTprj5jh075FiqghSvDDU/Zs2a5ebR9amuAzUHFixYIMdSNdbRXFM1tW1tbW5+yimnyLH6+vrcfNu2bW4eVdEePHjQzTds2ODmqj7ZzGzixIluruZn9PdSokpf9VpUde+cOXNyHx9mxx57rNxWW1vr5uoajOrAVb1vVJOc99kZXc+qKriY55B6/apyOLqXqGfngQMH3FzNCzP9+qPXouroqSOPa9wV9ZMQ0c8lqKpuVWGu5qWZvp6jualep7qnR2Opuanmf1TTrc5LvS/R80QdP+/5mhX3vqj7jxormud58Y0TAAAAACSwcAIAAACABBZOAAAAAJDAwgkAAAAAElg4AQAAAEDCiG7VUy0cqjVDtWmZ6XaOYlpeVGtI1M6lWmZUm0nU6Kdev9onartTDSyDg4NuHjWjNDQ0yG0ozrJly+S28847z81/+9vfuvm8efPkWC0tLW6urrWdO3fKsbZu3erma9eulfuo9qozzzzTzVesWCHHmjFjhpurJix1rZuZLV++3M3VXFPNfdHxVQNUMS1AURunugeq+5ZqNERs+vTpcpv6+6hmw+g5kPfvaaafd8U8H1UTp2qwjVoi6+rq3HzXrl1uHjUHqvdMHSMaS70vUXPZhAkT5LaxQl0D0X1bUXPmuOOOk/uollZ1r40+1zQ3N7t5dN0oqgkuegblbcKLzkvto56/Uaud2qaO0d/fL8dS7X1qLDP9OtX10tHRIcfKi2+cAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkMDCCQAAAAASRnSrXm1trZurdp4DBw7IsaZNmzYs5xQdv5g2EzWWahmJ9lFtQqrJJdqm3suoZSk6Dorz9re/XW6bP3++m2/cuNHNf/GLX8ixVEOOanYrLy+XY6n2vte//vVyn2OPPdbN8zbkmeVvCFL/vJnZI4884uaqBUm1E5rpJi71WqZMmSLHUn+XqLlMHUe1bkZNT9AmT54st6nGO9XqFT0H1FhRE5Y6jnp2RNeTGks1YarmQDPdhKUa6qL3RW1T1/O+ffvkWI2NjW4efdaYOnWq3DZWfPvb33bzj3/847nHev/73+/mn/70p+U+xx9/vJsX0zys9ilmninR5yp131bXYDRn1etU95Lq6mo5lprP6vhR42vez7Rm+Vtnt2zZkuufj/CNEwAAAAAksHACAAAAgAQWTgAAAACQwMIJAAAAABJYOAEAAABAAgsnAAAAAEgY0XXkqopUVT12dnbKsZqamnIfX1Uh5q0WN9N1k6o6VR0jOo6qZ4xqGz/wgQ+4+Z49e9w8eh/zVnDif7vooovc/IwzzpD7qOvzqquucvOoDlRVq6rroL+/X46lrt3o+lCV4KriX1V7m+lqVVXrGtWRv+pVr3LzOXPmuHl9fb0cS73/fX19bh69x2pbNNfVPainp8fN3/Oe98ixbrvtNrltrIvqqNV7rX7KIboGlGhuqGtQHT+q/VbzXFXyq59JiI6vPgNEP4eg5r+6/vfu3SvHUj/5ENVHq3vDWPLiiy+6eXTf2Lx5s5u/5S1vcXNVFW+mf37miSeecPPo2aieQdHcUNenuj9H15O6nlUenZe6N6jjq/lnFn9GzfvPq88f0U8YqGp19fMCTz/9tD65nPjGCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAksnAAAAAAgYUS36imq6ebRRx+V+8ybNy/3cVQ7iWq1i1pDVDOLanOJWlZUm1ox/3xDQ4Obq4ZC1VZjplvLkKZapaL3W7VBqZY2dQ1GVItidE2pa3dwcFDuk3dORXNNtfepFh713pvpdiR1jKjRbNeuXW5eTHNa3nuTWf5zXrdunRyL5jAtalZUc0BdZ9GcVQ19EXWcvA2yZnqed3V1uXn0WtQ2NTejOavaxtRr37ZtmxzrtNNOc/Ni7mUwu/TSS+W2k08+2c1Vu+f27dvlWOpe+8Y3vtHNDxw4IMdS12b0DFTtecU09Kl5pp5nETWWei3R80w9T4q5/tVYUUOpujd9/OMfz338vJjhAAAAAJDAwgkAAAAAElg4AQAAAEACCycAAAAASGDhBAAAAAAJI7pVTzVtqAaQqLVHNbYUCgW5j2rtUA0olZWVcizVgKSafiZMmCDHUq1B6v1S/7yZPufu7m43nz59uhwramBC7Pbbb3fz448/Xu5z7rnnunlzc7ObR62Hvb29bq7mRzRvVKtOdHzV9qPGipp76urq3FzNg+i1PPnkk25+9913u3lHR4cc6zvf+Y6bv/jii24eNXcV0+qn7pvq76LuTWZx2+NYF90H1d+0sbHRzdV9OBI1sqptag5EY6nXqZ5d0fWkWsiU6LzUezZ79mw3f/755+VYkyZNcvMNGzbIfYppLx0ror/bE088kSsvxi9+8Qs3/9M//VO5z8yZM928urpa7qNaH9WciZ5nalsxczbvczaas2vXrnVz9ZyNnmeqPe+BBx6Q+3zmM59xc/VZO3pfos8AHr5xAgAAAIAEFk4AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAkjuj9aVTqqyt2oBnbWrFlu3t7eLvdRlb8qjyolVUVr3qrJ6PiqBjWqKFb14jt37nTzqDa2qqpKbkNxbrjhhtzbli9f7ubXXnutHKumpsbNjz32WDdXledmZnv27HHz+vp6uY+qxd+2bZubr1ixQo71sY99zM3//u//3s37+/vlWMNJ1SSvXr3azYupSVaV49E29d5v3LhRjvUP//APbv43f/M3cp+xIroPqnu0qsrdv3+/HEs9U9TzIdqmnp1RhXBnZ6eb19bWunlU36yOr56DxVR+qzmj7ldm+qdHItFPiYwV6nqOKqHVzyKov3X0GUlte+yxx3LlGD3yVo5H+MYJAAAAABJYOAEAAABAAgsnAAAAAEhg4QQAAAAACSycAAAAACBhRLfqqRYe1bRVV1cnx1LtdVETn2rbUvsMDAzIsVTTkmqZidrrFHVeUZONam1qbW11846OjtzHx5H19NNPu/nll19+ZE/k/xC1fSmq1aqxsVHuEzWRldIvfvELNy/mfYnmdF6qBaynp2fYjjGWRE1saptqr1uzZo0cS7VnNjQ0yH1UQ1kxz0c1Vl9fn5tH7ZVqLNWsG7VHqmenGitq6Gtra3PzqCGQVj3dYBY1mxXzmQcoBb5xAgAAAIAEFk4AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAkjuj9a1YeqSstiKko3bdok95k0aZKbR3Wzijo3lUd1w6o6Vr1GVYVuZtbd3e3mxVQkq78XYFbcvFFGauX4kRLV+uZF7fjwiu6d6u9WTBVzbW1t7rEqKyvdfGhoyM0nTpwox1LPIfWTFdFzSL2W9vb2XP+8mX6P1bPu1a9+tRxL3bPUWGbFPTsBHD34xgkAAAAAElg4AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIGFEt+p1dna6eXV1tZvv3r1bjvXa177Wzbu6uuQ+zc3Nbl5Mq59q51HteVFrlmrtUcdQ75eZbjpSrWVRc96+ffvkNgAYC/bu3Su3nX766W6u7quq7c7MbPx4//GtmvPMzBoaGtxcNci+8MILcqxnnnnGzc8++2w337BhgxxLNfSdcsopbj4wMCDH2rVrl5ur97i1tVWOpZ6PTU1Ncp+ocQ/A0Y9vnAAAAAAggYUTAAAAACSwcAIAAACABBZOAAAAAJDAwgkAAAAAEkZ0q55qu1HtOFFrz9SpU9388ssvl/vU1NS4uWotUg08ZrodSbX6Ra1Bqj3vwIEDbq4ai8zMfvSjH7n5DTfc4OaqyclMtxkBwFhx3XXXyW2/+tWv3Pyd73ynm998881yLNWQpxpRzfQzUrXnPfHEE3IsRTXC/s//+T/lPv/4j//o5osWLXLzc845R4713HPPuflnPvMZN1+9erUca8WKFW5eX18v97n//vvlNgBHP75xAgAAAIAEFk4AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAkjuo5cVXXv3bvXzVUNauSWW27Jvc9YoN77jo4OuY+qQwcA6OrrqBJb+Yu/+As3X7hwodynr6/PzVXt9+mnny7Ham5udvNPfOITbh49H1772te6+aFDh9x848aNcixVx/7GN77RzdWzzszs7rvvltsAjE184wQAAAAACSycAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkJAV00QHAAAAAGMJ3zgBAAAAQAILJwAAAABIYOEEAAAAAAksnAAAAAAggYUTAAAAACSwcAIAAACABBZOAAAAAJDAwgkAAAAAElg4AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIIGFEwAAAAAksHACAAAAgAQWTgAAAACQwMIJAAAAABJYOAEAAABAAgsnAAAAAEhg4QQAAAAACSycAAAAACCBhVMJZFlWkWXZ17Ms25plWXeWZU9nWXZRqc8LGE2YZ8CRkWXZ1VmWPZFl2WCWZd8s9fkAo1WWZfdlWTaQZVnP7/+3vtTnNNawcCqN8Wa23czONrN6M/uYmX0/y7I5pTwpYJRhngFHxi4zu9HMvlHqEwHGgKsLhULN7/+3qNQnM9aML/UJjEWFQqHXzD75n6KfZVm22cxWmNmWUpwTMNowz4Ajo1Ao/NDMLMuyk81sRolPBwBeMXzjNAJkWdZsZgvN7PlSnwswWjHPAACjwGezLGvPsuyhLMtWlvpkxhoWTiWWZVmZmd1qZrcUCoV1pT4fYDRingEARoHrzWyemU03s6+Y2U+zLJtf2lMaW1g4lVCWZceY2bfN7KCZXV3i0wFGJeYZAGA0KBQKvykUCt2FQmGwUCjcYmYPmdkbSn1eYwn/jVOJZFmWmdnXzazZzN5QKBSGSnxKwKjDPAMAjGIFM8tKfRJjCd84lc6XzGyJmb2pUCj0l/pkgFGKeQa8wrIsG59lWaWZjTOzcVmWVWZZxr+YBYZRlmUNWZZd8B/zK8uyd5vZa83srlKf21iSFQqFUp/DmJNl2Wx7udVr0MwO/adNVxYKhVtLclLAKMM8A46MLMs+aWaf+D/ivy4UCp888mcDjE5Zlk0xszvNbLGZHTazdWb2PwqFwi9LemJjDAsnAAAAAEjg/1UPAAAAABJYOAEAAABAAgsnAAAAAEhg4QQAAAAACSycAAAAACAh/J2FLMtGfeXezTffLLetX7/ezQ8cOODmhw4dcnMzs56eHjffu3evm9fX18uxpk2b5ubjx/t/zui8LrnkEjf/yEc+4uZPPvmkHGukKhQKI/7H4cbCXDvuuOPktksvvdTNZ82a5ebXXnutHKu8vNzN29ra3LylpUWO9c///M9uftdd/s9m/Ou//qsca2ho9P/27kifa2Nhnk2ePFlue9vb3ubmb3rTm9z8jjvukGOpZ5d63qjnk5nZO97xDjdXz+Cvfe1rcqxt27bJbaMF8wx45al5xjdOAAAAAJDAwgkAAAAAElg4AQAAAEACCycAAAAASMgKBf3f8I2m/8Bv/vz5bv7CCy/IfXbv3u3mNTU1bj5u3Dg5lvoPw9VYvb29ciz1H99u2LDBzSdMmCDHWrhwoZtfc801bv7lL39ZjjVSjfT/kNZsdM21v/3bv3XzpqYmuY/6D7onTZrk5suXL5djDQwMuLkqh2hoaJBjPfTQQ3KbJyqauPvuu9389ttvz3WMkWykz7WROs/mzJnj5hdddJHc54QTTnDz6upquY8qKTr55JPdfNmyZXIs9Rw6fPiwm0fzTM3/1atXu3n0TOvv73dz9XyM5t+LL74ot5US8wx45VEOAQAAAABFYuEEAAAAAAksnAAAAAAggYUTAAAAACSwcAIAAACABBZOAAAAAJAwvtQncKRMnTrVzaPa782bN7t5bW2tm5eVlcmx+vr63Hz//v1uXldXl3usffv2ubmqoDUz27Nnj5tHrwVQleNmZkuXLnXzp59+Wu6jqvzVPs8//7wc69hjj3Xzl156yc1//etfy7HUzwioe0B0P1m5cqWbq2rlW2+9VY6Fo9Mb3/hGN7/gggvcPLp3t7a2unlXV5fcR1WIqzkwe/ZsOZaqUJ8yZYqbd3Z2yrFU7b+6L6j5Z6Z/4kP9HMKHP/xhOZa6//zLv/yL3AfA6MY3TgAAAACQwMIJAAAAABJYOAEAAABAAgsnAAAAAEhg4QQAAAAACWOmVW/ZsmW596mqqnJz1dqTZZkcq7m52c1VA1HUGnTw4EE3b2trc/Oozejw4cNuPjg4KPcB7r77brltxYoVbt7S0iL3UW10lZWVuf55M7NHH31UbvOoVjsz3S6pmi3Ly8vlWKqh74477gjODkebiooKue2UU05x871797q5us7MzAqFgpurOWOm7/fz5893c9XUamb25JNPurmam8cco/89rbo3qNeiGjKjbe3t7W6umm3NzJYsWeLm0eeJNWvWyG0Ajn584wQAAAAACSycAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkDBmWvVmz57t5lHTz7hx43Id49ChQ3KbarZTTT+qgctMt+o1Nja6eV1dnRxLNQeeeeaZbv7Vr35VjoWx46677pLbLr30UjefPn263Oe3v/2tm6vGq2huqpY8tY9qGjPT83bWrFlu3tDQIMd69tlncx0DR6eVK1fKbaqRtaenx83V/dnMrL+/382j61k9V9RYqg02Orfx4/2PFVHjpGoVVA190fzP+9yOPgOoZ+0555wj96FVDxjd+MYJAAAAABJYOAEAAABAAgsnAAAAAEhg4QQAAAAACSycAAAAACCBhRMAAAAAJIyZOvLFixe7eVRdWlFR4eZR3atSXV3t5vX19W6uKpXNdEWqqpRVlc5mxVWYA5HvfOc7bv65z31O7qOud1VTHM2PsrKyXHmku7vbzdV8njlzphzrT/7kT3IfH0efk046SW5TP1mRZVnu46jrOXqmqev59NNPd3P1fDIza21tdXP1GtWcMTObNm2am7e1tbn57t275ViDg4Nu/tJLL7m5qog3058BFi1aJPcBMLrxjRMAAAAAJLBwAgAAAIAEFk4AAAAAkMDCCQAAAAASWDgBAAAAQMKYadXr6Ohw8z179uTep6qqys3Hj9dvp2pAUq12UXNfZ2enmw8MDLh5X1+fHEs1He3bt0/uA0SefPLJ3PtUVla6+fHHH+/m0fxQzWFqDqpjm+n2PpVv375djqXmJ45O6t45b948uY963kSNc4pqV43mxvz5891827Ztbh49Ow4cOODmTU1Nbv7EE0/IsVSL68knn+zmao6bmXV1dbm5mv/R30s9B6OGzpaWFjdXDYEAji584wQAAAAACSycAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkDDmW/V6enrkPqq5R7XnRa16L730kpur1iLVnGdmNjQ05Oaq5Ui1DJmZTZ8+3c137twp9wEiqonq8ccfl/uohrA5c+a4+bp16+RYtbW1+uRyUg1ZqlXvQx/60LAdGyPbmWee6eatra1yn/LycjdXTa3HHKP/3aZ6dqlr1ky3walznjJlihyrt7fXzVVDoGrOMzObPHmym6t7xuLFi+VYg4ODcptHNdua6edg1DY4a9YsN6dVb3SJPu8dOnQo11jRPFefHY8E1WprZvbss88ewTMZWfjGCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAksnAAAAAAggYUTAAAAACSMmTpyVe+tqr3NzAqFgpurqsnKyko51rhx49x8//79bp5lmRzr8OHDufaJzkvVYG7dulXuAxTjs5/9rNz23ve+180nTpzo5lF9q6KqmKNqYTVvVU36wMBA7vPC0WnRokVuHt1v1TWorucFCxbIsTZv3uzmUR2/qhBXNenqZwLMzGbOnOnmO3bscHP10xdm+jms5p+6L5jpnx5paGhw86iOXD3royrq173udW7+2GOPyX1w9Ikqx9V8Vnne+nIzPWdXrVol91GfadUz8Oyzz5Zj7d69O1c+UivXi8E3TgAAAACQwMIJAAAAABJYOAEAAABAAgsnAAAAAEhg4QQAAAAACWOmVW/Xrl1uHrVgqSY+1WqnGpPMzJqbm91ctSbt27dPjqXOWTWz9PT0yLFUA1RXV5fcByimIWfGjBlyn7/+679283/8x39085aWFjmWmreqoSt6LWpO79y5081p1Rs7br75Zjc/88wz5T7veMc73Fw1zp1wwglyrAceeCA4O9+ECRPcvL6+3s2j61m1573mNa9x86eeekqOpVryZs+e7eZqjpuZVVVVubma/1ELorqXtbW1yX1uu+02uQ1jg7puhrM9TjVeRnPjggsucHPVahk9s8855xw3/973vufmR1tzXoRvnAAAAAAggYUTAAAAACSwcAIAAACABBZOAAAAAJDAwgkAAAAAElg4AQAAAEDCmKkjV/Xa48fnfwtU3Wlk//79bn7DDTe4+Ze//GU51vPPP+/mqp5SVbGbme3Zs8fNX3jhBbkPUIxirsO9e/e6+bZt2+RY5eXlbq6qxaOaVFVhrHLgwQcfzL0tyzI3/+UvfynHUhXevb29cp9CoeDmap5F13ljY6Obq+eT+ufN9E8CqJ/lmDJlihyrqanJzX/605+6+TXXXCPHUj/xAZTapZde6ubRT3Woz6Fr1651czWXzMwaGhr0yZWQ+umf6P6zbt26XMfgGycAAAAASGDhBAAAAAAJLJwAAAAAIIGFEwAAAAAksHACAAAAgIQx06rX0dHh5qrNx8zswIEDbq7auWpra+VYAwMDbn7XXXe5uWpZirS3t7t51ByojrNx48bcx8fYETXRKZs2bZLbfvKTn7j58ccf7+aLFy+WY6mGnKGhITePGrrq6urcXDWHAcVQbXfPPPOM3KeiosLNd+zYIfc544wz3Fy1VKqGKjPdXqnuDYODg3Is1d6nWsCi+a8aOlUbLs15w099rirmuTEWTJ8+XW677rrr3Py8885z8+7ubjnWN77xDTdXjcz33HOPHEvdZ6ZOnerm0TxT26LPruq5rT6HR/cyWvUAAAAAYJixcAIAAACABBZOAAAAAJDAwgkAAAAAElg4AQAAAEDCmGnVW79+vZurpi2z/C08qoXPzKy+vt7NVTPJ4cOH5Vh9fX1urhryJkyYIMfau3evm0fNLEDURqmak1asWCH3UfNQtddFTXizZs1yc9XQ1dnZKcfq7e1184ULF7q5atw006+RBqqxI+/f+sc//rEc641vfKObq2vWzGz37t1urhqn1LPGTD+7LrzwQje///775VjqeVdTU+PmTz31lBxrxowZbq6edZFi2m1VQ+JYwr3Ld/3117v5W97yFrmPumeosVQTrJluo2xpaXHzffv2ybFOPPFEN1f3n+gzg9r2ox/9SO6jnufq+MP5mZZvnAAAAAAggYUTAAAAACSwcAIAAACABBZOAAAAAJDAwgkAAAAAElg4AQAAAEDCmKkjVzWsAwMDch9VLdza2urmjY2NcixVYa5E1eZqLFUdGx17586duc4LMCuubnbVqlW591E1xdu3b8+9j5rrUV3/uHHj3FxVnp577rlyrLvuusvNqe4dO/L+rdeuXSu3rVy50s3Hj9ePdXW/P+uss9y8vb1djvXCCy+4+UMPPeTm0Ws/7bTT3FzVIT/88MNyLFVHrp7bEVVHzpyNRdXTinpPR+rPNZxxxhly24033ujm8+bNc/Obb75ZjvXtb3/bzfv7+938a1/7mhxr5syZbq5+wuO+++6TYz3yyCNuvmDBAjdXP19gpqvNo88M6qdK1GuZNm2aHGv16tVym4dvnAAAAAAggYUTAAAAACSwcAIAAACABBZOAAAAAJDAwgkAAAAAEsZMq54StXOpRp2qqio3j1peVAuXErXqTZo0yc23bt3q5g0NDXKsrq6uXOcFFGvixIlym2q8q6ysdPOoCU+16nV3dwdnl28slZ9yyilyLNWqh7FDPVMKhYKbR88UdQ1GrXqqYfW5555z85aWFjnW6173ulzH2LRpkxyrtrbWzdva2tw8mv/FzHNF/V0QG87GuyPRnnfmmWfKbR/4wAfcfOrUqXIfda1/+MMfdvOoPfP00093c9WEec8998ix/v7v/97N1Zz94he/KMe68MIL3Vx9Pv3Nb34jx1LP/1NPPVXuo16/+kxfXl4ux/r4xz8ut3n4xgkAAAAAElg4AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIGHMt+rt27dPbmtqanJz1QASNf3s2bMn13mpNiEz3Q6i2oTmz58vx9q2bVuu8wJSVBPXrFmz5D7r1q3LdYyDBw/KbWoeqvmhmvtS2zxRCxlQaqqJr729PVduZvbss8+6+fTp09189+7dciw1/1WrnXodkZqamtz7HHOM/++Wizk+YupeO2XKFDdXfxsz3TB87bXXuvnb3/52OdZTTz3l5lFLXGtrq5svXLjQzVUTnZnZvHnz3PyDH/ygm3/hC1+QY11++eVym6esrExuW7p0qZufffbZbn7xxRfLsVTjbPT5VLVFNzY2uvndd98tx1q0aJGbn3POOW7ON04AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAksnAAAAAAgYczXkQ8ODsptFRUVbt7b2+vmUXXxli1bcp3Xpk2b5LbjjjvOzVUNc3Rehw4dynVeQMrixYvdPKo2zWvcuHG5t6n62qjWVtUOqzkV1aSr47z00ktyH4wuql5biWqvsyxz86GhIblPbW2tm6trM3o+qG2qijl6LerZpX76o66uTo6l3uNi7j95/1542fjx/kfL+vp6uY+qHT/xxBPdPPrJlpkzZ7q5qh1/5pln5Fjf/OY33Tyq1161apWb//SnP3XzFStWyLGuu+46N3/yySfd/KyzzpJjqb/L1KlT3byjo0OOtWPHDjffuXOnm/f19cmx1HHUT4iYmW3fvt3N1X1pxowZcqy8n4P5xgkAAAAAElg4AQAAAEACCycAAAAASGDhBAAAAAAJLJwAAAAAIGHMt+pFjVqqUUe1GZWXl8uxtm3bluu8nnvuOblNNbCo81LtgGa6yQYo1vHHH+/mUXucatzK25CX2paXauJS7XmqHczMrKmpyc2jdiiMLuoerZ41qgXLTM+ZqL1OXc+qvS6init5myijfdRcjpoD1XvZ1dUl98HwUu15kyZNkvscOHDAze+55x43j+7zqj3yiiuucPOoVU09t77xjW/IfebPn+/me/bscfPHHntMjvXrX//azdWzUR3DTL/HNTU1bh61Su7du9fNb731VjdXLXxm+v1vbm6W+6jP22qs6B6n7k2q0ZBvnAAAAAAggYUTAAAAACSwcAIAAACABBZOAAAAAJDAwgkAAAAAEsZ8q55qGTIzq6qqyjVWXV2d3KbalJSoGaWhocHNBwcH3Vy1r5iZTZw4Mdd5ASnTpk1z82iu9fb2urm61qMGS0XtE42l5k4xzWHTp093c1r1xo6opcoTNaKq9qjoelbHV81h0TNQPW+KacJT9wY1z6IWNHX8qG1Qyfv3wstUW2/UOqr+burajFpald27d7t51N5WXV3t5tE1uHHjRjdXbX/RWE8++WSufdQxzHR7XmdnZ+7zUu9Ld3e3m0eNiuo40d9YNduqfaIWRtUCqfCNEwAAAAAksHACAAAAgAQWTgAAAACQwMIJAAAAABJYOAEAAABAAgsnAAAAAEgY83XkUd1i3irUqLpU1S0rqtLRTFd9zpgxI9cxzPLXMAIpqpY/qsVXNd5qn6haVNUeq8rjqCY92uaJ6sijmljA09jYKLf19PS4efQTE9HzzhM909RY48f7HyuiOnA1lqpjj+4lfX19bv66173OzZ9++mk5FoZXdD2r54a6B0f19v39/W6ufhJC/fNm+a9NM137PTAwkOufN9Of0dR8UvPPTL+Xqto7oo6jPutG75f6uZ6896tiRTX5Hr5xAgAAAIAEFk4AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIGPOtelHTx6RJk9xctdcNZ5tRZ2en3KYahWbOnOnmzc3NcizVQAQUK2qWU8rLy3P98y+99JLcppqDVAtR1NCltqnjR2OpNkyMHao9SrXXRQ1Zqokrai5rbW11c9UqFTWXqTlQzNzI+3yM3hfVkFZVVZXrGGZxqyC0devWufmOHTvkPuoaVNdz1ESnrjV1PUfXhhoraj5W5zacLbHRHMg7Vt77kpl+nqrnf9RQGz3P84ruM8quXbty/fN84wQAAAAACSycAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkDDmW/Wi1hDV5jJ37lw3r62tlWOpBhIlap9RDShNTU1uHrXP9Pb25jovICVq4lKqq6vdXLXtRPMpaijyRG0/qqEn73w2M1u4cGHufTC65G1pi9omJ0+e7OaqOc8s/3Ubna/aVszcUGMNDg66efS+qKbYvXv35j4vDK+enp7c23bv3v1KnQ5QFL5xAgAAAIAEFk4AAAAAkMDCCQAAAAASWDgBAAAAQAILJwAAAABIYOEEAAAAAAljvo58z549clt9fb2bDwwMuHlUm9nZ2ZnrvLZu3ZrrnzfTtcpRPbOqbgWKVVlZ6ebF1BTnPYaZripW13pUbayomvTI/Pnzc++Dsa2urk5uO3jwoJsfOnRI7lNRUeHmeWvSI6rCPzovdW9QzzT1DDbTP7+hqs0BIA++cQIAAACABBZOAAAAAJDAwgkAAAAAElg4AQAAAEACCycAAAAASBjzrXptbW1ym2qjU3nUTNTR0ZHrvKLWIHWc8eP9P2fUAFZMOxgw3IaGhtxcNXRFrXoTJkxw866uLjePWidV455qAYuaA6M5DXiqqqrkNnU9qeeAmZ5PKo+a6LIsc3M1Z1QLoJl+pqljFGM4Wz0BjF184wQAAAAACSycAAAAACCBhRMAAAAAJLBwAgAAAIAEFk4AAAAAkMDCCQAAAAASxnwdeXt7u9yWt7o1qvbOW0ceUbWuqoY2qlumIhnDLbrelEmTJrl5Z2enm0dzrayszM3zzmcz/VrUPqpW3cysoaHBzVW1OnMT0fXU19fn5sVcz8X8LIXaR1WLR/eFYur9FfW+RNXueUU16dHPkgA4+vGNEwAAAAAksHACAAAAgAQWTgAAAACQwMIJAAAAABJYOAEAAABAwphv1du3b1/ufVSjTtSm09/fn/s4Smtrq5tHbUrK4ODgf/V0MAapJjgz3R7X29sr98nbIFdM25YSNZcpxTQHdnd3uznteVCi9rZiqCY8lUfzTO1TzPNRjXXo0CE3Vw2yZrp1dvLkyW5eV1cnx+rq6nJzWvWAsYtvnAAAAAAggYUTAAAAACSwcAIAAACABBZOAAAAAJDAwgkAAAAAEsZ8q16kqqrKzVU7T9SONZwtYLW1tW5eUVHh5lEDmHqNQCS61jdu3OjmEyZMkPvMmTMn1/E7OzvlNtUuqebgvHnz5FhNTU1uvmXLFjdva2uTY/3617+W2zA2qHuxapVraWmRY0VtcEp9fb2bqya66LmltqlnSnS+qnFTtddFrZ49PT1uru4LxbRqAhi7+MYJAAAAABJYOAEAAABAAgsnAAAAAEhg4QQAAAAACSycAAAAACCBhRMAAAAAJGSFQkFvzDK9cQx4/etf7+aqCvWFF16QY61bt25YzslMVyRfdNFFbq6qXs3MfvzjH7v5aKpoLRQKfqftCDIW5lpZWVnufVQd89KlS+U+K1eudPOpU6e6+fe+9z051l133aVPDv+XkT7XSj3PVL22eg6Xl5fLsebOnevmUVW3qgpX+zQ2Nsqx1D7qtUTV5qoO/cCBA27e1dUlx1I/VbBnzx43V/XlEfV3NNOvfzgxz4BXnppnfOMEAAAAAAksnAAAAAAggYUTAAAAACSwcAIAAACABBZOAAAAAJAQtuoBAAAAAPjGCQAAAACSWDgBAAAAQAILJwAAAABIYOEEAAAAAAksnAAAAAAggYUTAAAAACT8fymIc0/kiZd3AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1080x1080 with 16 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, axes = plt.subplots(4, 4, figsize = (15,15))\n",
+    "for row in axes:\n",
+    "    for axe in row:\n",
+    "        index = np.random.randint(60000)\n",
+    "        img = f1.drop('target', axis=1).values[index].reshape(28,28)\n",
+    "        cloths = f1['target'][index]\n",
+    "        axe.imshow(img, cmap='gray')\n",
+    "        axe.set_title(clothing2[cloths])\n",
+    "        axe.set_axis_off()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "listed-handle",
+   "metadata": {
+    "papermill": {
+     "duration": 0.094937,
+     "end_time": "2021-04-26T04:07:34.668147",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:34.573210",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Analysis from dataset :\n",
+    "\n",
+    "- As from above plot we can see that there is mixed images in each target variable. Which may cause in performance while training neural networks and machine learning models.\n",
+    "- Moreover using trial and error method, we identified that most of the shoes/sandal/ankle boots/bags are fall under target variable '4' and '5'. However some of them items are also fall under target variable '3'.\n",
+    "- Cloth items are included in first 3 target variables but ditribution between first 3 variables are not clear."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "billion-chosen",
+   "metadata": {
+    "papermill": {
+     "duration": 0.088968,
+     "end_time": "2021-04-26T04:07:34.846876",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:34.757908",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 4.5 Data Preprocessing\n",
+    "\n",
+    "#### 4.5.1 Setting Random Seeds for Reproducibilty.\n",
+    "\n",
+    "- In order to generate same random numbers on multiple executions of the code on the same machine or on different machines (for a specific seed value)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "configured-defendant",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:35.044593Z",
+     "iopub.status.busy": "2021-04-26T04:07:35.043817Z",
+     "iopub.status.idle": "2021-04-26T04:07:35.046341Z",
+     "shell.execute_reply": "2021-04-26T04:07:35.046947Z"
+    },
+    "papermill": {
+     "duration": 0.099519,
+     "end_time": "2021-04-26T04:07:35.047160",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:34.947641",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "seed = 66\n",
+    "np.random.seed(seed)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "inside-kingdom",
+   "metadata": {
+    "papermill": {
+     "duration": 0.092879,
+     "end_time": "2021-04-26T04:07:35.328644",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:35.235765",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### 4.5.2 Splitting Data into Train and Validation Set\n",
+    "\n",
+    "- We are gonna split the training data into Train, Validation and Test Set. Train set is used for Training the model and Validation set is used for tuning parameters of our model and compute different Model's Performance on the Dataset. Test set to predict label and compute best Model's Performance.\n",
+    "\n",
+    "- This is achieved using the train_test_split method of scikit learn library.\n",
+    "\n",
+    "- We have split our dataset into 80% training, 10% validation and 10% for testing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "exciting-julian",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:35.585322Z",
+     "iopub.status.busy": "2021-04-26T04:07:35.584568Z",
+     "iopub.status.idle": "2021-04-26T04:07:36.045838Z",
+     "shell.execute_reply": "2021-04-26T04:07:36.045230Z"
+    },
+    "papermill": {
+     "duration": 0.636438,
+     "end_time": "2021-04-26T04:07:36.045978",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:35.409540",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "X = f1.iloc[:, :-1]\n",
+    "Y = f1.iloc[:,784]\n",
+    "x_train1, x_valtest, y_train, y_valtest = train_test_split(X, Y, test_size=0.2, random_state=seed)\n",
+    "x_val1,x_test1,y_val,y_test = train_test_split(x_valtest, y_valtest, test_size=0.5, random_state=seed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "czech-thanks",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:36.163771Z",
+     "iopub.status.busy": "2021-04-26T04:07:36.162374Z",
+     "iopub.status.idle": "2021-04-26T04:07:36.165663Z",
+     "shell.execute_reply": "2021-04-26T04:07:36.166096Z"
+    },
+    "papermill": {
+     "duration": 0.064274,
+     "end_time": "2021-04-26T04:07:36.166239",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:36.101965",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "48000\n",
+      "6000\n",
+      "37632000\n",
+      "4704000\n",
+      "4704000\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(len(x_train1))\n",
+    "print(len(x_test1))\n",
+    "print(x_train1.size)\n",
+    "print(x_test1.size)\n",
+    "print(x_val1.size)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "protecting-aspect",
+   "metadata": {
+    "papermill": {
+     "duration": 0.054336,
+     "end_time": "2021-04-26T04:07:36.274902",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:36.220566",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### 4.5.3 Reshaping Image :\n",
+    "\n",
+    "- As we have each images as 1D vector each containing 784 pixels. Before we feed the data to the CNN we must reshape the data into (28x28x1) 3D matrices.\n",
+    "- If dataset contains RGB images, there would have been 3 channels, but as dataset is gray scale it only uses one channel.\n",
+    "- We have to reshape each images as Keras wants an Extra Dimension in the end, for channels.\n",
+    "\n",
+    "**Note :**\n",
+    "\n",
+    "- We are going to reshape x_train, x_val and x_test for neural networks during preprocessing.\n",
+    "- As we also build a Machine Learning model we will use without reshaped values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "olympic-blink",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:36.391207Z",
+     "iopub.status.busy": "2021-04-26T04:07:36.390460Z",
+     "iopub.status.idle": "2021-04-26T04:07:36.392942Z",
+     "shell.execute_reply": "2021-04-26T04:07:36.393362Z"
+    },
+    "papermill": {
+     "duration": 0.062073,
+     "end_time": "2021-04-26T04:07:36.393491",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:36.331418",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "x_train = x_train1.values.reshape((-1, 28, 28, 1))\n",
+    "x_val = x_val1.values.reshape((-1, 28, 28, 1))\n",
+    "x_test = x_test1.values.reshape((-1, 28, 28, 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "serial-dialogue",
+   "metadata": {
+    "papermill": {
+     "duration": 0.055029,
+     "end_time": "2021-04-26T04:07:36.503640",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:36.448611",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### 4.5.4 Normalization ( Not required ) :\n",
+    "\n",
+    "- Sometimes the image pixel value are  stored as Integer Numbers in the range 0 to 255, the range that a single 8-bit byte.\n",
+    "- They need to be scaled down to [0,1] in order for Optimization Algorithms to work much faster.\n",
+    "- But in our dataset each image pixel values are already scaled down to [0,1] so we skipped this normalization step.\n",
+    "- Using normalization we can acheive Zero Mean and Unit Variance.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "organizational-maria",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:36.619371Z",
+     "iopub.status.busy": "2021-04-26T04:07:36.618577Z",
+     "iopub.status.idle": "2021-04-26T04:07:36.621779Z",
+     "shell.execute_reply": "2021-04-26T04:07:36.621319Z"
+    },
+    "papermill": {
+     "duration": 0.061993,
+     "end_time": "2021-04-26T04:07:36.621889",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:36.559896",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#x_train = x_train.astype(\"float32\")/255\n",
+    "#x_test = x_test.astype(\"float32\")/255\n",
+    "#x_val = x_val.astype(\"float32\")/255"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "concrete-healing",
+   "metadata": {
+    "papermill": {
+     "duration": 0.054797,
+     "end_time": "2021-04-26T04:07:36.732113",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:36.677316",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### 4.5.5 One Hot Encoding :\n",
+    "\n",
+    "- A one hot encoding is a representation of categorical variables as binary vectors.\n",
+    "- The labels are given as integers between 1-5. Which we then updated to 0-4 so that we can use to_categorical function.\n",
+    "- We applied one hot encode them , Eg 3 [0, 0, 1, 0, 0].\n",
+    "- As dataset have 5 labels so after One hot encoding we have the target variable with 5 classes. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "compact-nightlife",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:36.847346Z",
+     "iopub.status.busy": "2021-04-26T04:07:36.846678Z",
+     "iopub.status.idle": "2021-04-26T04:07:36.852592Z",
+     "shell.execute_reply": "2021-04-26T04:07:36.852078Z"
+    },
+    "papermill": {
+     "duration": 0.065515,
+     "end_time": "2021-04-26T04:07:36.852707",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:36.787192",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from keras.utils.np_utils import to_categorical\n",
+    "\n",
+    "y_train = to_categorical(y_train, num_classes=5)\n",
+    "y_val = to_categorical(y_val, num_classes=5)\n",
+    "y_test = to_categorical(y_test, num_classes=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "olive-messenger",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:36.968203Z",
+     "iopub.status.busy": "2021-04-26T04:07:36.967464Z",
+     "iopub.status.idle": "2021-04-26T04:07:36.970685Z",
+     "shell.execute_reply": "2021-04-26T04:07:36.971244Z"
+    },
+    "papermill": {
+     "duration": 0.063506,
+     "end_time": "2021-04-26T04:07:36.971390",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:36.907884",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(48000, 5)\n",
+      "(6000, 5)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(y_train.shape)\n",
+    "print(y_test.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "first-franklin",
+   "metadata": {
+    "papermill": {
+     "duration": 0.055939,
+     "end_time": "2021-04-26T04:07:37.083826",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:37.027887",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 4.6 Training a Convolutional Neural Network ( Model 1 )\n",
+    "\n",
+    "#### 4.6.1 Building a ConvNet :\n",
+    "\n",
+    "\n",
+    "**1) Conv2D :**\n",
+    "- Notice at as our output spatial volume is decreasing our number of filters learned is increasing — this is a common practice in designing CNN architectures.\n",
+    "\n",
+    "**Conv2D  Parameters:**\n",
+    "- **filters :** As far as choosing the appropriate number of filters , I nearly always recommend using powers of 2 as the values.\n",
+    "- **kernel_size :** The kernel_size must be an odd integer as well.\n",
+    "- **strides :** The strides parameter specifies the “step” of the convolution along the x and y axis of the input volume. We have select strides 1 which means : \n",
+    "     1. A convolutional filter is applied to the current location of the input volume.\n",
+    "     2. The filter takes a 1-pixel step to the right and again the filter is applied to the input volume.\n",
+    "     3.This process is performed until we reach the far-right border of the volume in which we move our filter one pixel down and then start again from the far left.\n",
+    "- **padding :** This parameter values are \"valid\" or \"same\". As we want to preserve the spatial dimensions of the volume such that the output volume size matches the input volume size we have selected \"same\". We will reduce spatial dimensions of our volume by Max pooling.\n",
+    "- **data_format :** This parameter values are \"channels_last\" or \"channels_first\". The TensorFlow backend to Keras uses channels last ordering. We used \"channels_last\" in convolution network.\n",
+    "\n",
+    "\n",
+    "<img src=https://pyimagesearch.com/wp-content/uploads/2018/12/keras_conv2d_channel_ordering.png width=\"250\">\n",
+    "\n",
+    "    \n",
+    "**2) Maxpool :**\n",
+    "- Max pooling is then used to reduce the spatial dimensions of the output volume.\n",
+    "\n",
+    "\n",
+    "**Note :**\n",
+    "-  we can use strides=2 to help reduce the size of the output volume."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "operational-novelty",
+   "metadata": {
+    "papermill": {
+     "duration": 0.05575,
+     "end_time": "2021-04-26T04:07:37.194873",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:37.139123",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### 4.6.2  The design of Convolution neural networks definition : \n",
+    "\n",
+    "1) Firstly we used **Sequential Keras API** which is just a linear stack of layers.\n",
+    "\n",
+    "2) Then we include **Convolutional Layers**, this operation performs below operations :\n",
+    "    1. Apply filters to extract features.\n",
+    "    2. Apply activation function( in our case 'relu' ) on every every input value of feature maps.\n",
+    "    3. Filters are composed of small kernels learned.\n",
+    "\n",
+    "3) Next we apply **Batch Normalization** to achieve zero mean and zero variance on image pixels after each convolution.\n",
+    "\n",
+    "4) Then we add **Max Pooling Layers**, which are used for Dimensionality Reduction or DownSampling the Input. These are used where we have lot of Input Features. It reduces the amount of Parameters and Computational power required drastically, thus reducing Overfitting. These along with Convolutional layers are able to learn more Complex features of the Image.\n",
+    "\n",
+    "5) We add **Dropout Layers** to avoid Overfitting. DropOut is a Regularization Technique, which Penalizes the Parameters. We DropOutRate to 0.25. Usually in general we can set this rate between 0.2-0.5.\n",
+    "\n",
+    "6) Then we include **Flatten layer** to map the input to a 1D vector. We then add Fully connected Layers after some convolutional/pooling layers.\n",
+    "\n",
+    "7) Lastly, we add the **Dense (Output) Layer**. It has units equal to the number of classes to be identified.Here, we use 'softmax' function since it is Multi-Class Classification. For binary classification we can use 'sigmoid' function.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "authentic-electronics",
+   "metadata": {
+    "papermill": {
+     "duration": 0.054872,
+     "end_time": "2021-04-26T04:07:37.305599",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:37.250727",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Different Activation Function : \n",
+    "\n",
+    "1. **relu :**\n",
+    "\n",
+    "- ReLU (Rectified Linear Activation function) is a piecewise linear function that will output the input directly if it is positive, otherwise, it will output zero.\n",
+    "- It has become the default activation function for many types of neural networks because a model that uses it is easier to train and often achieves better performance.\n",
+    "- **Function :** g(z) = max{0, z}\n",
+    "\n",
+    "2. **sigmoid :**\n",
+    "\n",
+    "- The sigmoid activation function, also called the logistic function.\n",
+    "- The input to the function is transformed into a value between 0.0 and 1.0. Inputs that are much larger than 1.0 are transformed to the value 1.0, similarly, values much smaller than 0.0 are snapped to 0.0.\n",
+    "- The shape of the function for all possible inputs is an S-shape from zero up through 0.5 to 1.0.\n",
+    "- **Function :** s(x) = 1/(1+e^(-x))\n",
+    "\n",
+    "\n",
+    "\n",
+    "3. **tanh :**\n",
+    "\n",
+    "- The hyperbolic tangent function, or tanh is a similar shaped nonlinear activation function that outputs values between -1.0 and 1.0.\n",
+    "- - **Function :** tanh(x) = (e^x - e^(-x))/(e^x + e^(-x))\n",
+    "\n",
+    "\n",
+    "4. **softmax :**\n",
+    "\n",
+    "- This function is used as the activation function in the output layer of neural network models that predict a multinomial probability distribution.\n",
+    "- Softmax is used as the activation function for multi-class classification problems where class membership is required on more than two class labels. In this dataset we use this activation function in the output layer for each neural network.\n",
+    "- **Function :**\n",
+    "![](http://www.gstatic.com/education/formulas2/355397047/en/softmax_function.svg)\n",
+    "\n",
+    "\n",
+    "#### Limitations of sigmoid and tanh :\n",
+    "\n",
+    "- A general problem with both the sigmoid and tanh functions is that these functions are saturate.\n",
+    "- This means that large values snap to 1.0 and small values snap to -1 or 0 for tanh and sigmoid respectively.\n",
+    "- Moreover these two functions are only really sensitive to changes around their mid-point of their input, such as 0.5 for sigmoid and 0.0 for tanh.\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Note :**\n",
+    "- Each activaton function 'sigmoid' and 'tanh' performance are included in CM6."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "congressional-charter",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:37.426395Z",
+     "iopub.status.busy": "2021-04-26T04:07:37.425857Z",
+     "iopub.status.idle": "2021-04-26T04:07:40.501331Z",
+     "shell.execute_reply": "2021-04-26T04:07:40.500277Z"
+    },
+    "papermill": {
+     "duration": 3.140554,
+     "end_time": "2021-04-26T04:07:40.501472",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:37.360918",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model = Sequential()\n",
+    "model.add(Conv2D(filters=32, kernel_size=(3, 3), activation='relu', strides=1, padding='same', \n",
+    "                 data_format='channels_last', input_shape=(28,28,1)))\n",
+    "model.add(BatchNormalization())\n",
+    "\n",
+    "model.add(Conv2D(filters=32, kernel_size=(3, 3), activation='relu', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model.add(BatchNormalization())\n",
+    "model.add(Dropout(0.25))\n",
+    "\n",
+    "model.add(Conv2D(filters=64, kernel_size=(3, 3), activation='relu', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model.add(MaxPooling2D(pool_size=(2, 2)))\n",
+    "model.add(Dropout(0.25))\n",
+    "    \n",
+    "    \n",
+    "model.add(Conv2D(filters=128, kernel_size=(3, 3), activation='relu', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model.add(BatchNormalization())\n",
+    "model.add(Dropout(0.25))\n",
+    "\n",
+    "model.add(Flatten())\n",
+    "model.add(Dense(512, activation='relu'))\n",
+    "model.add(BatchNormalization())\n",
+    "model.add(Dropout(0.5))\n",
+    "model.add(Dense(128, activation='relu'))\n",
+    "model.add(BatchNormalization())\n",
+    "model.add(Dropout(0.5))\n",
+    "model.add(Dense(5, activation='softmax'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "equipped-skiing",
+   "metadata": {
+    "papermill": {
+     "duration": 0.055658,
+     "end_time": "2021-04-26T04:07:40.617450",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:40.561792",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### 4.6.3 Optimizer of the model :\n",
+    "\n",
+    "- Before model compilation we need to set optimizer used by the model. We have multiple options for optimizer e.g ADAM, SGD, ADAGRAD, ADADELTA, RMSPROP.\n",
+    "- **Parameters :** \n",
+    "    - **learning rate :** the learning rate is a configurable hyperparameter used in the training of neural networks. The learning rate controls how quickly the model is adapted to the problem.\n",
+    "    - **beta1 :** The exponential decay rate for the first moment estimates (e.g. 0.9).\n",
+    "    - **beta2 :** The exponential decay rate for the second-moment estimates (e.g. 0.999).\n",
+    "\n",
+    "\n",
+    "![](http://www.linkpicture.com/q/1_osB82GKHBOT8k1idLqiqA-99.png)\n",
+    "\n",
+    "\n",
+    "**Learning rate adjustment :**\n",
+    "- The learning rate controls how quickly the model is adapted to the problem.\n",
+    "- Smaller learning rates require more training epochs given the smaller changes made to the weights each update.\n",
+    "- Larger learning rates result in rapid changes and require fewer training epochs.\n",
+    "\n",
+    "**Problem with too large or small learning rate value :**\n",
+    "* A learning rate that is too large can cause the model to converge too quickly to a suboptimal solution.\n",
+    "* A learning rate that is too small can cause the process to get stuck.\n",
+    "\n",
+    "**Note :**\n",
+    "- The learning rate is perhaps the ***most important hyperparameter***."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aboriginal-puzzle",
+   "metadata": {
+    "papermill": {
+     "duration": 0.055705,
+     "end_time": "2021-04-26T04:07:40.729530",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:40.673825",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "statewide-vaccine",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:40.849362Z",
+     "iopub.status.busy": "2021-04-26T04:07:40.847581Z",
+     "iopub.status.idle": "2021-04-26T04:07:40.850231Z",
+     "shell.execute_reply": "2021-04-26T04:07:40.850837Z"
+    },
+    "papermill": {
+     "duration": 0.064985,
+     "end_time": "2021-04-26T04:07:40.850986",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:40.786001",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "optimizer = tf.keras.optimizers.Adam(learning_rate=0.01, beta_1=0.9, beta_2=0.999)\n",
+    "\n",
+    "# SGD \n",
+    "optimizer_sgd = tf.keras.optimizers.SGD(learning_rate=0.01)\n",
+    "\n",
+    "# RMSProp\n",
+    "\n",
+    "optimizer_rmsprop = tf.keras.optimizers.RMSprop(learning_rate=0.01)\n",
+    "\n",
+    "# Adagrad\n",
+    "optimizer_adagrad = tf.keras.optimizers.Adagrad(learning_rate=0.01)\n",
+    "\n",
+    "# Adadelta\n",
+    "optimizer_adadelta = tf.keras.optimizers.Adadelta(learning_rate=0.01)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "demanding-circulation",
+   "metadata": {
+    "papermill": {
+     "duration": 0.056777,
+     "end_time": "2021-04-26T04:07:40.963933",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:40.907156",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### 4.6.4 Model compilation :\n",
+    "\n",
+    "- During model compile we need to specify the **loss** function for the neural network which we want to minimize. For Multi-class Classification we use \"categorical_crossentropy\" and for Binary Classification we use \"binary_crossentropy\".\n",
+    "- We need to specify the **metric** to evaluate our models performance. Here we used accuracy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "maritime-exposure",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:41.089544Z",
+     "iopub.status.busy": "2021-04-26T04:07:41.088682Z",
+     "iopub.status.idle": "2021-04-26T04:07:41.095312Z",
+     "shell.execute_reply": "2021-04-26T04:07:41.094784Z"
+    },
+    "papermill": {
+     "duration": 0.075193,
+     "end_time": "2021-04-26T04:07:41.095426",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:41.020233",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model.compile(optimizer=optimizer, loss=\"categorical_crossentropy\", metrics=[\"accuracy\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sharp-tracy",
+   "metadata": {
+    "papermill": {
+     "duration": 0.057917,
+     "end_time": "2021-04-26T04:07:41.210722",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:41.152805",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### 4.6.5 Model Summary :\n",
+    "\n",
+    "Summary shows below things of our model :\n",
+    "\n",
+    "- The layers and their order in the model.\n",
+    "- The output shape of each layer.\n",
+    "- The number of parameters (weights) in each layer.\n",
+    "- The total number of parameters (weights) in the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "exterior-stock",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:41.335216Z",
+     "iopub.status.busy": "2021-04-26T04:07:41.332546Z",
+     "iopub.status.idle": "2021-04-26T04:07:41.343933Z",
+     "shell.execute_reply": "2021-04-26T04:07:41.344348Z"
+    },
+    "papermill": {
+     "duration": 0.077931,
+     "end_time": "2021-04-26T04:07:41.344489",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:41.266558",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: \"sequential\"\n",
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "conv2d (Conv2D)              (None, 28, 28, 32)        320       \n",
+      "_________________________________________________________________\n",
+      "batch_normalization (BatchNo (None, 28, 28, 32)        128       \n",
+      "_________________________________________________________________\n",
+      "conv2d_1 (Conv2D)            (None, 28, 28, 32)        9248      \n",
+      "_________________________________________________________________\n",
+      "batch_normalization_1 (Batch (None, 28, 28, 32)        128       \n",
+      "_________________________________________________________________\n",
+      "dropout (Dropout)            (None, 28, 28, 32)        0         \n",
+      "_________________________________________________________________\n",
+      "conv2d_2 (Conv2D)            (None, 28, 28, 64)        18496     \n",
+      "_________________________________________________________________\n",
+      "max_pooling2d (MaxPooling2D) (None, 14, 14, 64)        0         \n",
+      "_________________________________________________________________\n",
+      "dropout_1 (Dropout)          (None, 14, 14, 64)        0         \n",
+      "_________________________________________________________________\n",
+      "conv2d_3 (Conv2D)            (None, 14, 14, 128)       73856     \n",
+      "_________________________________________________________________\n",
+      "batch_normalization_2 (Batch (None, 14, 14, 128)       512       \n",
+      "_________________________________________________________________\n",
+      "dropout_2 (Dropout)          (None, 14, 14, 128)       0         \n",
+      "_________________________________________________________________\n",
+      "flatten (Flatten)            (None, 25088)             0         \n",
+      "_________________________________________________________________\n",
+      "dense (Dense)                (None, 512)               12845568  \n",
+      "_________________________________________________________________\n",
+      "batch_normalization_3 (Batch (None, 512)               2048      \n",
+      "_________________________________________________________________\n",
+      "dropout_3 (Dropout)          (None, 512)               0         \n",
+      "_________________________________________________________________\n",
+      "dense_1 (Dense)              (None, 128)               65664     \n",
+      "_________________________________________________________________\n",
+      "batch_normalization_4 (Batch (None, 128)               512       \n",
+      "_________________________________________________________________\n",
+      "dropout_4 (Dropout)          (None, 128)               0         \n",
+      "_________________________________________________________________\n",
+      "dense_2 (Dense)              (None, 5)                 645       \n",
+      "=================================================================\n",
+      "Total params: 13,017,125\n",
+      "Trainable params: 13,015,461\n",
+      "Non-trainable params: 1,664\n",
+      "_________________________________________________________________\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "powerful-columbus",
+   "metadata": {
+    "papermill": {
+     "duration": 0.056379,
+     "end_time": "2021-04-26T04:07:41.459014",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:41.402635",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### 4.6.6 Learning Rate Decay :\n",
+    "\n",
+    "- We should tuned our learning so that it is not too high to take very large steps, neither it should be too small which not change weights and bias of the model.\n",
+    "- We use **LearningRateScheduler** here, which takes the step decay function as argument and return the updated learning rates for use in optimzer at every epoch stage. \n",
+    "- So at every epoch learning rate will be change by LearningRateScheduler."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "executed-agency",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:41.698784Z",
+     "iopub.status.busy": "2021-04-26T04:07:41.697980Z",
+     "iopub.status.idle": "2021-04-26T04:07:41.700810Z",
+     "shell.execute_reply": "2021-04-26T04:07:41.700312Z"
+    },
+    "papermill": {
+     "duration": 0.063755,
+     "end_time": "2021-04-26T04:07:41.700914",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:41.637159",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "reduce_lr = LearningRateScheduler(lambda x: 1e-3 * 0.9 ** x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "white-parts",
+   "metadata": {
+    "papermill": {
+     "duration": 0.055948,
+     "end_time": "2021-04-26T04:07:41.813280",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:41.757332",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### 4.6.7 Data Augmentation : \n",
+    "\n",
+    "- Data Augmentation is like adding a data and/or noise to a dataset, so that model can perform well in various patterns.\n",
+    "- For example, what if our images will have object at some angle ? In that case mostly our model will fail to predict right label.\n",
+    "- So using data augmentation our model will build with different variations so that model performance on variety of input will remain same.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "employed-travel",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:41.932115Z",
+     "iopub.status.busy": "2021-04-26T04:07:41.931303Z",
+     "iopub.status.idle": "2021-04-26T04:07:41.934175Z",
+     "shell.execute_reply": "2021-04-26T04:07:41.933723Z"
+    },
+    "papermill": {
+     "duration": 0.063599,
+     "end_time": "2021-04-26T04:07:41.934292",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:41.870693",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "datagen = ImageDataGenerator(\n",
+    "        rotation_range = 8,  # randomly rotate images in the range (degrees, 0 to 180)\n",
+    "        zoom_range = 0.1, # Randomly zoom image \n",
+    "        shear_range = 0.3,# shear angle in counter-clockwise direction in degrees  \n",
+    "        width_shift_range=0.08,  # randomly shift images horizontally (fraction of total width)\n",
+    "        height_shift_range=0.08,  # randomly shift images vertically (fraction of total height)\n",
+    "        vertical_flip=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "independent-jimmy",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:42.052742Z",
+     "iopub.status.busy": "2021-04-26T04:07:42.051590Z",
+     "iopub.status.idle": "2021-04-26T04:07:42.168213Z",
+     "shell.execute_reply": "2021-04-26T04:07:42.167710Z"
+    },
+    "papermill": {
+     "duration": 0.177111,
+     "end_time": "2021-04-26T04:07:42.168337",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:41.991226",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "datagen.fit(x_train)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "retained-landing",
+   "metadata": {
+    "papermill": {
+     "duration": 0.05645,
+     "end_time": "2021-04-26T04:07:42.281807",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:42.225357",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### 4.6.8 Model fitting :\n",
+    "\n",
+    "- **batch size :** The batch size is a hyperparameter that defines the number of samples to work through before updating the internal model parameters.\n",
+    "- **epochs :** The number of epochs is a hyperparameter that defines the number times that the learning algorithm will work through the entire training dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "sitting-shape",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:42.399741Z",
+     "iopub.status.busy": "2021-04-26T04:07:42.398975Z",
+     "iopub.status.idle": "2021-04-26T04:07:42.401573Z",
+     "shell.execute_reply": "2021-04-26T04:07:42.402102Z"
+    },
+    "papermill": {
+     "duration": 0.06368,
+     "end_time": "2021-04-26T04:07:42.402238",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:42.338558",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "batch_size = 128\n",
+    "epochs = 25"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "simplified-venezuela",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:07:42.522085Z",
+     "iopub.status.busy": "2021-04-26T04:07:42.520993Z",
+     "iopub.status.idle": "2021-04-26T04:14:17.310524Z",
+     "shell.execute_reply": "2021-04-26T04:14:17.309785Z"
+    },
+    "papermill": {
+     "duration": 394.851669,
+     "end_time": "2021-04-26T04:14:17.310653",
+     "exception": false,
+     "start_time": "2021-04-26T04:07:42.458984",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/25\n",
+      "375/375 - 20s - loss: 0.8274 - accuracy: 0.6723 - val_loss: 2.9754 - val_accuracy: 0.2008\n",
+      "Epoch 2/25\n",
+      "375/375 - 15s - loss: 0.5895 - accuracy: 0.7612 - val_loss: 0.4538 - val_accuracy: 0.8080\n",
+      "Epoch 3/25\n",
+      "375/375 - 16s - loss: 0.5323 - accuracy: 0.7857 - val_loss: 0.4347 - val_accuracy: 0.8212\n",
+      "Epoch 4/25\n",
+      "375/375 - 15s - loss: 0.4911 - accuracy: 0.8027 - val_loss: 0.3714 - val_accuracy: 0.8467\n",
+      "Epoch 5/25\n",
+      "375/375 - 15s - loss: 0.4761 - accuracy: 0.8068 - val_loss: 0.3637 - val_accuracy: 0.8527\n",
+      "Epoch 6/25\n",
+      "375/375 - 15s - loss: 0.4538 - accuracy: 0.8177 - val_loss: 0.3515 - val_accuracy: 0.8530\n",
+      "Epoch 7/25\n",
+      "375/375 - 15s - loss: 0.4423 - accuracy: 0.8222 - val_loss: 0.3486 - val_accuracy: 0.8547\n",
+      "Epoch 8/25\n",
+      "375/375 - 16s - loss: 0.4239 - accuracy: 0.8292 - val_loss: 0.4026 - val_accuracy: 0.8233\n",
+      "Epoch 9/25\n",
+      "375/375 - 16s - loss: 0.4168 - accuracy: 0.8331 - val_loss: 0.4718 - val_accuracy: 0.8017\n",
+      "Epoch 10/25\n",
+      "375/375 - 17s - loss: 0.4086 - accuracy: 0.8378 - val_loss: 0.3330 - val_accuracy: 0.8668\n",
+      "Epoch 11/25\n",
+      "375/375 - 16s - loss: 0.4004 - accuracy: 0.8393 - val_loss: 0.3413 - val_accuracy: 0.8570\n",
+      "Epoch 12/25\n",
+      "375/375 - 17s - loss: 0.3906 - accuracy: 0.8433 - val_loss: 0.3206 - val_accuracy: 0.8628\n",
+      "Epoch 13/25\n",
+      "375/375 - 16s - loss: 0.3865 - accuracy: 0.8465 - val_loss: 0.3003 - val_accuracy: 0.8800\n",
+      "Epoch 14/25\n",
+      "375/375 - 17s - loss: 0.3812 - accuracy: 0.8481 - val_loss: 0.3494 - val_accuracy: 0.8538\n",
+      "Epoch 15/25\n",
+      "375/375 - 15s - loss: 0.3752 - accuracy: 0.8506 - val_loss: 0.3980 - val_accuracy: 0.8295\n",
+      "Epoch 16/25\n",
+      "375/375 - 15s - loss: 0.3700 - accuracy: 0.8531 - val_loss: 0.2949 - val_accuracy: 0.8785\n",
+      "Epoch 17/25\n",
+      "375/375 - 16s - loss: 0.3647 - accuracy: 0.8568 - val_loss: 0.3159 - val_accuracy: 0.8670\n",
+      "Epoch 18/25\n",
+      "375/375 - 15s - loss: 0.3613 - accuracy: 0.8566 - val_loss: 0.3928 - val_accuracy: 0.8300\n",
+      "Epoch 19/25\n",
+      "375/375 - 15s - loss: 0.3589 - accuracy: 0.8588 - val_loss: 0.3712 - val_accuracy: 0.8405\n",
+      "Epoch 20/25\n",
+      "375/375 - 15s - loss: 0.3559 - accuracy: 0.8603 - val_loss: 0.3456 - val_accuracy: 0.8517\n",
+      "Epoch 21/25\n",
+      "375/375 - 15s - loss: 0.3473 - accuracy: 0.8617 - val_loss: 0.3141 - val_accuracy: 0.8660\n",
+      "Epoch 22/25\n",
+      "375/375 - 16s - loss: 0.3448 - accuracy: 0.8637 - val_loss: 0.3062 - val_accuracy: 0.8710\n",
+      "Epoch 23/25\n",
+      "375/375 - 15s - loss: 0.3455 - accuracy: 0.8639 - val_loss: 0.3027 - val_accuracy: 0.8717\n",
+      "Epoch 24/25\n",
+      "375/375 - 16s - loss: 0.3406 - accuracy: 0.8649 - val_loss: 0.3374 - val_accuracy: 0.8527\n",
+      "Epoch 25/25\n",
+      "375/375 - 15s - loss: 0.3377 - accuracy: 0.8674 - val_loss: 0.2979 - val_accuracy: 0.8735\n"
+     ]
+    }
+   ],
+   "source": [
+    "history = model.fit(datagen.flow(x_train, y_train, batch_size = batch_size), epochs = epochs, \n",
+    "                              validation_data = (x_val, y_val), verbose=2, \n",
+    "                              steps_per_epoch=x_train.shape[0] // batch_size,\n",
+    "                              callbacks = [reduce_lr])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "saved-airline",
+   "metadata": {
+    "papermill": {
+     "duration": 0.070296,
+     "end_time": "2021-04-26T04:14:17.451976",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:17.381680",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 4.7 Model Evaluation : \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "enormous-punishment",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:17.602265Z",
+     "iopub.status.busy": "2021-04-26T04:14:17.601346Z",
+     "iopub.status.idle": "2021-04-26T04:14:18.215585Z",
+     "shell.execute_reply": "2021-04-26T04:14:18.214712Z"
+    },
+    "papermill": {
+     "duration": 0.692773,
+     "end_time": "2021-04-26T04:14:18.215731",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:17.522958",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "188/188 [==============================] - 1s 3ms/step - loss: 0.2979 - accuracy: 0.8735\n",
+      "Loss: 0.2979\n",
+      "Accuracy: 0.8735\n",
+      "--- 0.6089019775390625 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "score = model.evaluate(x_val, y_val)\n",
+    "\n",
+    "print('Loss: {:.4f}'.format(score[0]))\n",
+    "print('Accuracy: {:.4f}'.format(score[1]))\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "thorough-subject",
+   "metadata": {
+    "papermill": {
+     "duration": 0.074086,
+     "end_time": "2021-04-26T04:14:18.363789",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:18.289703",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 4.8 Prediction on Test data :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "material-geography",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:18.530721Z",
+     "iopub.status.busy": "2021-04-26T04:14:18.529724Z",
+     "iopub.status.idle": "2021-04-26T04:14:19.125925Z",
+     "shell.execute_reply": "2021-04-26T04:14:19.125511Z"
+    },
+    "papermill": {
+     "duration": 0.682461,
+     "end_time": "2021-04-26T04:14:19.126076",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:18.443615",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "188/188 [==============================] - 1s 3ms/step - loss: 0.2735 - accuracy: 0.8840\n",
+      "Loss: 0.2735\n",
+      "Accuracy: 0.8840\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_score = model.evaluate(x_test, y_test)\n",
+    "print(\"Loss: {:.4f}\".format(test_score[0]))\n",
+    "print(\"Accuracy: {:.4f}\".format(test_score[1]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eleven-grace",
+   "metadata": {
+    "papermill": {
+     "duration": 0.076788,
+     "end_time": "2021-04-26T04:14:19.281015",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:19.204227",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 4.8 Prediction on Test data ( Way 2 ) :\n",
+    "\n",
+    "- We can also predict using method calls predict_classes and then check accuracy. However this method in deprecated so we will not use on test dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "private-means",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:19.441447Z",
+     "iopub.status.busy": "2021-04-26T04:14:19.439597Z",
+     "iopub.status.idle": "2021-04-26T04:14:19.442009Z",
+     "shell.execute_reply": "2021-04-26T04:14:19.442416Z"
+    },
+    "papermill": {
+     "duration": 0.083889,
+     "end_time": "2021-04-26T04:14:19.442553",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:19.358664",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#y_pred3=model.predict_classes(x_test)\n",
+    "#y_true=np.argmax(y_test,axis=1)\n",
+    "#model_acc = accuracy_score(y_true, y_pred3)\n",
+    "#print('Accuracy Score of Model = ', model_acc)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sporting-rebound",
+   "metadata": {
+    "papermill": {
+     "duration": 0.076784,
+     "end_time": "2021-04-26T04:14:19.596539",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:19.519755",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4.9 Training and validation curves on loss vs epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "noticed-knowing",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:19.773619Z",
+     "iopub.status.busy": "2021-04-26T04:14:19.772763Z",
+     "iopub.status.idle": "2021-04-26T04:14:19.907746Z",
+     "shell.execute_reply": "2021-04-26T04:14:19.907252Z"
+    },
+    "papermill": {
+     "duration": 0.234862,
+     "end_time": "2021-04-26T04:14:19.907866",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:19.673004",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAEWCAYAAABi5jCmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAArHklEQVR4nO3deZxcZZ3v8c+vlt7TSxZISIckQMIastAEFcHgMmpgwIUtzh2JOHLhKooz48bLEUfHcUbQQXRcEBAXJOMVjSgEWS4KiGAWEkICgQQC6ZCEpJP0kl6r63f/OKe7qzrdSae7q6uT832/qNeps9Sp53SF+tbzPOc8x9wdERGRLrF8F0BEREYXBYOIiGRRMIiISBYFg4iIZFEwiIhIFgWDiIhkUTCIHISZTTMzN7PEALZdbGZPjES5RHJFwSBHFDPbbGbtZja+1/Jnwi/3aXkq2iEFjEg+KRjkSPQKsKhrxsxmASX5K47I4UXBIEeinwEfzpi/Avhp5gZmVmFmPzWznWb2qpl90cxi4bq4md1kZrvM7GXg/D5ee7uZbTOzrWb2b2YWH0qBzewYM7vXzHab2UYz+1jGuvlmtsLMGsxsh5l9K1xeZGY/N7M6M9trZsvN7OihlEMEFAxyZHoKKDezk8Mv7MuBn/fa5jtABXAc8DaCIPlIuO5jwAXAXKAGuLjXa+8EUsAJ4TZ/A/zDEMu8BKgFjgnf79/N7O3hum8D33b3cuB44Jfh8ivCY5gCjAOuBlqGWA4RBYMcsbpqDe8Cnge2dq3ICIsvuHuju28Gvgn8fbjJpcDN7r7F3XcDX8947dHAQuA6d9/n7m8A/xXub1DMbApwNvA5d29199XAbfTUejqAE8xsvLs3uftTGcvHASe4e6e7r3T3hsGWQ6SLgkGOVD8DPgQsplczEjAeSAKvZix7FZgcPj8G2NJrXZep4Wu3hc03e4EfAkcNoazHALvdvbGf8nwUmAm8EDYXXRAu/xnwB2CJmb1uZt8ws+QQyiECKBjkCOXurxJ0Qi8Eft1r9S6CX9tTM5YdS0+tYhtB80zmui5bgDZgvLtXho9ydz91CMV9HRhrZmP6Ko+7v+TuiwjC5z+BX5lZqbt3uPu/uvspwFsImr8+jMgQKRjkSPZR4O3uvi9zobt3ErTTf83MxpjZVOAf6emH+CXwSTOrNrMq4PMZr90GPAh808zKzSxmZseb2dsOoVyFYcdxkZkVEQTAk8DXw2Wnh2X/OYCZ/S8zm+DuaWBvuI+0mZ1nZrPCprEGgrBLH0I5RPqkYJAjlrtvcvcV/ay+FtgHvAw8AfwCuCNc9yOCJpo1wCr2r3F8GCgA1gN7gF8Bkw6haE0EncRdj7cTnF47jaD28BvgBnd/ONz+PcA6M2si6Ii+3N1bgInhezcQ9KP8iaB5SWRITDfqERGRTKoxiIhIFgWDiIhkUTCIiEgWBYOIiGQ57EZ5HD9+vE+bNi3fxRAROaysXLlyl7tPGMi2h10wTJs2jRUr+jsDUURE+mJmrx58q4CakkREJIuCQUREsigYREQkS876GMIxYB4DCsP3+ZW739Brm0KCkS/PAOqAy8IhkEUkAjo6OqitraW1tTXfRTliFBUVUV1dTTI5+IF2c9n53EYwgFlTOBTwE2a2LGMseQgGCtvj7ieY2eUEI0delsMyicgoUltby5gxY5g2bRpmlu/iHPbcnbq6Ompra5k+ffqg95OzpiQPNIWzyfDRe2Cmi4CfhM9/BbzD9K9DJDJaW1sZN26cQmGYmBnjxo0bcg0sp30M4b1zVwNvAA+5+9O9NplMeEMUd08B9QR3pOq9n6vCe96u2LlzZy6LLCIjTKEwvIbj75nTYAhvNzgHqAbmm9lpg9zPre5e4+41EyYM6PqM/e1YB498FfbVDe71IiIRMSJnJbn7XuBRgnHlM20lvFOWmSUIbmyem2/uuk3w+E3QsPXg24pIJNTV1TFnzhzmzJnDxIkTmTx5cvd8e3v7AV+7YsUKPvnJT45QSUdWLs9KmgB0uPteMysmuCn7f/ba7F7gCuAvwMXA//Nc3SCiuDKYtuzJye5F5PAzbtw4Vq9eDcCXv/xlysrK+Od//ufu9alUikSi76/JmpoaampqRqKYIy6XNYZJwKNm9iywnKCP4fdm9hUzuzDc5nZgnJltJLi14uf72dfQFVcF09a9OXsLETn8LV68mKuvvpqzzjqLz372s/z1r3/lzW9+M3PnzuUtb3kLGzZsAOCPf/wjF1xwARCEypVXXsmCBQs47rjjuOWWW/J5CEOWsxqDuz8LzO1j+ZcynrcCl+SqDFmKKoOpagwio9K//m4d619vGNZ9nnJMOTf87amH/Lra2lqefPJJ4vE4DQ0NPP744yQSCR5++GGuv/567rnnnv1e88ILL/Doo4/S2NjIiSeeyDXXXDOkawny6bAbRG/QumoMLXvzWgwRGf0uueQS4vE4APX19VxxxRW89NJLmBkdHR19vub888+nsLCQwsJCjjrqKHbs2EF1dfVIFnvYRCcYCkohllBTksgoNZhf9rlSWlra/fxf/uVfOO+88/jNb37D5s2bWbBgQZ+vKSws7H4ej8dJpVK5LmbORGesJLOg1qCmJBE5BPX19UyePBmAO++8M7+FGSHRCQYI+hnUlCQih+Czn/0sX/jCF5g7d+5hXQs4FJars0Nzpaamxgd9o57b3gXJYrji3uEtlIgMyvPPP8/JJ5+c72Iccfr6u5rZSncf0Pm10aoxFFeqj0FE5CCiFQxFlepjEBE5iGgFQ3EVtNTnuxQiIqNaxIKhEtrqId2Z75KIiIxaEQuGrmExVGsQEelPtIJBw2KIiBxUtIJBw2KISIbzzjuPP/zhD1nLbr75Zq655po+t1+wYAFdp8svXLiQvXv37rfNl7/8ZW666aYDvu/SpUtZv3599/yXvvQlHn744UMsfe5ELBgqg2mragwiAosWLWLJkiVZy5YsWcKiRYsO+tr777+fysrKQb1v72D4yle+wjvf+c5B7SsXIhYMqjGISI+LL76Y++67r/umPJs3b+b111/n7rvvpqamhlNPPZUbbrihz9dOmzaNXbt2AfC1r32NmTNn8ta3vrV7WG6AH/3oR5x55pnMnj2bD37wgzQ3N/Pkk09y77338pnPfIY5c+awadMmFi9ezK9+9SsAHnnkEebOncusWbO48soraWtr636/G264gXnz5jFr1ixeeOGFnP1dojOIHqiPQWQ0W/Z52L52ePc5cRa89z/6XT127Fjmz5/PsmXLuOiii1iyZAmXXnop119/PWPHjqWzs5N3vOMdPPvss5x++ul97mPlypUsWbKE1atXk0qlmDdvHmeccQYAH/jAB/jYxz4GwBe/+EVuv/12rr32Wi688EIuuOACLr744qx9tba2snjxYh555BFmzpzJhz/8Yb7//e9z3XXXATB+/HhWrVrF9773PW666SZuu+22Yfgj7S9iNYbKYKoag4iEMpuTupqRfvnLXzJv3jzmzp3LunXrspp9env88cd5//vfT0lJCeXl5Vx44YXd65577jnOOeccZs2axV133cW6desOWJYNGzYwffp0Zs6cCcAVV1zBY4891r3+Ax/4AABnnHEGmzdvHuwhH1S0agyJQkiWaFgMkdHoAL/sc+miiy7i05/+NKtWraK5uZmxY8dy0003sXz5cqqqqli8eDGtra2D2vfixYtZunQps2fP5s477+SPf/zjkMraNbR3rof1jlaNATT0tohkKSsr47zzzuPKK69k0aJFNDQ0UFpaSkVFBTt27GDZsmUHfP25557L0qVLaWlpobGxkd/97nfd6xobG5k0aRIdHR3cdddd3cvHjBlDY2Pjfvs68cQT2bx5Mxs3bgTgZz/7GW9729uG6UgHLnrBoKG3RaSXRYsWsWbNGhYtWsTs2bOZO3cuJ510Eh/60Ic4++yzD/jaefPmcdlllzF79mze+973cuaZZ3av++pXv8pZZ53F2WefzUknndS9/PLLL+fGG29k7ty5bNq0qXt5UVERP/7xj7nkkkuYNWsWsViMq6++evgP+CCiNew2wI8XgjtceeBfASKSexp2Ozc07PahKq5SH4OIyAFELxg09LaIyAFFLxiKK9XHIDKKHG7N2aPdcPw9oxkMqRboGNzpZyIyfIqKiqirq1M4DBN3p66ujqKioiHtJ1rXMUDG0Nt7ITkxr0URibrq6mpqa2vZuXNnvotyxCgqKqK6unpI+4heMHQPi7EXxigYRPIpmUwyffr0fBdDeolgU1LXQHrqgBYR6UsEg6EymOqUVRGRPuUsGMxsipk9ambrzWydmX2qj20WmFm9ma0OH1/KVXm6qcYgInJAuexjSAH/5O6rzGwMsNLMHnL33sMUPu7uF+SwHNky+xhERGQ/OasxuPs2d18VPm8Engcm5+r9BqyoAjDVGERE+jEifQxmNg2YCzzdx+o3m9kaM1tmZqf28/qrzGyFma0Y8mltsTgUlauPQUSkHzkPBjMrA+4BrnP3hl6rVwFT3X028B1gaV/7cPdb3b3G3WsmTJgw9EJpWAwRkX7lNBjMLEkQCne5+697r3f3BndvCp/fDyTNbHwuywSE92TYm/O3ERE5HOXyrCQDbgeed/dv9bPNxHA7zGx+WJ66XJWpW3GlmpJERPqRy7OSzgb+HlhrZqvDZdcDxwK4+w+Ai4FrzCwFtACX+0gMmlJcBfW1OX8bEZHDUc6Cwd2fAOwg23wX+G6uytAv3cVNRKRf0bvyGXru+6wRHUVE9hPRYKgE74T2pnyXRERk1IloMGhYDBGR/kQzGDQshohIv6IZDKoxiIj0K6LBUBlMdS2DiMh+IhoMqjGIiPQnmsGgPgYRkX5FMxgKSiGWUFOSiEgfohkMZj0XuYmISJZoBgNoWAwRkX5ENxhUYxAR6VOEg6FSfQwiIn2IcDCoxiAi0pfoBkNRJbTU57sUIiKjTnSDobgK2uoh3ZnvkoiIjCoRDobKYNqqWoOISKYIB4OGxRAR6Ut0g0HDYoiI9Cm6wdBVY2hVjUFEJFOEg6EymKrGICKSJbrB0N2UpBqDiEim6AaDagwiIn2KbjAkCiFZomExRER6iW4wgIbFEBHpQ7SDQUNvi4jsJ9rBoBqDiMh+Ih4MlepjEBHpJWfBYGZTzOxRM1tvZuvM7FN9bGNmdouZbTSzZ81sXq7K06fiStUYRER6SeRw3yngn9x9lZmNAVaa2UPuvj5jm/cCM8LHWcD3w+nIUB+DiMh+clZjcPdt7r4qfN4IPA9M7rXZRcBPPfAUUGlmk3JVpv0UV0GqBTpaR+wtRURGuxHpYzCzacBc4OleqyYDWzLma9k/PDCzq8xshZmt2Llz5/AVrHvo7b3Dt08RkcNczoPBzMqAe4Dr3L1hMPtw91vdvcbdayZMmDB8heseenvv8O1TROQwl9NgMLMkQSjc5e6/7mOTrcCUjPnqcNnI0HhJIiL7yeVZSQbcDjzv7t/qZ7N7gQ+HZye9Cah39225KtN+1JQkIrKfXJ6VdDbw98BaM1sdLrseOBbA3X8A3A8sBDYCzcBHclie/ekubiIi+8lZMLj7E4AdZBsHPp6rMhyU7uImIrKfaF/5XFQBmGoMIiIZoh0MsTgUlauPQUQkQ7SDATSQnohILwoGDYshIpJFwVBcpaYkEZEMCgaNsCoikkXBUFylpiQRkQwKhqLKoMbgnu+SiIiMCgqG4irwTmhvyndJRERGBQVD13hJ6mcQEQEUDBoWQ0SkFwWDBtITEcmiYNDQ2yIiWQYUDGZWamax8PlMM7swvAnP4U81BhGRLAOtMTwGFJnZZOBBgvss3JmrQo0o9TGIiGQZaDCYuzcDHwC+5+6XAKfmrlgjqKAUYknVGEREQgMOBjN7M/B3wH3hsnhuijTCzIJ+BvUxiIgAAw+G64AvAL9x93VmdhzwaM5KNdI0LIaISLcB3drT3f8E/Akg7ITe5e6fzGXBRlTXsBgiIjLgs5J+YWblZlYKPAesN7PP5LZoI0hDb4uIdBtoU9Ip7t4AvA9YBkwnODPpyKCht0VEug00GJLhdQvvA+519w7gyBmOtKgSWurzXQoRkVFhoMHwQ2AzUAo8ZmZTgYZcFWrEFVdBWz2kO/NdEhGRvBtQMLj7Le4+2d0XeuBV4Lwcl23kdA+LoVqDiMhAO58rzOxbZrYifHyToPZwZNCwGCIi3QbalHQH0AhcGj4agB/nqlAjTsNiiIh0G9B1DMDx7v7BjPl/NbPVOShPfqjGICLSbaA1hhYze2vXjJmdDbTkpkh5oKG3RUS6DbTGcDXwUzOrCOf3AFcc6AVmdgdwAfCGu5/Wx/oFwG+BV8JFv3b3rwywPMNLNQYRkW4DHRJjDTDbzMrD+QYzuw549gAvuxP4LvDTA2zzuLtfMLCi5pD6GEREuh3SHdzcvSG8AhrgHw+y7WPA7sEWbEQlCiBZqqYkERGGdmtPG4b3f7OZrTGzZWbW7/0dzOyqrlNld+7cOQxv2wcNiyEiAgwtGIY6JMYqYKq7zwa+Ayzt943cb3X3GnevmTBhwhDfth8aeltEBDhIH4OZNdJ3ABhQPJQ3zmiSwt3vN7Pvmdl4d981lP0OmobeFhEBDhIM7j4mV29sZhOBHe7uZjafoPZSl6v3O6jiStj9ct7eXkRktBjo6aqHzMzuBhYA482sFrgBSAK4+w+Ai4FrzCxFcE3E5e6evxFb1ccgIgLkMBjcfdFB1n+X4HTW0aGoUn0MIiIMrfP5yFJcBakW6GjNd0lERPJKwdBFw2KIiAAKhh7dw2LszWsxRETyTcHQpXtYDHVAi0i0KRi6dNUY1JQkIhGnYOjS1cegGoOIRJyCoYv6GEREAAVDj8IKwFRjEJHIUzB0icWgqEJ9DCISeQqGTBoWQ0REwZBFw2KIiCgYshRXqcYgIpGnYMhUXKk+BhGJPAVDJt3FTUREwZCl6y5uebwthIhIvikYMhVXgXdCe1O+SyIikjcKhkwaFkNERMGQRcNiiIgoGLJo6G0REQVDFg29LSKiYMiiPgYREQVDFvUxiIgoGLIkSyCWVI1BRCJNwZDJTMNiiEjkKRh607AYIhJxCobeuobFEBGJKAVDb8VVakoSkUhTMPSmu7iJSMTlLBjM7A4ze8PMnutnvZnZLWa20cyeNbN5uSrLISmugpb6fJdCRCRvclljuBN4zwHWvxeYET6uAr6fw7IMXFEltNVDujPfJRERyYucBYO7PwbsPsAmFwE/9cBTQKWZTcpVeQase1gM1RpEJJry2ccwGdiSMV8bLtuPmV1lZivMbMXOnTtzWyoNiyEiEXdYdD67+63uXuPuNRMmTMjtm2lYDBGJuHwGw1ZgSsZ8dbgsvzT0tohEXD6D4V7gw+HZSW8C6t19Wx7LE9DQ2yIScYlc7djM7gYWAOPNrBa4AUgCuPsPgPuBhcBGoBn4SK7KckjUxyAiEZezYHD3RQdZ78DHc/X+g9bdlLQ3n6UQEcmbw6LzeUQlCiBZqqYkEYksBUNfNCyGiESYgqEvGnpbRCJMwdAXDb0tIhGmYOiL7uImIhEWqWDYsL1xYBuqj0FEIiwywfB/V2zhPd9+jL9sqjv4xupjEJEIi0wwLJw1ienjSvn0/6xmz772A29cVAmpFuhoHZGyiYiMJpEJhtLCBLcsmkvdvjY+d8+zBNfX9UPDYohIhEUmGABOm1zBZ999Eg+u38FdT7/W/4bdw2LsHYliiYiMKpEKBoCPvnU658wYz1d/v54Xd/TTGd099LY6oEUkeiIXDLGY8c1LZzOmKMEn736G1o4+buHZNV6SmpJEJIIiFwwAR40p4sZLZvPC9ka+fv/z+2+gEVZFJMIiGQwA5514FFeePZ2f/OVVHl6/I3ul7uImIhEW2WAA+Nx7T+SUSeV85ldr2NGQcWpqYQVgqjGISCRFOhgKE3FuWTSX1o40//jL1aTT4SmssRgUVaiPQUQiKdLBAHDCUWXc8Len8OeNdfzwsZd7VmhYDBGJqMgHA8BlZ05h4ayJfPPBDazesjdYqGExRCSiFAyAmfH195/O0eVFfGrJMzS1pTT0tohEloIhVFGS5ObL57BldzNfWvpcUGNQH4OIRJCCIcOZ08Zy7dtn8OtntvLKvqSakkQkkhQMvVz79hOomVrFQ6+04y174ECD7YmIHIEUDL0k4jFuvnwODVaKeScdLQ35LpKIyIhSMPShuqqEd807GYAblz7Fa3XNeS6RiMjISeS7AKPV7BlTYRU8sXYjtz6b4rTJ5SycNYnzZ01i6rjSfBdPRCRnFAz9CUdYvfPyGSytP5771m7nGw9s4BsPbODUY3pCYtp4hYSIHFkUDP0JB9I7KtnCVecez1XnHs+W3c0se24b963dzo1/2MCNf9jAKZPKOf/0ScGtQxUSInIEUDD0p4+ht6eMLekOido9zSxbu5371m7rDomTJ5Vz/qyJLDjxKE6eVE48Zvkpu4jIEOQ0GMzsPcC3gThwm7v/R6/1i4Ebga3hou+6+225LNOAHWTo7eqqEj527nF87Nzj2Lq3hWVrt3Hf2m3c9OCL3PTgi4wpTDBvahXzp49l/vSxnF5dQWEiPnLlFxEZpJwFg5nFgf8G3gXUAsvN7F53X99r0/9x90/kqhyDliyBWHJAw2JMrizmH845jn845zi217fy1Mt1/HXzbpa/spsb/7ABgIJEjDnVlcyfPpYzp4/ljKlVlBWqwiYio08uv5nmAxvd/WUAM1sCXAT0DobRyWxQw2JMrCjifXMn8765kwHYva+d5WFILN+8m+//aRPffXQjMYNTjiln/rRxnDG1ikmVRYwvLWT8mAJKChQYIpI/ufwGmgxsyZivBc7qY7sPmtm5wIvAp919S+8NzOwq4CqAY489NgdF7Udx5ZCHxRhbWsC7T53Iu0+dCMC+thSrXtvD8ld289fNu7nr6Ve548+vZL9tMs64sgLGlxUyvqyAcWFgBNNCxpcWcFR5IdVVJRQl1TwlIsMr3z9Nfwfc7e5tZva/gZ8Ab++9kbvfCtwKUFNTM3JjVBRXDfsIq6WFCc6ZMYFzZkwAoC3VyUs7mtjZ2MbOpjbqmtqpa2pjV1Mbdfva2bq3lTW19eze105nev9DP2pMIVPGljClqphjx5ZQPbaEKVUlHDuuhInlRaO3A7x9Hzx3Dzz7S5g0G95xAyQK8l0qESG3wbAVmJIxX01PJzMA7l6XMXsb8I0clufQFVXCjudgxR1QXg3lxwSP4qqgqWkYFCbinDa54qDbpdNOfUsHu5ra2NXUzvaGFrbsbmHL7ma27Glm+eY93LvmdTKzIxk3jqksZkpVCVPGljChrIDy4iQVmY+SJJXFBVQUJylKxrBhOq5+bV8LK34cBEJ7I1ROhc2Pw9ZVcOlPoOyo3L6/iBxULoNhOTDDzKYTBMLlwIcyNzCzSe6+LZy9EHg+h+U5dMe+CTY+BL//dPbyZEkYEpODR8XkcD4MjwknQjw5rEWJxYyq0gKqSguYcXTf23R0pnl9bxgYe5p5bXdzGBwtPLhuO7ub2w84JmBBPBYGR4KK4iSVJQUcXV7I0eVFTKooCqfFTCwvorw4MfAQaW+Gdb+BlT+G2uUQL4RT3w81H4EpZwU1h99+Am5dAJffBcfMPeS/j4gMH/Mcjh5qZguBmwlOV73D3b9mZl8BVrj7vWb2dYJASAG7gWvc/YUD7bOmpsZXrFiRszLvpzMFTTug4XVoqA2m9VuhoevxOjRuA0/3vKZ0Asy6BGZfDhNPH7baxVCl005ja4r6lo4DPhrC6Z7mdnY0tFG3r22/QClKxphUUczR5YXhNAiPcWUFlBTEKU4mqNq3iaNf+gUVG+4h1t5AeuwJUHMlsTmLoGRs9g63rYElfwf7dsLf3gKzLxu5P4xIBJjZSnevGdC2uQyGXBjxYBiIzPDYsxmevxdefAA62+GoU2D2oiAoyiflu6SD0p5K80ZjKzsaWtlW38r2rkdDz3RHQysdnU4h7SyMPc2HEo9wZuxF2jzBA+n5/CL1Dp72kwCjMBELwyNOcUGc0sIEJQVxjo438fFd/8bMltX85ahF/OX4aykpKqK0IE5JQYLSwp5paWGC0oLgdaWFCQoTI9AMJnIYUzCMBs27g+aTNXcHzScWg+POC0LipPOhoCTfJRw+qTbSLz9G23O/pWDDvcTb6mkZM43a4y/j5ckX0WDltHR00tLeSXN7Z6/nKZrbO2lu62Rfe4q2tjY+1nI7l6Xv54n0aXyi/Vr2MuagRYjHjJKCOGVhyATTjBApTDCmMMGYogRlhQnGFCUpKwrmxxQmg+Xh/Ki9ELFlD7zyWNB8WT2g/79HjjukOyGe7/NZpD8KhtFm10Z4dgmsWQL1W6BgDJxyEcxZBMe+BWKH4ejnrQ1B/8sL98GLDwYdyQVlMPPdMO8KmH7u0JrQnvk5/vtP42MmsffCO2msOJF9bZ00t6doagvCZF84DeZT7GvrWbavPUVzW8+6prYUja0p2lLpg751QTzGmKIERck4BYkYybiRjMdIxmMUxGMkE9nzmdsUJGIUJuIUJmIUJjOeJ2IUJuMUxLuW96wrSsYpSnZN4xQlYiTiMUinYdszsPER2Phw8AOjq8ly1qXwN1+FMRMH/zceDq31sPIn8PQPgybV8slQNRUqj814hPPlx0BslIZuBCgYRqt0Gl79cxAQ65dCexNUHAunvi/4H6qgBApKIVkaTHs/kqX5PaWzcQdsuD8Ig1f+FDSVlYyHkxbCSRfA9LdBsmj43m/Lcvif/wVtDfC+7wd/pyFqT6XDkOigsTUIi675rvBoCNe1daTp6Ox5tKW6njsdnWna+5hvTwXbtXcePID6Mo56zomt5bz4Gs6JPctYaySN8WLsBJ4pOIPnis+gJvUMFzT+X1KW5IEJH+Gp8R8kWVBAYSIeBlNP6BRkhFJXQBVkhVJsv9cVJGIHP815z6vw9A9g1U+Df8fTzoHqM6G+Fva+BntfDYIiUyzRKzimwtjjYNwJMO54KDx4zVAGT8FwOGhvDr5g19wNLz+a3Xl9ILFkECCF5cEFeMVVvR5j+1gWPhKFh/4rvm4TvPD7oKxb/go4VE0LguCkC2DK/Nz+CmzcHoRD7XI455/gvC8eFjWsdNppD8OkLdVJW0fG81Q6nO+kvb2d4jeeYdy2xznqjScY17Aew9mXqGJT+Vm8UDaf54pqqGMMbR2dtIavG9u2hY82/pD5qZVssmP5uv0DT3eeNKRQypSIGYm4kYzFSMSNRDxGMmacbhu5PPVbzkn9Bcd4ovBclpW9n9cKTwy2ixnx8FFEinHpnUxIbWd8ajvjOrYzLrWdqvbtVLVvY0yqLus9mwrGU188lYbSqTSWTmNf2VSayqbTNmYKsUQB8ZhREI9RUpigLKOfqSxsKixIjP5/F/mkYDjcpNqCC77am4LAaN8HHfvCZeGjozl7fVtDcFV2y56Mx25Ipw78XrFEEC6xRPCFHu963sejYx/sfjl43aTZYRicH3Soj2RHb6oN7vsneOZnMOPd8MEfQVE/13649/p7NgXPIfi1OmZi/pszGrcHTUMvPRT8KGitD/qgqs+EE94FJ7wDJs05eAC6BzW4ZZ+H+te6m5fSpUfvF0rtnT1h1BbWato6Mp6nOrtrO13bpdJBTagzlWLm3sc4e+f/ML15Lc2xUh4vv4CHyt7HG7HxpMIaVSrtpNNOKu10ZjxS+z1P05l24uk2Jqe3M8VfZxrbmG7bmB7bxnG2jXHW2H2YKY+xxSfwik9ikx/DBp/C8+mpvOSTaafntPBk3HqFRRAeRck4cTPicSNu2eGV9cjYBsDDP7ETfkd61zIPl/esN4xkwiiM9zQZFmTU0AoyamNdzYkF8aBmFoRwrLtcXfNdz+OxoJkyZgzpBAsFQ1S5B1+EWWERPpp3B1+Y6VT46IR0R/Z8Z695s6CJ4KSFQdU/38e2/DZ44PNQUR2EU1tjRnhmhMCBwrGrOaPy2GA/FVOgckowrZgSLBvO5jAIzlqr/WsQBBsfCi7yAyibCCe8E2a8E45b0DOi76Fqb4Yn/gv+/G2IF8B5X4D5Vw39Wpq2Jlj9C3jqe7DnlaDp503/B+b+3bA3+7j3BEgq7XQ21eG7N8GuTcT2bCS+exOJvS+T3LOJWGcrAGlL0FA2nbrSE9hRPIPawuPZnJjO9nRFVv9Ta0c6DKw0aSeYpoNpX+HVNcKAGRhG+F/WMguXmRlGEBLtYXNiX8rZx6mxzcyylzk99gqn2SsUWAer0jNYlZ7JivRM1vtUUge5tOyaBcfzufecNKi/sYJBjlybn4AHvxh8+ReUZfTBjOl5Xli2/zpPBx3/9bXBdO+WYNr7GhSA0qPCsKjODoyu+ZKxB68xZdYKNj0KbfVg8eCCvhnvDGoGE2cNb82rblMQnC89CBNOhvNvgmlvHfjr2/f19BG8+ufgCvXWvVA9H97yiaDGmO/aVrozqMVuXws71gUjE2x/LrjGqEvpBDj6VDj6tOBvXDUt499C+O8iUZyTJkl3p715L521q/HXV2PbVpPcsYZkfc94aK2lk2kYexqdJKise4bi5tcBSMWLqas4jTcq57CjYg7bymfRHCvLCsyaqVWcO3PCoMqmYBAZqM6O8KLFrrCoDZplup/XQqol+zWJ4iAkssKjOujf2fL0/rWCriA4bkHPDaByxR02LIMHPhd8wc+6BN4Vnr3Usic7FPduyTjWLdCc0eZvMTj5b+HNnwj6kUa75t3ZQbFjLbzxAnS29f+a7pM8SrJ/SCRLgv64WDI4/TaWDGpiXc2u8WTPunhB8LyzLfjMX38G6jb2vEd5NRwzJ7ia/5g5MGkulI7LLkf91uDfzZan4bWngv14J2Aw4SQ49iyY8qZgWjV90D8mFAwiw8U9+NKpf60nKLJqHbWw742e7S0eDKVywjthxruCX635uPCuoyVoXnri5uBLPpYITinOlCzJbkqrnBKcJVc5BcYeD2WD+2U6anSmoO6lYISC/vrush5NYV/evrDZtSPYR2d7z/N0RzDfl/LJQd9QdwjMGdzfsK0Jtq4MTvbY8lRwdl5bfbDuTR+H9/z7oP4cCgaRkdTRGnz5NL0BR5/Sf8d4Pux+GZ78bvArNysEpg6sSUz213UxX7qjp1+u6/4tuZBOw87ngxrFhJNh6psHtRsFg4iIZDmUYNCJvyIikkXBICIiWRQMIiKSRcEgIiJZFAwiIpJFwSAiIlkUDCIikkXBICIiWQ67C9zMbCfw6iBfPh7YNYzFOdxE+fijfOwQ7ePXsQemuvuAxug47IJhKMxsxUCv/DsSRfn4o3zsEO3j17Ef+rGrKUlERLIoGEREJEvUguHWfBcgz6J8/FE+doj28evYD1Gk+hhEROTgolZjEBGRg1AwiIhIlsgEg5m9x8w2mNlGM/t8vsszksxss5mtNbPVZnbE3+XIzO4wszfM7LmMZWPN7CEzeymc5uh2W/nVz7F/2cy2hp//ajNbmM8y5oqZTTGzR81svZmtM7NPhcuj8tn3d/yH/PlHoo/BzOLAi8C7gFpgObDI3dfntWAjxMw2AzXuHomLfMzsXKAJ+Km7nxYu+waw293/I/xhUOXun8tnOXOhn2P/MtDk7jfls2y5ZmaTgEnuvsrMxgArgfcBi4nGZ9/f8V/KIX7+UakxzAc2uvvL7t4OLAEuynOZJEfc/TFgd6/FFwE/CZ//hOB/mCNOP8ceCe6+zd1Xhc8bgeeByUTns+/v+A9ZVIJhMrAlY76WQf7BDlMOPGhmK83sqnwXJk+Odvdt4fPtwNH5LEwefMLMng2bmo7IppRMZjYNmAs8TQQ/+17HD4f4+UclGKLure4+D3gv8PGwuSGyPGg/PfLbUHt8HzgemANsA76Z19LkmJmVAfcA17l7Q+a6KHz2fRz/IX/+UQmGrcCUjPnqcFkkuPvWcPoG8BuCprWo2RG2wXa1xb6R5/KMGHff4e6d7p4GfsQR/PmbWZLgS/Eud/91uDgyn31fxz+Yzz8qwbAcmGFm082sALgcuDfPZRoRZlYadkRhZqXA3wDPHfhVR6R7gSvC51cAv81jWUZU15di6P0coZ+/mRlwO/C8u38rY1UkPvv+jn8wn38kzkoCCE/RuhmIA3e4+9fyW6KRYWbHEdQSABLAL470Yzezu4EFBEMO7wBuAJYCvwSOJRi2/VJ3P+I6afs59gUEzQgObAb+d0ab+xHDzN4KPA6sBdLh4usJ2tmj8Nn3d/yLOMTPPzLBICIiAxOVpiQRERkgBYOIiGRRMIiISBYFg4iIZFEwiIhIFgWDSMjMOjNGoFw9nKPwmtm0zBFPRUazRL4LIDKKtLj7nHwXQiTfVGMQOYjwfhbfCO9p8VczOyFcPs3M/l84ONkjZnZsuPxoM/uNma0JH28JdxU3sx+FY+U/aGbF4fafDMfQf9bMluTpMEW6KRhEehT3akq6LGNdvbvPAr5LcAU9wHeAn7j76cBdwC3h8luAP7n7bGAesC5cPgP4b3c/FdgLfDBc/nlgbrifq3NzaCIDpyufRUJm1uTuZX0s3wy83d1fDgcp2+7u48xsF8GNUTrC5dvcfbyZ7QSq3b0tYx/TgIfcfUY4/zkg6e7/ZmYPENxcZymw1N2bcnyoIgekGoPIwHg/zw9FW8bzTnr6+M4H/pugdrHczNT3J3mlYBAZmMsypn8Jnz9JMFIvwN8RDGAG8AhwDQS3lTWziv52amYxYIq7Pwp8DqgA9qu1iIwk/TIR6VFsZqsz5h9w965TVqvM7FmCX/2LwmXXAj82s88AO4GPhMs/BdxqZh8lqBlcQ3CDlL7EgZ+H4WHALe6+d5iOR2RQ1McgchBhH0ONu+/Kd1lERoKakkREJItqDCIikkU1BhERyaJgEBGRLAoGERHJomAQEZEsCgYREcny/wHxYC0qTrS/RgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.14694428443908691 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "plt.plot(history.history['loss'])\n",
+    "plt.plot(history.history['val_loss'])\n",
+    "plt.title(\"Model Loss\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Loss')\n",
+    "plt.legend(['Train', 'Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rental-asian",
+   "metadata": {
+    "papermill": {
+     "duration": 0.078936,
+     "end_time": "2021-04-26T04:14:20.067106",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:19.988170",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4.10 Training and validation curves on accuracy vs epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "finished-glass",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:20.267367Z",
+     "iopub.status.busy": "2021-04-26T04:14:20.266305Z",
+     "iopub.status.idle": "2021-04-26T04:14:20.386773Z",
+     "shell.execute_reply": "2021-04-26T04:14:20.386121Z"
+    },
+    "papermill": {
+     "duration": 0.239986,
+     "end_time": "2021-04-26T04:14:20.386933",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:20.146947",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAAz20lEQVR4nO3deXxU5dn/8c+VHZIAsu+LiijWBURwaVVcKi6FuoNPq/66WG2tWmtb7WOtS32ettrlabW2uNda0aq12KJWqfsKIqKgKKuEzQABsieTXL8/7pMwhAQmkMkE5vt+veY1c5aZuU4GznXu5dy3uTsiIiIAGakOQEREOg4lBRERaaSkICIijZQURESkkZKCiIg0UlIQEZFGSgqSFsxsqJm5mWUlsO9FZvZqe8Ql0tEoKUiHY2bLzKzGzHo2Wf9udGIfmqLQ4mMpMLMyM3s61bGItCUlBemolgJTGhbM7CCgc+rC2cZZQDVwkpn1bc8vTqS0I7KzlBSko3oQuCBu+ULgz/E7mFlXM/uzmRWb2XIzu87MMqJtmWZ2m5mtM7MlwGnNvPceM1ttZivN7GdmltmK+C4E/gjMA77S5LM/b2avm9lGM1thZhdF6zuZ2a+iWDeZ2avRuuPMrKjJZywzsxOj1zeY2WNm9hcz2wxcZGZjzeyN6DtWm9ntZpYT9/4Dzew5M9tgZmvN7Mdm1tfMKsysR9x+o6O/X3Yrjl32YEoK0lG9CXQxswOik/Vk4C9N9vk90BXYGziWkET+X7Ttm8DpwChgDHB2k/feD8SAfaN9vgh8I5HAzGwIcBzwUPS4oMm2p6PYegGHAnOjzbcBhwFHAd2BHwL1iXwnMAl4DOgWfWcd8D2gJ3AkcALw7SiGQuB54Bmgf3SMM919DfAicG7c534VmObutQnGIXs4JQXpyBpKCycBHwIrGzbEJYpr3b3U3ZcBvyKc5CCc+H7r7ivcfQPwv3Hv7QOcClzp7uXu/hnwm+jzEvFVYJ67LwCmAQea2aho2/nA8+7+sLvXuvt6d58blWC+Blzh7ivdvc7dX3f36gS/8w13f9Ld69290t3fcfc33T0WHfufCIkRQjJc4+6/cveq6O/zVrTtAaKSTfQ3nEL4O4sAoLpJ6cgeBF4GhtGk6ohwhZwNLI9btxwYEL3uD6xosq3BkOi9q82sYV1Gk/235wLgLgB3X2lmLxGqk94FBgGLm3lPTyCvhW2J2Co2M9sP+DWhFNSZ8H/5nWhzSzEA/AP4o5kNA0YAm9z97Z2MSfZAKilIh+XuywkNzqcCTzTZvA6oJZzgGwxmS2liNeHkGL+twQpCI3FPd+8WPbq4+4E7isnMjgKGA9ea2RozWwOMA86PGoBXAPs089Z1QFUL28qJa0SPruB7Ndmn6XDGdwIfAcPdvQvwY6Ahw60gVKltw92rgEcJpYWvolKCNKGkIB3d14Hj3b08fqW71xFObreYWWFUl38VW9odHgUuN7OBZrYXcE3ce1cD/wZ+ZWZdzCzDzPYxs2PZsQuB54CRhPaCQ4HPAZ2AUwj1/Sea2blmlmVmPczsUHevB+4Ffm1m/aOG8CPNLBf4GMgzs9OiBt/rgNwdxFEIbAbKzGx/4NK4bf8E+pnZlWaWG/19xsVt/zNwETARJQVpQklBOjR3X+zus1vY/F3CVfYS4FXgr4QTL4TqnWeB94A5bFvSuADIARYAJYRG3H7bi8XM8ghtFb939zVxj6WEk+uF7v4poWTzfWADoZH5kOgjrgbeB2ZF234BZLj7JkIj8d2Ekk45sFVvpGZcTWi/KI2O9ZGGDe5eSmiH+RKwBvgEGB+3/TVCA/ecqDQm0sg0yY5I+jGz/wB/dfe7Ux2LdCxKCiJpxswOJ1SBDYpKFSKNVH0kkkbM7AHCPQxXKiFIc1RSEBGRRiopiIhIo93u5rWePXv60KFDUx2GiMhu5Z133lnn7k3vf9lGUpOCmU0A/g/IBO5295832T6E0IWwF6GL3lfcfbtd8YYOHcrs2S31UBQRkeaYWULdj5NWfRTdlXkH4YaekcAUMxvZZLfbgD+7+8HATcSNTyMiIu0vmW0KY4FF7r7E3WsIA4dNarLPSOA/0esXmtkuIiLtKJlJYQBbD+JVxJbByhq8B5wZvT4DKIwf672BmV1sZrPNbHZxcXFSghURkdT3ProaONbM3iUM+7uSME78Vtx9qruPcfcxvXrtsJ1ERER2UjIbmley9SiVA4kbDx/A3VcRlRTMrAA4y903JjEmERHZjmSWFGYBw81sWDRN4GRgevwOZtazYfpE4Fq2DGYmIiIpkLSk4O4x4DLCSJUfAo+6+3wzu8nMJka7HQcsNLOPgT7ALcmKR0REdmy3G+ZizJgxrvsUpMNZ8wF8+gaM/DIUdLB2r1gNZOWkOgpJMTN7x93H7Gi/3e6OZpEOo7oUPngc3nkAVs0J6/5zMxz/ExjzNcjITG18APP/Do9/A7rvDcOOhb2Pg6Gfh07dUh2ZdFBKCiKt4Q4r58Cc++H9x6G2HHodABN+DgPGhKQw42qY82c47VcwaGzqYl32KjxxMfQ5EPJ7wdyHYNZdYBnQf1RIEMOOhUHjIDsvdXHuTtzB66E+Fveog6w8yOm84/fvrOKP4bXfwrhLoN/ByfseVH0kkpjKEpj3aCgVfDYfsjvD586E0RfCwMPBoumR3cPV+bP/DaWrYNRX4MQbIb9n+8a7dgHcOwEK+8LXnoHO3UM1UtEsWPIiLH0JimaDRye0wUdsSRL9DukYpZxkcYeKDbBpBWxeCZtWxr0ugtLVEKve+qQfnwSak5kDnzsbjrgk/P3ayur34JVfwYLp4Xc6/Tdw6JSd+qhEq4+UFGT3UrIcXvol9BoRrnD7HZK8q1x3WP46zHkAFvwDYlXQ71A47MJwAsjr0vJ7q8vg5V/CG3dATn77ViltWgn3nBROZt94HroNan6/qs2w/DVY8lJIFMUfhvV53eCAL4XST25B8uNNlppy+OQ5+GxBONlvKtqSBGKVW++bmQNdBkDXgdClP2R3goysLQ/L2Ho5I3Pr5XUfw3vTQslxyNFwxKUw4lTIyMTdidU7tXX11Macmrp6auvqqaipo6w6RllVjNKqWkqj12XVMboWz+aIlfczovRNKqwzMzpP5NGM07ngpMM4/eD+O/XnUFKQPU99PTxwemjQ9fqwLjMnJIZB40JVzcCx0GW7Uy03r+HqsWQplCwL/8k/eBzWL4LcLnDQOSEZtPYqsHhhqE5a+nJ476m/gkGHtz6+RFVuhPtOgY0r4GtPQ9+DEn9v6ZoQ5+IXYN60UO005RHo2nQggo6pvt6pLt9E/cJnyPxoOjnLZpIRq8Ixajr3obJTX8pz+7A5ty8bs3qzIasXn2X04jPrSXFdIeW19ZTX1FFRHaPOPdQUAbjjRDVHROujbQ3nz3p3cmKlnFz9HGfF/kV/iinyXjxYP4GHY8ey2ROpWnKOyZjHd7L+wbiMj9hAFx7PmcR/Cr5ERueuFOZmM2XcYI7db+c6MigpyJ7nzT/CMz+CSXfA8C/CirdhxVuhSmTlHKirDvt1HRwSREOi6PM5yMwK1SebVmw58Zcsgw1LQ+mjZBnUNJmIbNARIRGM/PKu1Rc3Vin9OFRNjPoqnHhD21cpxarhL2fBp2/CVx4L1UE765Pn4W8XhVLO+dNCG8ROcHcqa8MVcXl1HeXVseh1jPKaOqpq66iuraM6Vh9eR89VtfVUx7Z+btgeHnVUR9uya8s4um4WX7Q3OTZjHrlWy1rvxtN1Y3m6bhzv+HBiLTSf5mRlkJ+TSeecLPJzw3On7EyyMkN1oJlhhNpBa7IM1rg+w4ycrAyyMzPIy6zjoLLXOLL4MYaUzaUmozMf9jmdBYPPp6JwKDmZRnZmBp1yMinMy6IgJ5P+q2fS+73byflsHt6lP3bUFTD6gjZtp1BSkNZzh7oaqK0Mj6zcUBfdEaxfDHceDcO+AOc/uqUOv0GsBtbM25IoVrwVTsAQ6v879whVBw0lDIDMXNhr6NaP7sPCc7fB4YTYlqpLQ9XXm3+AnAI44Sdw2P9rmyql+np4/Osw/wk48y44+NwWd62qrWNDeQ3ry2pYV17N+rIaNkTP68pqWF9eTXl1jMG1y/nRxuvpUr+JO7r9kNmdPk9GBlh0MoQtJ8kMg+pYfdxJvy468ceob8UpJsMgLzuT3KyMbZ5zG56zMtkro5zRlW8wqvQl9i2bRZbXUprTm6W9TmBFvy+ysecocrOzyc3KoHOTk37Dc+ecTLIzkzzSz6q58NYf4f3HQnvEfieHqqVhx4blDx6HV34N6xaGHmKf/x4cPDkpXYiVFPYk7qGhc8OS6Mp2aagm8PrtPLzJcl24kmw44ddWbHkdi1sXf9K0DDjmB3DMD8OVdqrU18P9p8Ha+fCdN0Od7464hzrkorfh07egauO2CaCgL2SkYPiv+CqlvgfDyf8Tkl2C3J3ymrpQDx3VR/d642cM/uge3h1xFW/3/0rj+tKqGJurYuGkHyWCsurmG0tzsjLomZ9D94IcCnOzASiMbeDqkhvZt3YhDxV+jX90Oot6iKtOobF6JSczg/zcLApyw4l3y+us6HUm+Tnx6zKjE34mednh5J+VYVjThN+gdA188u/QvrPkxXBS7ToIRk4KjwFjUvN7JqJ0Lcy+F2bfA+XF0Hsk1JTBxk+h94HwhavgwDOS2uakpLC7qa8PvVUaTvrxCWDDMqjetPX+OQVgmVG5NmM7j7jtWXmhAW2rR+etn7Pytrz+9M1QtzxwLJx1VziRpsKbd8Iz18CkP8Co/0pNDLvA3amtC9UoVdGjsiZG7sJ/0H/W/5JbvopVfcbz5j5XsDJzIGXV4UReVh1O7KEhMhatr6W8euur769nzuAn2X/hvtjJ3Bi7ADAyDApysyjMy6YwL4seBTn0yM+lR0EOPQty6Z6fQ4/8HHoU5NKzIIfu+TkU5GY1f0KurYQnLw1VYKO+Cqf9un1uhitfD8teCY+lL4d2HoBuQ+DAL4dE0H/0tqXGjqy2KpQOZt8TSqpHXxFKD+1wDEoKu4O6Wnj7rtC7ZcPSLXXiEHo0dBscipR7DYuqNYZFy0PCSbs9vP8Y/PN74fXpv4GDzm6f723QWG10DJz/SEpOAFW1dZRU1LCxorbxueH1pspaSspr2FhZy6bKWipr6pqc/OuoitVT10IdSi41fC3zGb6d9Q86Uc1DdSdwJ+cQy+tBYV5WqHPObXjOblwXHtnst+7fHPb29ykZcgrrJvyRws55FOaFqpEWr7h3Rn09vPg/8PKtMPQLcN6D0Gmvtvt8gKpNobfX0pfDY+0HYX12Pgw5Kvwb2PvYULranRJBB6Gk0NEtfgGe/lGoSxx8FAw8bMtJv/sw6DIwtVU28UqWwxPfDPX0h0yBU2+F3MLkf299Hdx3augq+e23dq5XUTPcnU2VtRSXVodH2dbP68pqKC6tpqS8hpKKGqpj9S1+Vl52Bnt1zqFrp2y6dsomPzersSqkU3Zm43OnnFAf3iknk7yssNywvTAvi271m+j5zq/Jfe/PWE4+fOH74Ual7XW3XfoK/OXMUG3y1b+3zw1o702D6d8NV+vnPwI99tn5z6opDz3Jlr4cjmX13FB9mZUXOgkM+0Koe+8/CjKz2+wQ0pWSQkdVsizc2PTRP0N1zISfw34TOv6VT10sXCW+/MtwQjjrnpDIkumNO0KPnS//EQ6dQnWsjs82h5N3ZUPPlbjeKlW1dVTF9VipblhXW0dpVSzupF9Nbd22/+5zMjPoVRiqUxqqWPbKDyf8vTrnsFfnbLp2bnidQ7fO2eRlt3EdcPFC+PdP4JNnQ0nxhJ/C587a9t9HczentZflr8O0/wIcJv81XMUnorIktO98+nr4jFXvhnaBjKxwA+CwY0IpZODhusM6CZQUOpqacnj1N/Da70Jj0jFXwxHf2f3+8S9/I5QaSlfD+P8OdaK72Djm7pRWx1i7qYrVm6pYs7mK6tULmTxnCvPzRvPj3P9mbWloKE1U094rBblZ9CrMbXz0LIheF+TSqzCHXgV5dOnUQp16Kix5EZ69Dta+H0oCJ/8PDB4Xtm0qgrtPAhy+/lzLN6cl0/rF8NfzwkXOxN83f5dt6dotCWD566GjAA4Z2TDgMBhyZEgCg49o+55esg0lhY7CPXQT/PdPQpfIg84Jwx7sJjcENatyI/zzytDwOPQLcObUZnsEVdXWNV6ZryurCc/RcnFZNetKw7q1m6sor9ky4V4G9TyacxP7Zazk213/QM5eA+jTJY9+XfPo2yWPXl1y6RxVvYRHxlY9WHIyM8jI6CAn911RXwfvPQwzb4ayNaFh9fNXwd8vCYmhtTentbXKEnj0glD984WrYfRXw0XD8tdCEtiwOOyXnR9u2BtyNAw+EgaOab82MWmkpNARrHk/tBssfy385z3l1nB1tCdwJ/buQ2TM+AGxjByeH34dz9UfTlFJRUgApdWUttD1sUteFj2jq/Sehbn0Kcyjb9dc+nbtRN8ueQxffD97vXojnPEnOGRyOx9YB1RTDq//Hl77v9BtOCN7129Oayt1tfCvq8IAgA3yuoUqpcFHhkTQ72C1CXQASgqpVLEBXrgl9EvO6xZuUhp94W47yFhlTR2Li8tYXFzGos+2PJatL2dA/Sr+L/sODslYwt8zvsgTvb9N1y5dt6qe6VkY6uh7FoQukblZ2/k7rPsE/vh52Of4UF/dUapzOoLNq+H134Whr/c/LdXRbOEeullWloRk0OuAjnu/QBpTUkiF8nWhC+dLPw+DjR3+DRh/bdt33WtD7k5JRS1rN1fFPUKVzqqNlSwqLqOopJKGfyYZBkN65LNv74Lw6FXA8B457P/R78l58/ehfvuYH4ReSq29OqyvC42n6z6G77wVGlFFpE1okp324B56i3z8NCx8JnTZxEM9+ym/CAOKdQBrNlUxa9kGikoqWbu5is9Kw4l/zaYqikurqanbtstl9/wc+nTJ45CB3Thr9ECG9y5k394FDO3Zufkr/aE3w4gvwnPXhy6LL98aulUecn7iNzq9+YdwB/KZdykhiKSISgqtVVcbGtE+fgYWzgi9LyCMgLnfKTBiQhheOYXVHms2VfHW0vW8uWQ9by7ZwNJ15Y3bCnOz6N0llz5dQqNt7y559ImW+3TJpXdhHr275G6/imd73GHR8/Di/8LKd8LgdF+4Cg79r+0nh+KPQ7XRvifC5IdUbSTSxlR91JYqS8KokR8/HZ6rN4Vb1Pc+NtxjsN+ElPYmWru5KkoAWyeBwrwsxg3rzhF792DcsB7s3Suf/Nx2Khy6w6KZUXKYHcao+fz3wqQzWblb71tfB/eeHIap/vZbUNinfWIUSSMdovrIzCYA/wdkAne7+8+bbB8MPAB0i/a5xt1nJDOmVln4DLxxeygZeF2Y0vCAL8GIU0LPj3aegMTd2VwZo7isivmrNreYBP5r3GCO2LsHB/TrQmaqumaawfATYd8TYPFMePEXoZfKK7+GL3wvjKHTkBzeuD0Mf33m3UoIIimWtJKCmWUCHwMnAUXALGCKuy+I22cq8K6732lmI4EZ7j50e5/briWFPx0b+oOPviDMojTgsKT0qqioiW0ZcqGhH3/88AulW4ZfiK//jy8JpDwJ7Ig7LHkBXvx5aHvpMiCUHAaNg7tPhOEnwXl/UbWRSJJ0hJLCWGCRuy+JApoGTAIWxO3jQMOchl2BVUmMp/UqNoQ67hN/2uYfXVlTx9MfrGbarBW8vXTDNtszDLrnb7kDd9/ehXF34+awd88CRvbvwEmgKbPQzXTv8eFu3Zd+EYaPxkLvrNN/o4Qg0gEkMykMAFbELRcB45rscwPwbzP7LpAPnJjEeFqvsqTNu5N+sHITj8xawZNzV1JaFWNIj85cfvy+DO6RHzfsQhh3Z7c54beGGewzPlS/LX0Z3vpTmN2soHeqIxMRUt8ldQpwv7v/ysyOBB40s8+5+1Z9JM3sYuBigMGDB7dPZHW1YXrGNkgKm6tqmT53FdNmfcoHKzeTk5XBqZ/ry3mHD+aIvbt3nPF22pNZaKjf+9hURyIicZKZFFYC8SN1DYzWxfs6MAHA3d8wszygJ/BZ/E7uPhWYCqFNIVkBb6WyJDzv5OiT7s7s5SVMe3sF/3p/FVW19ezft5AbJx7Ilw8dQNfOuu1fRDqeZCaFWcBwMxtGSAaTgfOb7PMpcAJwv5kdAOQBxUmMKXENSaGVJYV1ZdU8MaeIabNWsKS4nPycTM4YNZDJhw/i4IFd07NUICK7jaQlBXePmdllwLOE7qb3uvt8M7sJmO3u04HvA3eZ2fcIjc4XeUe5caKVSaG0qpY7X1zM3a8upSZWz2FD9uKXZ+/DaQf1a797A0REdlFSz1bRPQczmqy7Pu71AuDoZMaw0yqiHkE7SAqxunoemb2C3zz3MevKajhj1AAuPW4f9uvTDjOTiYi0MV3CtiSBksJLHxdzy78W8PHaMsYO7c69Fx3AwQO7tU98IiJJoKTQksqopNBMQ/PHa0u55V8f8tLHxQzp0Zk/fmU0Jx/YV+0FIrLbU1JoSWUJWCbkdmlcta6smt889zEPv/0pBblZXHfaAXz1yCE7P3iciEgHo6TQksoS6NQNzKiqrePe15byhxcWU1VbxwVHDuWKE4azV36CQ0KLiOwmlBRaUrEB79Sdp95bxS+e/oiVGys5aWQfrj1lf/bu1b4D4YmItBclhZZUlrCsPIfLH36Xkf26cOs5B3PUPj1THZWISFIpKbSgYvM6Fpfn8M0vDOOaUw7YM8chEhFpQrNrt6ByYzEVmV24/IThSggikjaUFJoxf9UmcmObGdS/P4V5GqNIRNKHkkIz7pz5IQVWxQH7DE11KCIi7UpJoYmFa0p5a/5iAPIKe6Q4GhGR9qWk0MTtLyyiX05lWGjjCXZERDo6JYU4iz4r45/zVnHugflhxU7OpSAisrtSUojzhxcWkZuVwcQRncIKlRREJM0oKUSWrSvnH++t4ivjhtDFy8LKTiopiEh6UVKI/OHFRWRmGBcfs3fCcymIiOxplBSAFRsqeGLOSs4fO5jeXfLCYHgZWZCriXJEJL0oKQB3vrSYDDO+dezeYUVlSSglaH4EEUkzaZ8UVm2s5G+zV3DOmIH06xo1MFduUNWRiKSltE8Kf3ppMe5w6XH7bFnZUFIQEUkzSU0KZjbBzBaa2SIzu6aZ7b8xs7nR42Mz25jMeJr6bHMVD89awVmjBzJwr85bNlSUqOeRiKSlpA2dbWaZwB3ASUARMMvMprv7goZ93P17cft/FxiVrHia86eXl1BX73x7/D5bb6gsgb4HtWcoIiIdQjJLCmOBRe6+xN1rgGnApO3sPwV4OInxbGVdWTUPvbWcSYf2Z0iP/K03VpbobmYRSUvJTAoDgBVxy0XRum2Y2RBgGPCfJMazlbteWUJ1rJ7vjN936w2xaqgtD/Mzi4ikmY7S0DwZeMzd65rbaGYXm9lsM5tdXFy8y1+2obyGB99YzpcO7s8+TedbriwJz2poFpE0lMyksBIYFLc8MFrXnMlsp+rI3ae6+xh3H9OrV69dDuzeV5dSUVPHZcfvu+3GxqSg6iMRST/JTAqzgOFmNszMcggn/ulNdzKz/YG9gDeSGEujTRW1PPD6Mk49qC/79WnmjmUNcSEiaSxpScHdY8BlwLPAh8Cj7j7fzG4ys4lxu04Gprm7JyuWePe9vpTS6hiXjR/e/A6qPhKRNJa0LqkA7j4DmNFk3fVNlm9IZgzxSqtquffVpZw0sg8j+3dpfqfKqKSg3kcikoY6SkNzu/jzG8vZXBXj8uNbKCWASgoiktbSJimUV8e4+5UljB/Ri4MGdm15x8oSyMiGnIKW9xER2UOlTVL4y5vLKamo5bsnbKeUAKGhWSOkikiaSmqbQkfyxQP7AjB68A6qhTQYnoiksbQpKQzrmc+3jt1nxztqiAsRSWNpkxQSppKCiKQxJYWmlBREJI0pKTSlpCAiaUxJIV5tFdRWKCmISNpSUoinG9dEJM0pKcTTEBcikuaUFOKppCAiaU5JIZ7mUhCRNKekEE9zKYhImlNSiKfqIxFJc0oK8SpLIDMHcvJTHYmISEooKcSr1AipIpLelBTi6W5mEUlzSgrxKkrU80hE0pqSQjyVFEQkzSkpxKssgc5KCiKSvnaYFMzsS2a2U8nDzCaY2UIzW2Rm17Swz7lmtsDM5pvZX3fme9pMQ0OziEiaSuRkfx7wiZn90sz2T/SDzSwTuAM4BRgJTDGzkU32GQ5cCxzt7gcCVyb6+W2uthJiVUoKIpLWdpgU3P0rwChgMXC/mb1hZhebWeEO3joWWOTuS9y9BpgGTGqyzzeBO9y9JPquz1p9BG1FQ1yIiCTWpuDum4HHCCf2fsAZwBwz++523jYAWBG3XBSti7cfsJ+ZvWZmb5rZhOY+KEpCs81sdnFxcSIht56GuBARSahNYaKZ/R14EcgGxrr7KcAhwPd38fuzgOHAccAU4C4z69Z0J3ef6u5j3H1Mr169dvErW6AhLkREyEpgn7OA37j7y/Er3b3CzL6+nfetBAbFLQ+M1sUrAt5y91pgqZl9TEgSsxKIq21pLgURkYSqj24A3m5YMLNOZjYUwN1nbud9s4DhZjbMzHKAycD0Jvs8SSglYGY9CdVJSxILvY2ppCAiklBS+BtQH7dcF63bLnePAZcBzwIfAo+6+3wzu8nMJka7PQusN7MFwAvAD9x9fWsOoM2ooVlEJKHqo6yo9xAA7l4TXfnvkLvPAGY0WXd93GsHrooeqVWxATJzIbtTqiMREUmZREoKxXFX9pjZJGBd8kJKkYYhLjRCqoiksURKCpcAD5nZ7YARuplekNSoUqGyRI3MIpL2dpgU3H0xcISZFUTLZUmPKhU0GJ6ISEIlBczsNOBAIM+i6hV3vymJcbW/yhLovneqoxARSalEbl77I2H8o+8Sqo/OAYYkOa72p5KCiEhCDc1HufsFQIm73wgcSbifYM/hHnofKSmISJpLJClURc8VZtYfqCWMf7TnqK2Eumo1NItI2kukTeGpaDyiW4E5gAN3JTOodlepwfBERGAHSSGaXGemu28EHjezfwJ57r6pPYJrNxriQkQE2EH1kbvXEybKaViu3uMSAmiICxGRSCJtCjPN7CyzPfhWX82lICICJJYUvkUYAK/azDabWamZbU5yXO1L1UciIkBidzTvaNrN3V9DUlDvIxFJcztMCmZ2THPrm066s1ur3ABZeRohVUTSXiJdUn8Q9zoPGAu8AxyflIhSobJEjcwiIiRWffSl+GUzGwT8NlkBpUSFhrgQEYHEGpqbKgIOaOtAUkrjHomIAIm1KfyecBczhCRyKOHO5j1HZQn03DfVUYiIpFwibQqz417HgIfd/bUkxZMalRoMT0QEEksKjwFV7l4HYGaZZtbZ3SuSG1o7cVf1kYhIJKE7moH4vpqdgOcT+XAzm2BmC81skZld08z2i8ys2MzmRo9vJBZ2G6qtgLoa9T4SESGxkkJe/BSc7l5mZp139CYzyySMm3QSoXF6lplNd/cFTXZ9xN0va03QbUpDXIiINEqkpFBuZqMbFszsMKAygfeNBRa5+xJ3rwGmAZN2Lswk0t3MIiKNEikpXAn8zcxWEabj7EuYnnNHBgAr4paLgHHN7HdWdNf0x8D33H1F0x3M7GLgYoDBgwcn8NWtoLkUREQaJXLz2iwz2x8YEa1a6O61bfT9TxF6M1Wb2beAB2jmTml3nwpMBRgzZow33b5LNBieiEijHVYfmdl3gHx3/8DdPwAKzOzbCXz2SmBQ3PLAaF0jd1/v7tXR4t3AYYmF3YY0l4KISKNE2hS+Gc28BoC7lwDfTOB9s4DhZjbMzHKAycD0+B3MLH6u54nAhwl8bttqbGju1u5fLSLS0STSppBpZubuDo29inJ29CZ3j5nZZcCzQCZwr7vPN7ObgNnuPh243MwmEm6K2wBctJPHsfMqSyCrk0ZIFREhsaTwDPCImf0pWv4W8HQiH+7uM4AZTdZdH/f6WuDaxEJNksqN6nkkIhJJJCn8iNDz55JoeR6hB9KeQUNciIg02mGbgrvXA28Bywj3HhxPKur+k0VDXIiINGqxpGBm+wFTosc64BEAdx/fPqG1k8oS6LlfqqMQEekQtld99BHwCnC6uy8CMLPvtUtU7alC1UciIg22V310JrAaeMHM7jKzEwh3NO85GkZIVUOziAiwnaTg7k+6+2Rgf+AFwnAXvc3sTjP7YjvFl1w1ZVBfq5KCiEgkkYbmcnf/azRX80DgXUKPpN2fhrgQEdlKq+ZodvcSd5/q7ickK6B2pSEuRES20qqksMfRXAoiIltJ76Sg6iMRka0oKYB6H4mIRNI8Kaj6SEQkXponhY2QnQ9ZuamORESkQ0jvpKC7mUVEtpLeSUGD4YmIbEVJobOSgohIgzRPCqo+EhGJl+ZJQdVHIiLx0jcpNIyQqiEuREQapW9SqC6F+phKCiIicZKaFMxsgpktNLNFZnbNdvY7y8zczMYkM56t6G5mEZFtJC0pmFkmcAdwCjASmGJmI5vZrxC4gjAPdPvRuEciIttIZklhLLDI3Ze4ew0wDZjUzH43A78AqpIYy7Y0xIWIyDaSmRQGACvilouidY3MbDQwyN3/tb0PMrOLzWy2mc0uLi5um+g0l4KIyDZS1tBsZhnAr4Hv72jfaGKfMe4+plevXm0TgOZSEBHZRjKTwkpgUNzywGhdg0Lgc8CLZrYMOAKY3m6NzZUbw7OSgohIo2QmhVnAcDMbZmY5wGRgesNGd9/k7j3dfai7DwXeBCa6++wkxrRFZQnkFEBWTrt8nYjI7iBpScHdY8BlwLPAh8Cj7j7fzG4ys4nJ+t6EaYgLEZFtZCXzw919BjCjybrrW9j3uGTGsg0NcSEiso30vaNZSUFEZBvpmxQ0wY6IyDbSNylUlmiICxGRJtIzKTSOkKqSgohIvPRMCtWbweuUFEREmkjPpKAhLkREmpWeSUFDXIiINCs9k4LmUhARaVZ6JwWVFEREtqKkICIijZQURESkUXomhYoNkFMImdmpjkREpENJz6SgG9dERJqVvkmhs5KCiEhTaZoUNBieiEhz0jQplOhuZhGRZqRxUlBJQUSkqfRLCvX1SgoiIi1Iv6RQvRm8XkNciIg0I/2Sgm5cExFpUVKTgplNMLOFZrbIzK5pZvslZva+mc01s1fNbGQy4wFCzyNQUhARaUbSkoKZZQJ3AKcAI4EpzZz0/+ruB7n7ocAvgV8nK55GmktBRKRFySwpjAUWufsSd68BpgGT4ndw981xi/mAJzGeoELVRyIiLclK4mcPAFbELRcB45ruZGbfAa4CcoDjm/sgM7sYuBhg8ODBuxaV2hRERFqUzKSQEHe/A7jDzM4HrgMubGafqcBUgDFjxuxaaUJJQaTDqK2tpaioiKqqqlSHssfIy8tj4MCBZGfv3ICfyUwKK4FBccsDo3UtmQbcmcR4gsoNkNsFMlOeD0XSXlFREYWFhQwdOhQzS3U4uz13Z/369RQVFTFs2LCd+oxktinMAoab2TAzywEmA9PjdzCz4XGLpwGfJDGeQDeuiXQYVVVV9OjRQwmhjZgZPXr02KWSV9Iul909ZmaXAc8CmcC97j7fzG4CZrv7dOAyMzsRqAVKaKbqqM0pKYh0KEoIbWtX/55JrUNx9xnAjCbrro97fUUyv79ZFRohVUSkJel5R7OGuBARYP369Rx66KEceuih9O3blwEDBjQu19TUbPe9s2fP5vLLL2+nSNtP+rW2ai4FEYn06NGDuXPnAnDDDTdQUFDA1Vdf3bg9FouRldX8aXLMmDGMGTOmPcJsV+mVFOrroXKjkoJIB3TjU/NZsGrzjndshZH9u/DTLx3YqvdcdNFF5OXl8e6773L00UczefJkrrjiCqqqqujUqRP33XcfI0aM4MUXX+S2227jn//8JzfccAOffvopS5Ys4dNPP+XKK6/cbUsR6ZUUqjcBriEuRGS7ioqKeP3118nMzGTz5s288sorZGVl8fzzz/PjH/+Yxx9/fJv3fPTRR7zwwguUlpYyYsQILr300p2+VyCV0ispVGgwPJGOqrVX9Ml0zjnnkJmZCcCmTZu48MIL+eSTTzAzamtrm33PaaedRm5uLrm5ufTu3Zu1a9cycODA9gy7TaRXQ3PlxvCshmYR2Y78/PzG1z/5yU8YP348H3zwAU899VSL9wDk5uY2vs7MzCQWiyU9zmRIs6SgIS5EpHU2bdrEgAEDALj//vtTG0w7SLOkoOojEWmdH/7wh1x77bWMGjVqt736bw1zT/5o1W1pzJgxPnv27J1781t/gqd/CD9YAvk92jYwEWm1Dz/8kAMOOCDVYexxmvu7mtk77r7DPrRpVlKIqo/yuqY2DhGRDiq9kkLFBsjtqhFSRURakF5JobIEOqs9QUSkJWmWFDTEhYjI9qRZUijR3cwiItuRhklBJQURkZakV1LQXAoiEmf8+PE8++yzW6377W9/y6WXXtrs/scddxwNXeJPPfVUNm7cuM0+N9xwA7fddtt2v/fJJ59kwYIFjcvXX389zz//fCujT470SQr1dVC1SUNciEijKVOmMG3atK3WTZs2jSlTpuzwvTNmzKBbt2479b1Nk8JNN93EiSeeuFOf1dbSp29mVcMIqSopiHRIT18Da95v28/sexCc8vMWN5999tlcd9111NTUkJOTw7Jly1i1ahUPP/wwV111FZWVlZx99tnceOON27x36NChzJ49m549e3LLLbfwwAMP0Lt3bwYNGsRhhx0GwF133cXUqVOpqalh33335cEHH2Tu3LlMnz6dl156iZ/97Gc8/vjj3HzzzZx++umcffbZzJw5k6uvvppYLMbhhx/OnXfeSW5uLkOHDuXCCy/kqaeeora2lr/97W/sv//+bfv3Ip1KChr3SESa6N69O2PHjuXpp58GQinh3HPP5ZZbbmH27NnMmzePl156iXnz5rX4Ge+88w7Tpk1j7ty5zJgxg1mzZjVuO/PMM5k1axbvvfceBxxwAPfccw9HHXUUEydO5NZbb2Xu3Lnss88+jftXVVVx0UUX8cgjj/D+++8Ti8W48847G7f37NmTOXPmcOmll+6wimpnpU9JoTEpqPpIpEPazhV9MjVUIU2aNIlp06Zxzz338OijjzJ16lRisRirV69mwYIFHHzwwc2+/5VXXuGMM86gc+fOAEycOLFx2wcffMB1113Hxo0bKSsr4+STT95uLAsXLmTYsGHst99+AFx44YXccccdXHnllUBIMgCHHXYYTzzxxK4eerOSWlIwswlmttDMFpnZNc1sv8rMFpjZPDObaWZDkhaM5lIQkWZMmjSJmTNnMmfOHCoqKujevTu33XYbM2fOZN68eZx22mktDpe9IxdddBG3334777//Pj/96U93+nMaNAzPncyhuZOWFMwsE7gDOAUYCUwxs5FNdnsXGOPuBwOPAb9MVjyNJQU1NItInIKCAsaPH8/XvvY1pkyZwubNm8nPz6dr166sXbu2sWqpJccccwxPPvkklZWVlJaW8tRTTzVuKy0tpV+/ftTW1vLQQw81ri8sLKS0tHSbzxoxYgTLli1j0aJFADz44IMce+yxbXSkiUlmSWEssMjdl7h7DTANmBS/g7u/4O4V0eKbQPKmKVKbgoi0YMqUKbz33ntMmTKFQw45hFGjRrH//vtz/vnnc/TRR2/3vaNHj+a8887jkEMO4ZRTTuHwww9v3HbzzTczbtw4jj766K0ahSdPnsytt97KqFGjWLx4ceP6vLw87rvvPs455xwOOuggMjIyuOSSS9r+gLcjaUNnm9nZwAR3/0a0/FVgnLtf1sL+twNr3P1nzWy7GLgYYPDgwYctX7689QF99C+Y+1c498+Qkdn694tIm9PQ2cmxK0Nnd4iGZjP7CjAGaLac5O5TgakQ5lPYqS/Z/7TwEBGRFiUzKawEBsUtD4zWbcXMTgT+GzjW3auTGI+IiOxAMtsUZgHDzWyYmeUAk4Hp8TuY2SjgT8BEd/8sibGISAe1u83+2NHt6t8zaUnB3WPAZcCzwIfAo+4+38xuMrOGjry3AgXA38xsrplNb+HjRGQPlJeXx/r165UY2oi7s379evLy8nb6M9JrjmYR6VBqa2spKira5f77skVeXh4DBw4kOzt7q/W7VUOziKSn7Oxshg0bluowJE76jH0kIiI7pKQgIiKNlBRERKTRbtfQbGbFwE7c0gxAT2BdG4azu0nn40/nY4f0Pn4dezDE3Xvt6A27XVLYFWY2O5HW9z1VOh9/Oh87pPfx69hbd+yqPhIRkUZKCiIi0ijdksLUVAeQYul8/Ol87JDex69jb4W0alMQEZHtS7eSgoiIbIeSgoiINEqbpGBmE8xsoZktMrNrUh1PezKzZWb2fjQS7R4/mqCZ3Wtmn5nZB3HrupvZc2b2SfS8R87L2sKx32BmK6Pff66ZnZrKGJPFzAaZ2QtmtsDM5pvZFdH6dPntWzr+Vv3+adGmYGaZwMfASUARYa6HKe6+IKWBtRMzWwaMcfe0uIHHzI4ByoA/u/vnonW/BDa4+8+ji4K93P1HqYwzGVo49huAMne/LZWxJZuZ9QP6ufscMysE3gG+DFxEevz2LR3/ubTi90+XksJYYJG7L3H3GmAaMCnFMUmSuPvLwIYmqycBD0SvHyD8Z9njtHDsacHdV7v7nOh1KWEelwGkz2/f0vG3SrokhQHAirjlInbij7Ubc+DfZvaOmV2c6mBSpI+7r45erwH6pDKYFLjMzOZF1Ut7ZPVJPDMbCowC3iINf/smxw+t+P3TJSmku8+7+2jgFOA7URVD2vJQZ7rn15tucSewD3AosBr4VUqjSTIzKwAeB650983x29Lht2/m+Fv1+6dLUlgJDIpbHhitSwvuvjJ6/gz4O6E6Ld2sjepcG+pe02ZOcHdf6+517l4P3MUe/PubWTbhhPiQuz8RrU6b376542/t758uSWEWMNzMhplZDjAZSIv5oM0sP2p0wszygS8CH2z/XXuk6cCF0esLgX+kMJZ21XBCjJzBHvr7m5kB9wAfuvuv4zalxW/f0vG39vdPi95HAFE3rN8CmcC97n5LaiNqH2a2N6F0AGH61b/u6cduZg8DxxGGDV4L/BR4EngUGEwYev1cd9/jGmRbOPbjCFUHDiwDvhVXx77HMLPPA68A7wP10eofE+rV0+G3b+n4p9CK3z9tkoKIiOxYulQfiYhIApQURESkkZKCiIg0UlIQEZFGSgoiItJISUEkYmZ1cSNJzm3L0XTNbGj8yKUiHVVWqgMQ6UAq3f3QVAchkkoqKYjsQDQfxS+jOSneNrN9o/VDzew/0UBjM81scLS+j5n93czeix5HRR+VaWZ3RWPd/9vMOkX7Xx6NgT/PzKal6DBFACUFkXidmlQfnRe3bZO7HwTcTrgzHuD3wAPufjDwEPC7aP3vgJfc/RBgNDA/Wj8cuMPdDwQ2AmdF668BRkWfc0lyDk0kMbqjWSRiZmXuXtDM+mXA8e6+JBpwbI279zCzdYRJTWqj9avdvaeZFQMD3b067jOGAs+5+/Bo+UdAtrv/zMyeIUyM8yTwpLuXJflQRVqkkoJIYryF161RHfe6ji1teqcBdxBKFbPMTG19kjJKCiKJOS/u+Y3o9euEEXcB/oswGBnATOBSCFPBmlnXlj7UzDKAQe7+AvAjoCuwTWlFpL3oikRki05mNjdu+Rl3b+iWupeZzSNc7U+J1n0XuM/MfgAUA/8vWn8FMNXMvk4oEVxKmNykOZnAX6LEYcDv3H1jGx2PSKupTUFkB6I2hTHuvi7VsYgkm6qPRESkkUoKIiLSSCUFERFppKQgIiKNlBRERKSRkoKIiDRSUhARkUb/Hy6hi6TqH10rAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.15070080757141113 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time()\n",
+    "plt.plot(history.history['accuracy'])\n",
+    "plt.plot(history.history['val_accuracy'])\n",
+    "plt.title(\"Model Accuracy\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Accuracy')\n",
+    "plt.legend(['Train', 'Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "composite-presentation",
+   "metadata": {
+    "papermill": {
+     "duration": 0.087703,
+     "end_time": "2021-04-26T04:14:20.560516",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:20.472813",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Note :**\n",
+    "- The Training and Validation Curves being close, we can conclude that the Model is not Overfitting the Data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "extreme-monitor",
+   "metadata": {
+    "papermill": {
+     "duration": 0.081041,
+     "end_time": "2021-04-26T04:14:20.728116",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:20.647075",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4.11 Confusion Matrix :"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "restricted-stick",
+   "metadata": {
+    "papermill": {
+     "duration": 0.08003,
+     "end_time": "2021-04-26T04:14:20.889074",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:20.809044",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "- A confusion matrix is a technique for summarizing the performance of a classification algorithm.\n",
+    "- The matrix compares the actual target values with those predicted by the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "useful-italic",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:21.061268Z",
+     "iopub.status.busy": "2021-04-26T04:14:21.058992Z",
+     "iopub.status.idle": "2021-04-26T04:14:21.061886Z",
+     "shell.execute_reply": "2021-04-26T04:14:21.062343Z"
+    },
+    "papermill": {
+     "duration": 0.093102,
+     "end_time": "2021-04-26T04:14:21.062486",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:20.969384",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def plot_confusion_matrix(cm, classes,\n",
+    "                          normalize=False,\n",
+    "                          title='Confusion matrix',\n",
+    "                          cmap=plt.cm.Blues):\n",
+    "    \n",
+    "    plt.imshow(cm, interpolation='nearest', cmap=cmap)\n",
+    "    plt.title(title)\n",
+    "    plt.colorbar()\n",
+    "    tick_marks = np.arange(len(classes))\n",
+    "    plt.xticks(tick_marks, classes, rotation=90)\n",
+    "    plt.yticks(tick_marks, classes)\n",
+    "\n",
+    "    if normalize:\n",
+    "        cm = cm.astype('float') / cm.sum(axis=1)[:, np.newaxis]\n",
+    "\n",
+    "    thresh = cm.max() / 2.\n",
+    "    for i, j in itertools.product(range(cm.shape[0]), range(cm.shape[1])):\n",
+    "        plt.text(j, i, cm[i, j],\n",
+    "                 horizontalalignment=\"center\",\n",
+    "                 color=\"white\" if cm[i, j] > thresh else \"black\")\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "    plt.ylabel('True label')\n",
+    "    plt.xlabel('Predicted label')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "discrete-limit",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:21.229243Z",
+     "iopub.status.busy": "2021-04-26T04:14:21.228310Z",
+     "iopub.status.idle": "2021-04-26T04:14:22.166302Z",
+     "shell.execute_reply": "2021-04-26T04:14:22.166851Z"
+    },
+    "papermill": {
+     "duration": 1.023855,
+     "end_time": "2021-04-26T04:14:22.167012",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:21.143157",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAVcAAAEmCAYAAADWT9N8AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAA2qUlEQVR4nO3dd3gV1dbA4d9KAhGpIj0BUXoRgQBBmggqHVSKoAgqivqhol5FvfcqdrmiKBZEbBfFgihKb1KkSA0iAoJEgUtCR3pNwvr+OJMYWnISzslMTtbrMw9n9uyZWRNhZZ89e/aIqmKMMSawwtwOwBhjQpElV2OMCQJLrsYYEwSWXI0xJggsuRpjTBBYcjXGmCCw5JpHiUgBEZkkIgdEZNwFHOc2EZkZyNjcIiLNRWSD23GY0CA2ztXbRORW4FGgOnAIWAW8pKoLL/C4twMPAk1UNflC4/Q6EVGgiqrGux2LyRus5ephIvIo8CbwMlAaqACMALoE4PCXAb/nhcTqDxGJcDsGE2JU1RYPLkBR4DDQPYM6kfiS7zZneROIdLa1BBKAfwC7gO3Anc6254CTQJJzjn7As8CYdMeuCCgQ4azfAfyJr/W8CbgtXfnCdPs1AZYDB5w/m6TbNg94AVjkHGcmUOI815Ya/6B08d8ItAd+B/4C/pmufiNgMbDfqfsOkN/ZNt+5liPO9d6S7vhPADuAz1LLnH0qOeeo76yXA3YDLd3+u2FL7lis5epdVwMXAd9lUOdfQGOgLnAVvgTz73Tby+BL0lH4Eui7InKJqg7G1xoeq6qFVPWjjAIRkYLAW0A7VS2ML4GuOke94sAUp+6lwDBgiohcmq7arcCdQCkgP/BYBqcug+9nEAU8A3wA9AZigObA0yJyuVM3BXgEKIHvZ9ca+D8AVW3h1LnKud6x6Y5fHF8rvn/6E6vqH/gS7xgRuRj4BBitqvMyiNeYNJZcvetSYI9m/LX9NuB5Vd2lqrvxtUhvT7c9ydmepKpT8bXaqmUznlNAbREpoKrbVXXtOep0ADaq6meqmqyqXwLrgU7p6nyiqr+r6jHga3y/GM4nCV//chLwFb7EOVxVDznnX4fvlwqqGqeqS5zzbgbeB67x45oGq+oJJ57TqOoHQDywFCiL75eZMX6x5Opde4ESmfQFlgO2pFvf4pSlHeOM5HwUKJTVQFT1CL6v0vcB20VkiohU9yOe1Jii0q3vyEI8e1U1xfmcmvx2ptt+LHV/EakqIpNFZIeIHMTXMi+RwbEBdqvq8UzqfADUBt5W1ROZ1DUmjSVX71oMnMDXz3g+2/B9pU1VwSnLjiPAxenWy6TfqKozVPV6fC249fiSTmbxpMaUmM2YsuI9fHFVUdUiwD8ByWSfDIfKiEghfP3YHwHPOt0exvjFkqtHqeoBfP2M74rIjSJysYjkE5F2IvKqU+1L4N8iUlJESjj1x2TzlKuAFiJSQUSKAk+lbhCR0iLSxel7PYGve+HUOY4xFagqIreKSISI3ALUBCZnM6asKAwcBA47rer7z9i+E7gii8ccDqxQ1bvx9SWPvOAoTZ5hydXDVPV1fGNc/43vTvVW4AHge6fKi8AKYDXwK7DSKcvOuWYBY51jxXF6Qgxz4tiG7w76NZydvFDVvUBHfCMU9uK7099RVfdkJ6YsegzfzbJD+FrVY8/Y/iwwWkT2i0iPzA4mIl2Atvx9nY8C9UXktoBFbEKaPURgjDFBYC1XY4wJAkuuxhgTBJZcjTEmCCy5GmNMEHhqsgqJKKASWcTtMLLlyqrRbodwQcLDMhsS6m25O/rca8uWzezZsydgP/7wIpepJp/1sNx56bHdM1S1baDOH0jeSq6RRYis0cvtMLJl5pyhbodwQQpGhrsdwgWJCLcvYW5oGtsgoMfT5ONEVu/pd/3jP7+d2VN4rvFUcjXG5HECSGh8D7HkaozxFgmNbyGWXI0x3mItV2OMCTSxlqsxxgSFtVyNMSbABGu5GmNM4Im1XI0xJiis5WqMMUFgLVdjjAk0Gy1gjDGBJ0BY7n4UO5UlV2OMh1jL1RhjgiOXz9CWypKrMcY7bJyrMcYESYiMFsjVvyJGPtOLLTNfYMXYJ9LKbm59FXFjn+DIsmHUr1E+rbx40YuZPnIAu+f/hzcGdT3tOPWqR7P8q0Gs+e5fvP7YzTkW//m8/+5wWsRexTWN63LfXb05fvw4jwzoT6umMVzbpD79br+FI4cPux3mWRK2bqX9Da1pULc2DetdyYh33gLgX08Non6dmjRuUJdePW5m//797gaaBSkpKTRuUI+bu3R0OxS/bd26lTbXXUu9OjWpf1Ut3nlruNshZYHT5+rv4mHeji4Tn01aSpcH3z+tbO0fO+g56BMW/vznaeXHTyTz/HtTeWr4hLOO89ZT3Rnw4lhq3/QSlcqX5IYmNYIad0a2b0vkw5HvMmPeEn5csoqUlBS+//Zrnn/lNeYsimPuTyuJLl+Bj0eNcC3G84mIiODl/wxlxao1zJn/E6NGjmD9b+to1eo6lq1czZIVq6hcpSqvDx3idqh+e+et4VSr4d7fh+yIiIhgyKuv8/Pqdfy4cAnvj3yX39atczss/4n4v3hYrk6ui37+k78OHj2tbMPmnWzcsuusukePn+SnXzZx/ETyaeVlLi1C4YIXsWzNFgC+mLqcTi2vDF7QfkhJSeb4sWMkJydz7NgxypQpS+EivtffqCrHjh3z5F+sMmXLUrdefQAKFy5MterV2ZaYSOvrbyAiwtcD1bBRLNsSEtwM028JCQlMnzaFO++62+1QsqRs2bLUq//3/4fq1WuwbVuiy1FlgbVcQ0O5UkVJ3Lk/bT1x537KlSzqWjxly0Vx/4OPEFO7EnWqVqBIkSK0bH09AAP/726urFKe+I0b6HfvANdi9MeWzZtZvWoVDRrFnlb+2ehPuL6NJ195dJbH//EwL73yKmFhufefyZbNm1m16mcanvH/wbOy0mr1YAMjvaD9rRGRj0Vkl4isCdY5QtH+ffuYPmUSy1b/zi8btnD06BG+Gfs5AMNHfMgvG7ZQpWp1Jowf53Kk53f48GF69+rOkNeGUaTI3y+cHDrkZSIiIril120uRuefqVMmU6pkKerHxLgdSrYdPnyYXj26MvT1N0/7/+B51nLN1H8BzzdRtu06QFTpYmnrUaWLsW33AdfimT9vNhUuq0iJEiXJly8f7TvdyPKlS9K2h4eHc2PXHkyZ+J1rMWYkKSmJ3j270aPnrXS58e+bg2M+/S/Tpk3ho/+OQTze4gBY/NMiJk+eSLXKFelzW0/mzZ3DnX16ux2W35KSkujVoyu39LqNG29y/yZtlljLNWOqOh/4K1jHD5Qdew9y6MhxGtW+DIBb2zdk8o+/uhZPdPkKxK1YytGjR1FVFvw4lyrVqrPpj3jA1+c6Y+pkKlep5lqM56OqDLj3bqpVr8GDAx9JK581czpvDnuNsd98z8UXX+xihP574aVX+GNzAhviN/Pp51/R8tpWfPLpGLfD8ouqct89/ahWvQYDH3nU7XCyKLCjBc71DVpEiovILBHZ6Px5iVMuIvKWiMSLyGoRqZ9un75O/Y0i0tefK3F9nKuI9Af6A5C/cJb2Hf1SH5rHVKJEsULET3mWF0ZNY9+Bowx7vCslLinE+Df7s/r3RDo/OBKA9ROfoXDBSPLni6DTNVfS8YH3WL9pJwOHfMOoZ2+lQGQ+Zv70GzMW/Rboy/Rb/QaN6NjlZm5o0YjwiAiurFOX2++4m26dbuDQoYOoKrVq1+E/w95xLcbzWfzTIr78Ygy1al9Jk0a+v5eDn3+RQY8+zIkTJ+jSoQ3gu6k1/J333Aw1pP20aBFffP4ZtWtfSWxMXQCee/Fl2rZr725g/gj83AL/Bd4BPk1X9iQwW1WHiMiTzvoTQDugirPEAu8BsSJSHBgMNAAUiBORiaq6L8NLUdVAXsjpBxepCExW1dr+1A8rWFoja/QKWjzBtHnOULdDuCAFI3P3ZBkR4d7ufwtVTWMbEBe3ImDfz8OKXaaRzZ/IvKLj+OQBcaraIKM6Z+YhEdkAtFTV7SJSFpinqtVE5H3n85fp66UuqnqvU35avfNxveVqjDGnCX5famlV3e583gGUdj5HAVvT1Utwys5XniFLrsYYb8naKIASIrIi3fooVR3l786qqiISlK/vQUuuIvIlvuZ0CRFJAAar6kfBOp8xJkRkreW6J7NugXPYKSJl03ULpD51lAiUT1cv2ilLxJfL0pfPy+wkwRwt0EtVy6pqPlWNtsRqjMmU5MjcAhOB1Dv+fYEJ6cr7OKMGGgMHnO6DGcANInKJM7LgBqcsQ9YtYIzxlgD2uZ7rGzQwBPhaRPoBW4AeTvWpQHsgHjgK3Amgqn+JyAvAcqfe86qa6TBTS67GGE8J5EMmqnq+4Uetz1FXgXM+V66qHwMfZ+XcllyNMZ4hBDa5usmSqzHGO8RZQoAlV2OMh4i1XI0xJhgsuRpjTBBYcjXGmEATEHu1tjHGBJZYn6sxxgSHJVdjjAkCS67GGBMEllyNMSbQ7CECY4wJDmu5GmNMgNloAWOMCRJLrsYYEwyhkVu9lVzrVItmzo+vuR1GtkT1/sTtEC7I2lG93Q7hgpQpepHbIWRbWIg8kRQQYi1XY4wJCkuuxhgTYIIQFha0V/vlKEuuxhhvCY2GqyVXY4yHWJ+rMcYEhyVXY4wJAkuuxhgTDKGRWy25GmO8xVquxhgTYCI2t4AxxgSFJVdjjAkCS67GGBMMoZFbLbkaY7zFWq7GGBNo9oSWMcYEnm/iFkuuxhgTcCHScCU05vY6h7o1K9OsUV2uuTqGVs1jAejX51auuTqGa66OoW7NylxzdYzLUf5tQMdarBjelbjh3XigY20A6lQszo9DOrNk2M0sHHojDaqUBKB5rbLsGNOXJcNuZsmwm3mqRz03Q+eJgffSsOZltG3R4KxtH44YTqVSF/PX3j0ALFk0n6sqlaHjtbF0vDaWt197OafDPa/7+t/FZdGlaVDvyrSyv/76i47tbqBOzap0bHcD+/btczFC/82cMZ06tapRq3plhr46xO1wsiR1rKs/i5eFdMt1wtQfuLREibT1jz79Iu3z0089TpEiRd0I6yw1K1zCnddXp/nj33My+RQTn2nH1BX/46W+sbz09UpmrkygTf3yvNSnEW2engLAot920PWlGS5H7tO15+3c3u8+HnvgntPKtyUmsHDebMpFlz+tvGHjJnz4+ficDNEvvW+/g3vvf4B77uqbVvb60CG0bNWKxx5/kteGDuH1oUN48eX/uBhl5lJSUnj4oQFMmTaLqOhomjVuSMeOnalRs6bboWVOrOWaq6kq34//hpu73+J2KABUjy7G8t93c+xkCimnlAVrt3Nj44qoQpEC+QEoenF+tv911OVIz63R1c0oVqz4WeUvPT2IJ5550fMtjFTNmreg+CWnX8eUSRO5rbcv2d7Wuy+TJ05wI7QsWb5sGZUqVebyK64gf/78dL+lJ5MneT9u8I3CCgsTvxe/jinyiIisFZE1IvKliFwkIpeLyFIRiReRsSKS36kb6azHO9srZvdaQja5igjdurSjVbNGjP74g9O2LV60kJKlSlGpchWXojvd2v/to2nNMhQvHEmB/OG0jSlPdIlCPP7xYl7uG8vGD3rxyh2xPDNmedo+sdVKsXTYzXz/dFtqlL/ExejPbda0SZQuW44ateucte3nFcvo0DKWO3t24ff161yIzn+7du2kbNmyAJQpU4Zdu3a6HFHmtm1LJDrdt4WoqGgSExNdjChrRPxfMj+WRAEPAQ1UtTYQDvQE/gO8oaqVgX1AP2eXfsA+p/wNp162BK1bQETKA58CpQEFRqnq8GCd70xTZs2jXLkodu/aRdfObalStTpNmjUH4NtxX9G1e8+cCiVTGxL28/r4X5g0uB1Hjyfzy6a9pJw6Rf82NRj08WK+X7KZrk2u4L0BLejw7FRW/bmHav2/5MjxZNrUL8/XT17PlQO+dvsy0hw7epT3hg9l9NeTztpWq05d5setp2ChQsz9YTr39b2FOUt/dSHKrMsN/XyhIAg/4wiggIgkARcD24FWwK3O9tHAs8B7QBfnM8A3wDsiIqqqWT1pMFuuycA/VLUm0BgYICI51ulTrlwUACVLlaJDpxtZGedr9SUnJzNl4vfc2LV7ToXil9GzN9D0se+5/t+T2X/4BBu3HeC2a6vy/ZLNAHz7059pN7QOHUviyPFkAGas3Eq+iDAuLRzpVuhn+d/mP9n6vy10uDaWFjHV2bEtkc7XNWH3zh0ULlyEgoUKAXDtdW1JTk5Ku9nlRaVKlWb79u0AbN++nZIlS7kcUebKlYsiIWFr2npiYgJRUVEuRpQFWWi1Ojm4hIisSLf0T384VU0EXgP+hy+pHgDigP2qmuxUSwBSf0BRwFZn32Sn/qXZuZSgJVdV3a6qK53Ph4Df+PsCgurIkSMcOnQo7fPcObOoUbMWAD/OnU2VqtWIiorOiVD8VtJ5NXT5EgXp0vhyxs7/g+37jtC8lu8racsryxG//QAApYsVSNuvQZWShImw99CJnA/6PKrVrM3ydVuYH7ee+XHrKVMuiok//ETJ0mXYvXMHqY2AX1Yu59SpU1xSPFt/d3NE+46d+HzMaAA+HzOaDp06uxxR5ho0bEh8/EY2b9rEyZMnGTf2Kzp09H7c4OtzzeJogT2q2iDdMuq044lcgq81ejlQDigItM2Ja8mR0QJOp3A9YGlOnG/3rp306dUNgOTkFLr26Enr69sAMP6bsZ65kZXel4Oup3jhSJKST/HwqEUcOHqSASMWMLTf1USEhXEiKYUHRiwE4KarL+eetjVJTjnF8ZPJ9Hl9tquxD7y3L0sXzWffX3tpelVlBg76Nz1uu+OcdadN/o4v/vsh4eERXFTgIoa//6lnvmr3vf1WFsyfx949e6hyRXn+/fSz/OPxJ7n91lv49JOPKV/hMj77YqzbYWYqIiKCN4a/Q6cObUhJSaHvHXdRs1Ytt8PyU8C7Xq4DNqnqbgARGQ80BYqJSITTOo0GUjulE4HyQIKIRABFgb3ZObFkoyshaycQKQT8CLykqmeNv3Ga8f0BostXiPnltz+CGk+wRPX+xO0QLsjaUb3dDuGClHFa/rlRbn4iqWlsA+LiVgTsAi4uV02r9h/hd/1fnrsuTlXPHmDtEJFY4GOgIXAM+C+wAmgBfKuqX4nISGC1qo4QkQHAlap6n4j0BG5W1R7ZuZagjhYQkXzAt8Dn50qsAKo6KrVJn35MqjEmbwrkQwSquhTfjamVwK/4ct4o4AngURGJx9en+pGzy0fApU75o8CT2b2OYI4WEHyB/qaqw4J1HmNM6BAJfEteVQcDg88o/hNodI66x4GA3O0OZsu1KXA70EpEVjlL+yCezxgTAgI5ztVNQWu5qupCQmbaW2NMTvHKDc4LFdJzCxhjcp8Qya2WXI0xHmKTZRtjTOD5HiJwO4rAsORqjPGQ0Jm/wZKrMcZTQiS3WnI1xniLtVyNMSbQcsH4VX9ZcjXGeEbqrFihwJKrMcZTLLkaY0wQhEhuteRqjPGQIEzc4hZLrsYYzxAb52qMMcERIrnVkqsxxlvCQiS7WnI1xnhKiORWS67GGO8QmxXLGGOCI0QGC3gruQqSa/tbEsfc6XYIFyS676duh3BB1r9/q9shZFupXPzm2mCwlqsxxgRBiORWS67GGO8QfN9gQ8F5k6uIvA3o+bar6kNBicgYk6flhT7XFTkWhTHGAEgeeEJLVUenXxeRi1X1aPBDMsbkVQKEh0jTNSyzCiJytYisA9Y761eJyIigR2aMyZNE/F+8LNPkCrwJtAH2AqjqL0CLIMZkjMnDxOka8GfxMr9GC6jq1jMuJCU44Rhj8rLc0CL1lz/JdauINAFURPIBA4HfghuWMSavyq0PEp3Jn26B+4ABQBSwDajrrBtjTMBJFhYvy7Tlqqp7gNtyIBZjjPF8X6q//BktcIWITBKR3SKyS0QmiMgVORGcMSZvEXwPEfi7eJk/3QJfAF8DZYFywDjgy2AGZYzJo7IwUsDrLVx/kuvFqvqZqiY7yxjApvExxgRFoMe5ikgxEflGRNaLyG/O2P3iIjJLRDY6f17i1BUReUtE4kVktYjUz+51nDe5OicvDkwTkSdFpKKIXCYig4Cp2T2hMcZkJAgt1+HAdFWtDlyFb7TTk8BsVa0CzHbWAdoBVZylP/Bedq8joxtacfgmbkm9gnvTbVPgqeye1BhjziW1zzVgxxMpiu+hpzsAVPUkcFJEugAtnWqjgXnAE0AX4FNVVWCJ0+otq6rbs3rujOYWuDyrBzPGmAuVxb7UEiKSfpKpUao6Kt365cBu4BMRuQpfo3EgUDpdwtwBlHY+RwFb0+2f4JQFLrmmJyK1gZqk62tVVU9PXZ+SksK1zWIpW64cY7+dSLvrr+HwocMA7Nm9i/oNGvL52PEuR3ludWtWplChQoSHhxMeEcGcBUsBGPXeO3w0aiTh4eHc0LYdz744xOVIff6vfU3uvK4aIvDJDxt4d8o6Pn2kJVXLFQWgaMH8HDhyksaPT6B4oUg+f6wVMZVKMGbeRh79aImrsT/20L3MmTmNS0uUZNbCOABeGvwUs2dMJV/+/FxW8XKGvj2KokWL8d24Lxn17ptp+/629lemzFlMrSuvcin6c9u6dSt339mHXbt2IiLc1a8/Dzw00O2w/CIC4VlLrntUtUEG2yOA+sCDqrpURIbzdxcAAKqqInLe6VWzK9PkKiKD8TWfa+Lra20HLAQ8nVxHvvsWVatV59ChgwBMm/Vj2rY+t3anfYfOboXmlwlTf+DSEiXS1hf8OI9pUyYxf0kckZGR7N61y8Xo/lazfDHuvK4aLZ6cyMnkU0z4dxumxW2lzxvz0uq80qcRB4+eBOB4UgrPf7WSWhWKUbP8JS5F/bfuPW+nb7/7eHTA3WllzVu25omnXyAiIoJXnvsXI94cylODX+Km7r24qXsvANavW8M9fXp4LrECREREMOTV16lXvz6HDh2iSWwMra+7nho1a7odml8CPAggAUhQ1aXO+jf4kuvO1K/7IlIWSP0HlQiUT7d/tFOWZf6MFugGtAZ2qOqd+DqEi2bnZDklMTGBmdOn0ueOu87advDgQeb/OJf2nbq4EFn2ffLh+wz8xyAiIyMBKFmqlMsR+VSLLsaKjbs5djKFlFPKwnXb6RJb8bQ6XZtU5OuFfwJw9EQyi9fv5PhJb0xPEdukGcUuKX5aWYtrryMiwtfuqNegEdu3nf1va+L4r+l0U/cciTGrypYtS736vpvchQsXpnr1Gmw7xzV4VSBvaKnqDnyP8FdziloD64CJQF+nrC8wwfk8EejjjBpoDBzITn8r+Jdcj6nqKSBZRIrgy/DlM9nHVf8c9CjPvTSEsLCzL2/qpAlc07IVRYoUcSEy/4gI3bq0o1WzRoz++AMA/oj/nSWLFnJ9yyZ0atOKlXHLXY7SZ93/9tGkRmmKF4qkQP5w2tQrT/SlBdO2N61Rml0HjvPHjoMuRpl9X3/+KS1btzmrfNL339Dl5h4uRJQ1WzZvZtWqn2nYKNbtUPwWhCkHHwQ+F5HV+B7ffxkYAlwvIhuB65x18H07/xOIBz4A/i+71+FPn+sKESnmnCgOOAwszmwnEbkImA9EOuf5RlUHZzdQf02fNpkSJUtRt14MC+fPO2v7N+O+os8d/YIdxgWZMmse5cpFsXvXLrp2bkuVqtVJTk5h376/mDl3ESvjltOvz62sXPO76wOpNyQeYNj3q5n0dBuOnEhm9ea9pJz6u/uqR7Mr0lqtuc3bw/5DREQ4N3XveVr5z3HLKFDgYqrVqOVSZP45fPgwvXp0Zejrb3q6MZFeMN4AraqrgHP1y7Y+R10lQHOn+DO3QGrmHiki04Eiqrraj2OfAFqp6mFnNq2FIjJNVYN6B2Pp4p+YPmUSs2ZM48Tx4xw6dJD+d/Vh1MefsnfPHlbGLWfMV98GM4QLVq5cFOD76t+h042sjFtOuagoOna+CREhpkEjwsLC2LtnDyVKlnQ5Whg9ZyOj52wE4LlbY0jcewTwzSjfObYizQZNyGh3Txr35WfMnjmVL8dPO+sX2KTx4+js8VZrUlISvXp05ZZet3HjTTe7HY7/QmjKwYweIqh/5gIUByL8eWpBfQ47q/mcJeB35M40+PmXWbtxC6t/+4OPRn9O82uuZdTHvntvE77/ljZtO3DRRd59wOzIkSMcOnQo7fPcObOoUbMW7Tt2TmuJx2/8nZMnT552w8tNJYv4fp7RJQrSOfYyxi7wtVRb1SnH74n7Sfwrd70daN7smYx8exgfjfmGAhdffNq2U6dOMXnCt3T2aH8rgKpy3z39qFa9BgMfedTtcLIsVB5/zajl+noG2xRoldnBRSQcX1dCZeDddHfs0tfpj+9JCKLLV8jskBdk/DdjefjRQUE9x4XavWsnfXp1AyA5OYWuPXrS+vo2nDx5kgfvv5umDeuSP38+3n3/Y8/85fri8VYULxRJUoryyIeLOeCMDOjW9ArGLTq7S+C3Ed0pXCA/+SPC6NToMjq9MIP1CftzOGqfB+/pw+JFC9j31x5ir6zEI088zYjhQzl54gS9u3UEoF5MI15+/W0Alv60kHJR0VSo6N1h4D8tWsQXn39G7dpXEhtTF4DnXnyZtu3auxuYn/y5EZQbiK+LIcgn8fXZfodvrNma89WrV7+Bzl14Vv7NFU7lwM8xmKL7enpkXabWv3+r2yFkW6mi3v0mlZmmsQ2Ii1sRsN/ypSvX1lte+8bv+m/fVCMuk3GursmRXxKquh+YC7TNifMZY3KvvDTlYLaISEmnxYqIFACux3mDrDHGnE+oJFe/Hn/NprLAaKffNQz4WlUnB/F8xphczjd+1eNZ00/+PP4q+F7zcoWqPi8iFYAyqroso/2c4Vr1AhOmMSavCA+RO1r+XMYI4Gqgl7N+CHg3aBEZY/Is35SD4vfiZf50C8Sqan0R+RlAVfeJSP4gx2WMyaNCpOHqV3JNcvpNFXw3qoBTQY3KGJNnebxB6jd/kutb+MaolhKRl/DNkvXvoEZljMmTJBd83feXP3MLfC4icfgmORDgRlX9LeiRGWPypBDJrX6NFqgAHAUmpS9T1f8FMzBjTN7k9fGr/vKnW2AKf7+o8CJ876TZAHh7vjVjTK6TOlogFPjTLXBl+nVnRqxsTyBrjDEZCZHcmvUntFR1pYjknmnNjTG5Ry54rNVf/vS5pp8QMgzfmxS3BS0iY0yeJoRGdvWn5Vo43edkfH2w3p7K3xiTK/n6XN2OIjAyTK7OwwOFVfWxHIrHGJPHhXxyFZEIVU0WkaY5GZAxJu8SfO9eCwUZtVyX4etfXSUiE4FxwJHUjao6PsixGWPymhB6QaE/fa4XAXvxvTMrdbyrApZcjTEBlxfGuZZyRgqs4e+kmip3vzDKGONJeeWGVjhQCM45LsKSqzEmKEKk4Zphct2uqs/nWCT4fmNdlD88J09pHNs/6+t2CBekTJOBboeQbQkL3nQ7hGxLCfhbj4WwPDDONTSu0BiTawh5o+XaOseiMMYYyBuPv6rqXzkZiDHGQN4YLWCMMTkqr3QLGGNMjrOWqzHGBEGI5FZLrsYY7xCB8BDJrqHyinBjTIiQLCx+HU8kXER+FpHJzvrlIrJUROJFZKyI5HfKI531eGd7xQu5DkuuxhjPSH2Hlr+LnwYC6d9Y/R/gDVWtDOwD+jnl/YB9TvkbTr1ss+RqjPGUQLZcRSQa6AB86KwLvkmovnGqjAZudD53cdZxtrd26meLJVdjjKeI+L8AJURkRbql/xmHexMYBJxy1i8F9qtqsrOeAEQ5n6OArQDO9gNO/WyxG1rGGA8RsthY3KOqDc55JJGOwC5VjRORlgEILkssuRpjPEMI6NfppkBnEWmPb17qIsBwoFjqm1aAaCDRqZ8IlAcSRCQCKIpvLutssW4BY4yniIjfS0ZU9SlVjVbVikBPYI6q3gbMBbo51foCE5zPE511nO1zVLM/7ZclV2OMpwR6KNY5PAE8KiLx+PpUP3LKPwIudcofBZ7M/imsW8AY4yVCVvtc/aKq84B5zuc/gUbnqHMc6B6oc+aJluvMGdOpU6satapXZuirQ9wOJ0tyW+zHjx+nVfPGNI2tT+OYOrz8wrMA/Dh3Ni2ubkiz2Bjatm7Bn3/EuxbjyMG3sWX2K6wY98+0spuvq0fcN//iSNxb1K9ZIa28VWx1Fn0+iOVf/5NFnw/imoZVzzreuDfvPe1Ybjmwfz939r6FxvVrc3XMlSxfuphXXhhMi8b1aNkkhm5d2rF9+za3w8xQap+rv4uXeT2+C5aSksLDDw1gwqRp/Lx6HeO++pLf1q1zOyy/5MbYIyMjmTjtBxYtXcmCJXHMnjWD5cuW8OjAB/jgk09ZuDSObj16MfQ/L7sW42eTltBlwLunla39Yxs9//EBC1f+cVr53v2H6fbw+zTs8TL3PPMZH7/Y57TtXVpdxZGjJ4Iesz/+OegRWl13A0tWruHHxXFUrVaDBwb+g/lLfmbeT3Hc0LY9rw150e0wMxWoPle3hXxyXb5sGZUqVebyK64gf/78dL+lJ5MnTch8Rw/IjbGLCIUKFQIgKSmJpKRkxBlec+jgQQAOHjxA2TJlXYtx0co/+OvA0dPKNmzaycYtu86q+8uGBLbvPgDAuj+2c1FkPvLn8/WmFSyQn4d6t2LIh9ODH3QmDh44wOKfFtK7710A5M+fn6LFilG4SJG0OkePHPV8QoIc6XPNESHf57ptWyLR0eXT1qOiolm2bKmLEfkvt8aekpLCNU0asenPeO6+934aNIrlrRHv0/3mThS4qACFixRh1rxFboeZZTddV5dV67dyMsk3/nzw/3Vk+GezOXrspMuRwZYtm7i0RAkevK8fa9espk7d+rz86hsULFiQl557mrFfjqFIkaJ8P2WW26FmSLCJW/x25qQJJvSFh4ezcGkcazduIW7FctatXcOIt4czbvwk1sVv4bbb+/KvJx5zO8wsqXFFGV58qAsPvPgVAHWqRnF5+ZJMnLva5ch8kpOTWb3qZ+68+17mLlpBwYIFeWvYqwD8a/ALrF6/iW49evHhqBEuR5q5LD6h5Vk50S1w5qQJOapcuSgSEramrScmJhAVFZXBHt6Rm2MHKFasGM1btOSHmdNZ8+tqGjSKBeCmbj1YtnSxy9H5L6pUMcYO68/dT3/GpoQ9AMRedTkxNSuwfspzzPnkEapcVooZH7j3BtpyUdGUi4ompqHvZ9ypS1d+WfXzaXW63dKLyRO+cyO8LJAs/edlQU2uZ06a4IYGDRsSH7+RzZs2cfLkScaN/YoOHTu7FU6W5MbY9+zezf79+wE4duwY8+b8QNVq1Tl48ADxG38HYO5sX1luULRQAca/fR9PvzWBxb/8mVb+wbiFXHHDv6jeYTCt7nyDjVt20eae4a7FWbp0GaKiotn4+wYA5v84h2rVa/BH/Ma0OtOmTKRK1Wpuhei3UGm5BrvP9U18kyYUPl8FZ6KF/gDlK1Q4X7Vsi4iI4I3h79CpQxtSUlLoe8dd1KxVK+DnCYbcGPuOHdu5/567SDmVgp46xY03d6Nt+44Mf+d9+tzaAwkLo1ixYrw70rXft4x+5Q6ax1ShRLFCxE9/gRdGTmXfgSMMe6I7JS4pxPi37mP1hkQ6D3iX+3q2oFL5kjzVvx1P9W8HQKf732H3vsOuxX8+r7z2Jvfd3Yekkye5rOIVvP3ehzz8wL3Eb/ydsDAhuvxlvD783cwP5CLfUCyPZ00/yQU83ZXxgX2TJrRX1f9zJk14TFU7ZrRPTEwDXbR0RVDiMRk7kZTidggXpEwT976SX6iEBW+6HUK2tW4Ry6qVcQHLhlVr19W3v/b/plvbWqXizjdxi9uC2XI9a9IEERmjqr2DeE5jTC7n9a/7/gpan+t5Jk2wxGqMyVCo3NAK+XGuxpjcw/eaF7ejCIwcSa7pJ00wxpiMeL1F6i9ruRpjPCVU+lwtuRpjPMVarsYYE2CChMzcApZcjTHekQuevPKXJVdjjKeESG615GqM8Q7fUKzQSK+WXI0xnhIaqdWSqzHGa0Iku1pyNcZ4ig3FMsaYIAiRLldLrsYYbwmR3GrJ1RjjMSGSXS25GmM8w/fK7NDIrpZcjTHeYU9oGWNMcIRIbrXkaozxEkFCpOlqydUY4ykhklstuRqfyHzhbodwQXb8NNztELKtTLNH3Q4h205sSAjo8QTrFjDGmOAIkexqydUY4ymhMhQraK/WNsaY7BDxf8n8WFJeROaKyDoRWSsiA53y4iIyS0Q2On9e4pSLiLwlIvEislpE6mf3Oiy5GmM8RbKw+CEZ+Ieq1gQaAwNEpCbwJDBbVasAs511gHZAFWfpD7yX3euw5GqM8Y6sZFY/squqblfVlc7nQ8BvQBTQBRjtVBsN3Oh87gJ8qj5LgGIiUjY7l2J9rsYYT8lin2sJEVmRbn2Uqo4653FFKgL1gKVAaVXd7mzaAZR2PkcBW9PtluCUbSeLLLkaYzxDyPI41z2q2iDT44oUAr4FHlbVg+kfVFBVFRHNYqiZsm4BY4ynBLjPFRHJhy+xfq6q453inalf950/dznliUD5dLtHO2VZZsnVGOMtAcyu4muifgT8pqrD0m2aCPR1PvcFJqQr7+OMGmgMHEjXfZAl1i1gjPGUAL/9tSlwO/CriKxyyv4JDAG+FpF+wBagh7NtKtAeiAeOAndm98SWXI0xnhLI1KqqCzM4ZOtz1FdgQCDObcnVGOMtofGAliVXY4x32JsIjDEmGOxNBMYYExwhklstuRpjPCZEsqslV2OMh0jI9LnmiYcIZs6YTp1a1ahVvTJDXx3idjhZcu/dd1GhXCli6tZ2O5QsO378OM2ubkSj+ldR/6pavPDcYLdDytDx48dp1bwxTWPr0zimDi+/8CwAqsoLg/9NTJ0aNKpXm5Ej3nYtxpHP9GLLrBdZMfbJtLKbr6tL3NdPcmT5G9Sv8ffDRcWLXsz09x9g94JXeWNQ13Meb9ywu087lhcEcspBN4V8yzUlJYWHHxrAlGmziIqOplnjhnTs2JkaNWu6HZpfbu97B/f93wPcfVcft0PJssjISKbPmkOhQoVISkqi1TXNuKFNO2IbN3Y7tHOKjIxk4rQf0uJt27oF17dpy4b160lITGD5qrWEhYWxe9euzA8WJJ9NWsbIrxfw4XO908rWxm+n5+Mf884/e5xW9/iJZJ5/byo1K5WlVqUyZx2ry7V1OHLsZNBjzopQes1LyLdcly9bRqVKlbn8iivInz8/3W/pyeRJEzLf0SOaNW9B8eLF3Q4jW0SEQoUKAZCUlERyUpKn3+x5ZrxJSckIwscfjOSJp/5NWJjvn0vJUqVci3HRz3/w14Gjp5Vt2LyTjVvOTvhHj5/kp1V/cvxk0lnbChbIz0O9r2XIhzOCFmu2BXpyAZeEfHLdti2R6Oi/vypFRUWTmJiteRhMNqSkpBAbU5cK5UrR6rrraRQb63ZIGUpJSaFZbAxVLivLta1b06BRLJs2/cn4b76mZdNYunXpwB/xG90O84INvr8Dw8fM5ejxsxOv2yQL/3lZUJOriGwWkV9FZNUZcy6aPCI8PJylcauI35zAiuXLWLtmjdshZSg8PJyFS+NYu3ELcSuWs27tGk6eOEHkRRcxb9FS+tx5Nw/cd7fbYV6QOlWjuDz6UibOXe12KOcUKn2uOdFyvVZV6/oz52IwlCsXRULC33PfJiYmEBUV5UYoeVqxYsW4puW1zJw53e1Q/FKsWDGat2jJ7FkzKBcVTacuNwHQqcuNrF3zq8vRXZjYOhWJqVmB9ZOeYc5HA6lyWUlmvP+A22H5CIRlYfGykO8WaNCwIfHxG9m8aRMnT55k3Niv6NCxs9th5Qm7d+9m//79ABw7dozZP8yiWrXq7gaVgT1nxDtvzg9UqVqNDp06s+DHeQAsXPAjlSpXdS/IAPjgm0Vc0fYZqnd6nlb9hrNxy27a3PuO22GlExqdrsEeLaDATGeW7/fP9foFEemP70VglK9QIeABRERE8Mbwd+jUoQ0pKSn0veMuataqFfDzBEuf3r1Y8OM89uzZQ6WK0Tz9zHPccVc/t8Pyy47t27nnrr6kpKRwSk/RtVsP2nfo6HZY57Vjx3buv+cuUk6loKdOcePN3WjbviONmzSj/5238947wylYsCBvjXjftRhHv9SH5g0qU6JYIeKnPscL709j38GjDHu8KyUuKcT44fey+vcEOj8wEoD1k56hcMGLyJ8vgk4t69BxwAjWb9rpWvyZycabCDxLfDNsBengIlGqmigipYBZwIOqOv989WNiGuiipdY1a7LuRFKK2yFkW5lmj7odQradWP8Vp47sDFg6vKpejE6bu9jv+lGXRMa51eWYmaB2C6hqovPnLuA7oFEwz2eMyf3shlYmRKSgiBRO/QzcAHj7VrExxnWhMhQrmH2upYHvnEHjEcAXqpo7bhUbY9zj7Zzpt6AlV1X9E7gqWMc3xoSmEMmtoT+3gDEm98gNfan+suRqjPEUr/el+suSqzHGW0Ijt1pyNcZ4S4jkVkuuxhgvEcJCpNPVkqsxxjNC6fHXkJ+4xRhj3GAtV2OMp4RKy9WSqzHGU2woljHGBJo9RGCMMYHn/Smw/WfJ1RjjLSGSXS25GmM8xfpcjTEmCEKlz9XGuRpjPCXQrycUkbYiskFE4kXkySCEfE6WXI0x3hLA7Coi4cC7QDugJtBLRGoGI+wzWbeAMcYzBAI9t0AjIN6ZvB8R+QroAqwL5EnOxVPJdeXKuD0F8smWIB2+BLAnSMfOCbk5fovdPcGO/7JAHmzlyrgZBfJJiSzscpGIpH9l9ChVHZVuPQrYmm49AYi9kBj95ankqqolg3VsEVnh1Vfw+iM3x2+xuye3xa+qbd2OIVCsz9UYE8oSgfLp1qOdsqCz5GqMCWXLgSoicrmI5Ad6AhNz4sSe6hYIslGZV/G03By/xe6e3B7/BVHVZBF5AJgBhAMfq+ranDi3qGpOnMcYY/IU6xYwxpggsORqjDFBYMnVGGOCwJKrCTgRaSQiDZ3PNUXkURFp73Zc2SEin7odg8md8tJogVxDRKrje7JkqaoeTlfeVlWnuxdZ5kRkML7nuCNEZBa+p2HmAk+KSD1VfcnVADMgImcO0RHgWhEpBqCqnXM8qAsgIs3wPf65RlVnuh1PXpPnRguIyJ2q+onbcZyPiDwEDAB+A+oCA1V1grNtparWdzG8TInIr/jijgR2ANGqelBECuD7ZVHHzfgyIiIr8T1z/iGg+JLrl/jGRqKqP7oXXeZEZJmqNnI+34Pv79F3wA3AJFUd4mZ8eU1e7BZ4zu0AMnEPEKOqNwItgadFZKCzLTfMdJmsqimqehT4Q1UPAqjqMeCUu6FlqgEQB/wLOKCq84Bjqvqj1xOrI1+6z/2B61X1OXzJ9TZ3Qsq7QrJbQERWn28TUDonY8mGsNSuAFXdLCItgW9E5DJyR3I9KSIXO8k1JrVQRIri8eSqqqeAN0RknPPnTnLXv5EwEbkEX6NJVHU3gKoeEZFkd0PLe3LTX5ysKA20AfadUS7ATzkfTpbsFJG6qroKQFUPi0hH4GPgSlcj808LVT0BackqVT6grzshZY2qJgDdRaQDcNDteLKgKL6WtwAqImVVdbuIFCJ3/GIOKSHZ5yoiHwGfqOrCc2z7QlVvdSEsv4hINL6v1jvOsa2pqi5yISyTi4nIxUBpVd3kdix5SUgmV2OMcVtevKFljDFBZ8nVGGOCwJJrCBKRFBFZJSJrRGSc0+eW3WP9V0S6OZ8/zOjlbiLSUkSaZOMcm0XOfrXH+crPqHM4o+3nqP+siDyW1RiNySpLrqHpmKrWVdXawEngvvQbRSRbo0RU9W5VzejFbi2BLCdXY0KRJdfQtwCo7LQqFziPeK4TkXARGSoiy0VktYjcCyA+7zjvef8BKJV6IBGZJyINnM9tRWSliPwiIrNFpCK+JP6I02puLiIlReRb5xzLRaSps++lIjJTRNaKyIf4MUxIRL4XkThnn/5nbHvDKZ8tIiWdskoiMt3ZZ4HzSLExOSZUx7ka0lqo7YDU+QjqA7VVdZOToA6oakMRiQQWichMoB5QDd873kvjexz04zOOWxL4AN+Y1k0iUlxV/xKRkcBhVX3NqfcF8IaqLhSRCvhmg68BDAYWqurzzljSfn5czl3OOQoAy0XkW1XdCxQEVqjqIyLyjHPsB/DNwH+fqm4UkVhgBNAqGz9GY7LFkmtoKiAiq5zPC4CP8H1dX5ZurOMNQJ3U/lR8A9CrAC2AL1U1BdgmInPOcfzGwPzUY6nqX+eJ4zqgpvz9HvoizoD2FsDNzr5TROTMhz3O5SERucn5XN6JdS++p77GOuVjgPHOOZoA49KdO9KPcxgTMJZcQ9MxVa2bvsBJMkfSFwEPquqMM+oFcmrAMKCxqh4/Ryx+cx4Bvg64WlWPisg84KLzVFfnvPvP/BkYk5OszzXvmgHcLyL5AESkqogUBOYDtzh9smWBa8+x7xKghYhc7uxb3Ck/BBROV28m8GDqiojUdT7OB251ytoBl2QSa1Fgn5NYq+NrOacKA1Jb37fi6244CGwSke7OOURErsrkHMYElCXXvOtDfP2pK0VkDfA+vm8y3wEbnW2fAovP3NGZEKQ/vq/gv/D31/JJwE2pN7SAh4AGzg2zdfw9auE5fMl5Lb7ugf9lEut0fPPD/gYMwZfcUx0BGjnX0Ap43im/DejnxLcW6OLHz8SYgLHHX40xJgis5WqMMUFgydUYY4LAkqsxxgSBJVdjjAkCS67GGBMEllyNMSYILLkaY0wQ/D/cZqc+JasVQAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Predict the values from the validation dataset\n",
+    "Y_pred = model.predict(x_test)\n",
+    "# Convert predictions classes to one hot vectors \n",
+    "Y_pred_classes = np.argmax(Y_pred,axis = 1) \n",
+    "# Convert validation observations to one hot vectors\n",
+    "Y_true = np.argmax(y_test,axis = 1) \n",
+    "# compute the confusion matrix\n",
+    "confusion_mtx = confusion_matrix(Y_true, Y_pred_classes) \n",
+    "# plot the confusion matrix\n",
+    "plot_confusion_matrix(confusion_mtx, \n",
+    "            classes = ['1','2','3','4','5'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "welcome-glory",
+   "metadata": {
+    "papermill": {
+     "duration": 0.080528,
+     "end_time": "2021-04-26T04:14:22.338010",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:22.257482",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Correctly predicted classes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "dense-rachel",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:22.512183Z",
+     "iopub.status.busy": "2021-04-26T04:14:22.511283Z",
+     "iopub.status.idle": "2021-04-26T04:14:22.774295Z",
+     "shell.execute_reply": "2021-04-26T04:14:22.773503Z"
+    },
+    "papermill": {
+     "duration": 0.352042,
+     "end_time": "2021-04-26T04:14:22.774422",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:22.422380",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "Y_pred = model.predict(x_test)\n",
+    "# Convert predictions classes to one hot vectors \n",
+    "Y_pred_classes = np.argmax(Y_pred,axis = 1) \n",
+    "Y_true = np.argmax(y_test,axis = 1) \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "other-shopper",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:22.988496Z",
+     "iopub.status.busy": "2021-04-26T04:14:22.982854Z",
+     "iopub.status.idle": "2021-04-26T04:14:23.595097Z",
+     "shell.execute_reply": "2021-04-26T04:14:23.594632Z"
+    },
+    "papermill": {
+     "duration": 0.739885,
+     "end_time": "2021-04-26T04:14:23.595225",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:22.855340",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.28609752655029297 seconds ---\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkkAAAJeCAYAAACgU5EXAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAABHbElEQVR4nO3de7ycZXnv/+83K+fzAUhCDgTCQSMbgo1QCgqewdaKdW8r7VawutFt7bZ9tbb+rFb2tmywL4+7rVhUCq2gxSLVeoRSQfAMiEAIhFMgCTlBIFk5Z2Vdvz/miS7ivea+18yz1pqVfN6v13pl1tzX3M89z5q5cs0zM9fjiBAAAACea9RwLwAAAKATUSQBAAAkUCQBAAAkUCQBAAAkUCQBAAAkUCQBAAAkUCQdxGxfZfuvq8svtv3gEG03bB9b85y/uC9DeVsAw4P81f5t0T6KpGFme5Xtnba32d5QPSEm172diLgtIk4oWM+Ftm+ve/t95r/F9tsHa/66VftjX/X32f9z9nCvC+gE5K/OZvtE29+x/ZRtmiK2gCKpM7w2IiZLeqGkZZI+cGCA7dFDvirs98OImNzn55bhXhDQQchfnWuvpOskvW24FzJSUSR1kIhYK+lbkk6UfnHY9w9tPyTpoeq637J9t+1nbf/A9kn7b2/7FNt32e62/S+SxvcZO9v2mj6/L7D9FdubbD9t++9sP1/SZySdXr0yfLaKHWf7o7afqF4tfsb2hD5zvdf2OttP2v6DVu+/7S/bXm97i+3v2X7BASGH2b6pun+32j6qz22fV41ttv2g7Te2ug4AA0f+6rz8FREPRsTnJS2vY75DEUVSB7G9QNJrJP2sz9XnSTpN0hLbp0i6UtI7JM2S9A+SvlYlgbGS/k3SP0uaKenLkt7Qz3a6JH1d0uOSFkmaJ+lLEbFC0jv1yyMn06ubXCbpeElLJR1bxf9VNdc5kv5M0islHSfpFW3sgm9Vcxwh6S5J1xww/vuSPizpMEl37x+3PUnSTZKurW77Jkmftr0kt0HbC6uEvbBJ2CnV4eqVtj/Iq2LgV5G/OjZ/oR0Rwc8w/khaJWmbpGfVeNJ/WtKEaiwkvaxP7OWSPnzA7R+UdJakl0h6UpL7jP1A0l9Xl8+WtKa6fLqkTZJGJ9ZzoaTb+/xuSdslLe5z3emSHqsuXynpsj5jx1frPraf+3uLpLcX7Jfp1TzTqt+vUiMR7h+fLGmfpAWSflfSbQfc/h8kfajPbf+6xb/PMZKOVuMFxX+RdL+k/2+4Hzf88NMJP+SvfvdLR+SvPvMdKymG+/EyEn94RdwZzouI/+hnbHWfy0dJusD2H/W5bqykI9V4Qq6N6hlRebyfORdIejwiegrWdrikiZLutL3/Okvqqi4fKenOgm02Vb06vETSf6u22VsNHSZpS3X5F/siIrbZ3lxt/yhJp+0/vF4Zrcar0rZExKN9fr3X9v+R9F5Jl7Y7N3CQIH91aP5C+yiSOl/fpLFa0iURccmBQbbPkjTPtvskmoWSHknMuVrSQtujE4nmwG9APCVpp6QXROMzBwdap0bS2q/Vw76/J+l1ahzuXiVpmqRn1Eho+/1iO258g2amGq8+V0u6NSJe2eK2ByIOWBOA/pG/fqkT8hcGiM8kjSyflfRO26e5YZLt37Q9RdIPJfVI+l+2x9j+HUmn9jPPT9RIDpdVc4y3fUY1tkHS/OozAoqI3mq7n7B9hCTZnmf71VX8dZIutL3E9kRJHyq4H6Orbe7/GSNpiqTdkp5W45Xf/03c7jW2z6zW9mFJP4qI1Wp8PuF422+u7vsY2y+qPsjZFtvn2p5dXX6epA9K+mq78wKHIPLX0Ocv2x6vxhE7Vesd1+68hxKKpBEkIu6Q9D8k/Z0ar1IeVuM9eEXEHkm/U/2+WY33ub/Szzz7JL1Wjfepn5C0poqXpP9U45sQ620/VV33F9W2fmR7q6T/kHRCNde3JH2yut3D1b85l6vx6m7/zz9K+ic1DnWvVeNzPz9K3O5aNZLYZkm/Jum/V2volvQqNT7w+KSk9ZI+IimbDKoPPm5r8sHHl0u6x/Z2Sd9UY5+mEiCAJshfw5K/jqrWuP/bbTvV+BwYCvm5bwEDAABA4kgSAABAEkUSAABAAkUSAABAAkUSAABAAkUSitm+2PYXap5zkRvneBpwz652bgvg0EL+QisokkYQ27fYfqa0z4XtC23fPtjrqrb1nBNQjgS2V9neWX2FdpvtG4d7TcDBivxVL9sftn2v7R7bFw/3eg5WFEkjhO1Fkl6sRkfZ3x7e1RxUXhuNk2FOjohXDfdigIMR+WtQPCzpzyV9Y7gXcjCjSBo53qJGg7KrJF3Qd8D2Attfsb3J9tO2/67q1voZSadXR0merWJvsf32Prd9zqs125+yvdr2Vtt32n5xuwuvuur+rJpzdT+vev7A9pO219n+sz63HWX7fbYfqe7bdbZntrsmAEOK/FVz/oqIq6tmmN11zIc0iqSR4y2Srql+Xu1fniqjS4229o9LWiRpnhpnm14h6Z2SflgdJZleuJ2fSlqqxnmFrpX05aqtfTu2V+ufLuk3Jf1P2+cdEPNSScep0Xn2L2y/orr+jySdp8aZwo9Uo1Pv35ds1PanbX86E3ZNlZxvtH1yybwABoz8NTj5C4OMImkEsH2mGu3lr4uIO9U46ePvVcOnqvHke29EbI+IXRHR8vv4EfGFiHg6Inoi4mNqtMY/oZ31R8QtEXFvRPRGxD2SvqhG0ujrf1frv1eNNv/nV9e/U9JfRsSaiNgt6WJJ/7Xkw44R8a6IeFeTkN9XIzEfJem7kr5je/oA7hqADPLXoOUvDAGKpJHhAkk3RsT+cxFdq18esl4g6fHE2bBbYvvPbK+wvaU6xD1N0mFtznma7e9WR2y2qJE4DpxzdZ/Lj6uROKVGcr3B9rPVelZI2idpdjtrkqSI+H5E7IyIHRFxqaRn1fjcBID6kL8GIX9haPDVww5ne4KkN0rqsr2+unqcpOnV20OrJS20PTqRaFIn5tuuxlmq95vTZ1svVuODgC+XtDwiem0/I8lt3o1r1Tip5bkRscv2J/WrSWaBpAeqywvVONGj1Lh/fxAR3z9w0urDoHUKtX9fAVTIX0OavzAIOJLU+c5T45XHEjXea18q6fmSblPjffKfSFon6TLbk2yPt31GddsNkubbHttnvrsl/Y7tibaPlfS2PmNTJPVI2iRptO2/kjR1IIuttt/3x9W8m6sEc6p+eai9rw9Wa3qBpLdK+pfq+s9IusT2UdX8h9t+3UDW1M86F9o+w/bYap3vVSPx/UoyA9Cy80T+qj1/VXONqT5vNUqN+zu++owXakSR1PkukPSPEfFERKzf/6PGK5vfV+NV0mslHSvpCUlrJP1uddv/lLRc0nrb+w91f0LSHjUS0NVqfJByv+9I+raklWocMt6l5x5GzpknaecBP4slvUvS/7HdLemvJF2XuO2tanyl9WZJH42I/T2LPiXpa5JurG7/I0mnlSzG9mdsf6af4SmSLlfjg5RrJZ2jxivFp0vmBlCE/DU4+UuSPlut8XxJf1ldfnPJ3CjniNQRTQAAgEMbR5IAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAAShrSZpG2+SgccpCLioG7ESf5qz8yZ+fO6Tpw4sel4Xd/GHj06/1/fuHHjsjHd3flzy+7du7ft9Tz77LPZOXbt2pWNQf/6y19tFUm2z1GjD0SXpM9FxGXtzAcAQ4kcNnRe/epXZ2OWLVvWdHzPnj3ZOUaNyr9BMmvWrGzM0UcfnY255ZZbsjHr1q3Lxsye3fwsJddff312jgceeCAbg4Fr+e22qrPn30s6V41uqufbXlLXwgBgMJHDAOS085mkUyU9HBGPRsQeSV+SVEu7dQAYAuQwAE21UyTN03Nbvq+prgOAkYAcBqCpQf/gtu2LJF002NsBgLqRv4BDWztF0lpJC/r8Pr+67jki4gpJV0h8OwRAR8nmMPIXcGhr5+22n0o6zvbRtsdKepMaZzsGgJGAHAagqZaPJEVEj+13S/qOGl+fvTIilte2MgAYROSwoVXy9f3169c3HV+4cGF2jvnz52djSvokLV+efyhs2bIlG7NixYq211Oy7zA42vpMUkR8U9I3a1oLAAwpchiAZjgtCQAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQMKgn7sNAHBwmzt3bjZm0aJF2ZhHH3206fhJJ52UneOII45oezulli5dmo0566yzsjGPP/540/Ft27Zl5+ju7s7GbNq0KRuD5+JIEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQALNJAEAbTnmmGOyMePHj8/GTJgwoen4ww8/nJ1j/fr12ZiSxpYXXHBBNuZb3/pWNuaGG27Ixqxdu7bp+Jw5c7JzlDS2vOmmm7IxeC6OJAEAACRQJAEAACRQJAEAACRQJAEAACRQJAEAACRQJAEAACRQJAEAACTQJwkA0JbJkydnY55++ulszL59+5qOP/jgg9k5ent7szEzZszIxrz3ve/Nxtx1113ZmLlz52ZjVq5c2XS8ZN9NnTo1G4OB40gSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAs0kAQBtOe6447IxPT092Zj169c3HR81Kv+6vqSx5fe///1szKJFi7IxRx11VDZmzZo12Zhdu3Y1Hd+zZ092ju3bt2djMHAcSQIAAEho60iS7VWSuiXtk9QTEcvqWBQADAVyGIBm6ni77aUR8VQN8wDAcCCHAUji7TYAAICEdoukkHSj7TttX1THggBgCJHDAPSr3bfbzoyItbaPkHST7Qci4nt9A6rEQ/IB0Ima5jDyF3Boa+tIUkSsrf7dKOkGSacmYq6IiGV8IBJAp8nlMPIXcGhruUiyPcn2lP2XJb1K0n11LQwABhM5DEBOO2+3zZZ0g+3981wbEd+uZVUAMPjIYTUpaRSZa5hYYvHixdmYF7/4xdmY5z//+dmYkgaON998czam5H6PHTu26fjOnTuzc4wfPz4bg4FruUiKiEclnVzjWgBgyJDDAOTQAgAAACCBIgkAACCBIgkAACCBIgkAACCBIgkAACCBIgkAACCBIgkAACCh3XO3AQAOcVOmTMnGbNmyJRuzd+/epuPPPPNMdo4nn3wyG3PGGWdkY0aPzv/3OGnSpGzM9u3bszGjRjU/XjFhwoTsHDSTHBwcSQIAAEigSAIAAEigSAIAAEigSAIAAEigSAIAAEigSAIAAEigSAIAAEigSAIAAEigmSR+RVdXVzZm3759Q7CSci996Uubjn/3u9+tZTtjxozJxuQa4gGHonHjxmVjZs+e3fYc3/72t7Mxb3jDG7IxCxYsyMasXLkyGzNnzpxszK5du5qOd3d3Z+fYunVrNgYDx5EkAACABIokAACABIokAACABIokAACABIokAACABIokAACABIokAACABIokAACABJpJHmRGjWpe9/b29mbnqKtR5POe97xszNlnn52Nee9735uNmTx5ctPxs846KzvHAw88kI3ptCaaObnHg1TWPJQGmWim5PExa9asbIztpuNPPfVUdo7p06dnY775zW9mY17xildkY44++uhszOrVq7Mx48ePbzpe8jzesWNHNgYDx5EkAACABIokAACABIokAACABIokAACABIokAACABIokAACABIokAACABIokAACABJpJdohcEzVJiohsTEmzyJxFixZlYy6//PJszDnnnJONWbNmTTamu7s7G5Nz4YUXZmPe9773ZWNK9m9J47cSdfwtS+aoYzs4tPX09GRjDj/88GzM5s2bm47v2rUrO8fLXvaybMwPfvCDbExJo8gXvvCF2Zi77747GzNnzpym4zNmzMjOsWXLlmwMBi6bzW1faXuj7fv6XDfT9k22H6r+zf8FAWAYkMMAtKrkJe9Vkg48JPA+STdHxHGSbq5+B4BOdJXIYQBakC2SIuJ7kg48Bvo6SVdXl6+WdF69ywKAepDDALSq1Q9PzI6IddXl9ZJm17QeABgK5DAAWW1/cDsiwna/nyi2fZGki9rdDgAMhmY5jPwFHNpaPZK0wfZcSar+3dhfYERcERHLImJZi9sCgLoV5TDyF3Boa7VI+pqkC6rLF0j6aj3LAYAhQQ4DkJV9u832FyWdLekw22skfUjSZZKus/02SY9LeuNgLrKT1dXfqCSmxLHHHtt0/LLLLsvO8YY3vCEbs3LlymzMj3/842zM8uXLszEvetGLsjG5v8Of//mfZ+co6TNy6aWXZmM6qe/QpEmTsjGveMUrsjFf/erIrSHIYYOvpE9SSa+fKVOmtD3H3LlzszGf/OQnszElPdyuvfbabMy0adOyMdu3b286Pn369Fq2g4HLFkkRcX4/Qy+veS0AUDtyGIBWcVoSAACABIokAACABIokAACABIokAACABIokAACABIokAACABIokAACAhLbP3TZQuaZ/XV1dbc9RErNnz57sHCXqagL5ghe8IBtzzTXXZGNOPvnkpuO7d+/OznHbbbdlY0r238aN/Z6t5hfe+ta3ZmNKmlvmmtB97nOfy85xySWXZGPe9a53ZWP+/u//Phuzbt26bMzxxx+fjXn1q1/ddHzcuHHZOU488cRsTMlzDoeukgaqEydOzMZMmDCh6fisWbOyc3R3d2djNmzYUEvMmDFjsjElz+NVq1Y1HS9pFPnYY49lYzBwHEkCAABIoEgCAABIoEgCAABIoEgCAABIoEgCAABIoEgCAABIoEgCAABIoEgCAABIGPJmkrnmiz09PUO0knrkmp9J0re+9a1szFlnnZWNeeKJJ7IxX/7yl5uOlzQ/K2kUWdJEs2SeLVu2ZGNKGkGefvrpTcfPPvvs7Byf//znszEljeEuvfTSbExd7r///qbjd9xxR3aOK6+8sq7l4BC1fPnybMzSpUuzMWPHjm06Pn369OwcJU1s63LXXXdlY2bOnJmNWbt2bdPxvXv3ZucoaX6JgeNIEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQMKQNpO0rdGjm2/yL//yL7Pz5BqOSdL48eObji9atCg7x4wZM7IxRx55ZDampGHijTfeWMs8J554YtPxww8/PDvHmjVrsjElf4OFCxdmYx577LFsTMnf4cEHH2w6/oEPfCA7x6//+q9nY170ohdlY0oeW7t27crGPPzww9mYzZs3Nx0/7LDDsnOUPOfuvvvupuMlTStx8MrldUnauXNnNiaXe0455ZTsHCXPm7rcd9992ZhcTpbyTTLHjRuXnWPatGnZGAwcR5IAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAAShryZ5JgxY5rGvPKVr8zOc/TRR2dj9u3b13R89+7d2Tl6e3uzMSUNHksaB5Y0/Vu8eHE2ZuvWrU3HV65cmZ1j3rx52Zjt27dnYx544IFsTEkTutWrV2djVq1a1XS8pJnk29/+9mzMDTfckI0p2cclf++Xv/zl2Zgzzzyz6XhJ89Curq5szL/+6782Hb/nnnuyc+DgtWnTpmzMEUcckY05+eSTm46X5P677rorG1OXkhxX0qR2yZIlTccnT56cnWMo7/ehJHskyfaVtjfavq/PdRfbXmv77urnNYO7TABoDTkMQKtK3m67StI5ies/ERFLq59v1rssAKjNVSKHAWhBtkiKiO9Jan6CKADoUOQwAK1q54Pb77Z9T3UoO38GUgDoLOQwAE21WiRdLmmxpKWS1kn6WH+Bti+yfYftOyKixc0BQK2Kcljf/DWEawPQIVoqkiJiQ0Tsi4heSZ+VdGqT2CsiYllELLPd6joBoDalOaxv/hraFQLoBC0VSbbn9vn19ZLu6y8WADoNOQxAiWyTGttflHS2pMNsr5H0IUln214qKSStkvSOwVsiALSOHAagVdkiKSLOT1z9+VY2VtJM8owzzmhl6l/x4Q9/uOn4i170ouwcs2bNysZMnTo1G3PkkUfWErN3795sTO4tzZ6enuwcJTElTQpL3l4dNSp/MLNknlxTyscffzw7x6JFi7Ixf/Inf5KNGUq5z/n9xm/8RnaO66+/PhtzzDHHNB0fN25cdo7hUmcOQ1rJ86vkM6m5RrYlTRUfe+yxbExdbrvttmzMW97ylmxMLg+W5NuSxpYYOE5LAgAAkECRBAAAkECRBAAAkECRBAAAkECRBAAAkECRBAAAkECRBAAAkECRBAAAkJBtJlmniFBvb2/TmBe84AXZeZ544olszAc/+MHidfWnq6srG3PsscdmY+bPn5+NOfroo7MxRx11VDYm11Rx5syZ2TlKGpdt3rw5G1Mi93gotXPnzqbj+/bty85RErNr165sTEnTvJLmi3v27MnGTJ8+ven4ySefnJ2jpJnk3/7t3zYdr+vxgJGppCnslClTsjFjx45tOl7S6PYnP/lJNqYuDz/8cDZmwoQJ2Zjc/SrJOyX7FwPHkSQAAIAEiiQAAIAEiiQAAIAEiiQAAIAEiiQAAIAEiiQAAIAEiiQAAICEIe2T1Nvbq+7u7qYxy5cvz85T0sdn3rx52bXkbN++PRtT0ifjwQcfzMaUOP7447MxJ5xwQtPxxx57LDtHrueQNLQ9OUr+VuPHj286nusfVedaSnrGlPRkKtnHuX5Lub4zkrRt27ZsTF39rHBwKunhdthhh2Vjco/Fkn5BJflrKK1evTobM2fOnLa3U1eOw3NxJAkAACCBIgkAACCBIgkAACCBIgkAACCBIgkAACCBIgkAACCBIgkAACCBIgkAACBhyLtP2W46HhHZOTZt2tR2TK4Jn1TWQG/q1KnZmJkzZ2ZjduzYUcs8uf27aNGi7BwTJkzIxuzevTsbU9Iwsa6Ynp6epuMlj6vcvivV1dVVS0zJ/d6yZUvRmpp55plnsjFPPfVU29vBwWvWrFnZmNxzVMo3Yh2JTU1Lck9u35Tki8mTJxevCeU4kgQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJAw5M0kSxprDYWSZoglShrxlcSUWLduXS3zAECdShqfbt68ORszffr0puN1NE8datu2bcvGzJ49u+l4d3d3dg6aSQ6O7JEk2wtsf9f2/baX235Pdf1M2zfZfqj6d8bgLxcAypG/ALSj5O22Hkl/GhFLJP26pD+0vUTS+yTdHBHHSbq5+h0AOgn5C0DLskVSRKyLiLuqy92SVkiaJ+l1kq6uwq6WdN4grREAWkL+AtCOAX1w2/YiSadI+rGk2RGx/0My6yU1f1MVAIYR+QvAQBV/cNv2ZEnXS/rjiNja94zpERG2k5/Itn2RpIvaXSgAtIr8BaAVRUeSbI9RI8FcExFfqa7eYHtuNT5X0sbUbSPiiohYFhHL6lgwAAwE+QtAq0q+3WZJn5e0IiI+3mfoa5IuqC5fIOmr9S8PAFpH/gLQjpK3286Q9GZJ99q+u7ru/ZIuk3Sd7bdJelzSGwdlhQDQOvIXgJZli6SIuF2S+xl+eb3LAYD6kL+GRk9PTzZm1Kj8pzt6e3ubjo8ePeT9j9u2YcOGbMxxxx3XdHwk3u+DBaclAQAASKBIAgAASKBIAgAASKBIAgAASKBIAgAASKBIAgAASKBIAgAASKBIAgAASKBDFQBg0OUaRZZ46KGHaliJ1PcEx+2ISJ4X+TnWrl3b9nZK9t2uXbva3g5+FUeSAAAAEiiSAAAAEiiSAAAAEiiSAAAAEiiSAAAAEiiSAAAAEiiSAAAAEiiSAAAAEmgmCQBoy+jR+f9KSmJGjWr+ur2uZpK57ZTat29fNqakyWNuPePHj8/OUdLYEgPHkSQAAIAEiiQAAIAEiiQAAIAEiiQAAIAEiiQAAIAEiiQAAIAEiiQAAIAEiiQAAIAEmkkCANoyZsyYbExJA8dcw8nVq1cXr6mZ3t7ebExdDSdLGmD29PQ0HV+3bl12jgkTJhSvCeU4kgQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAnyQAQFtKegpt3749G7Nz586m44888kjxmjrF/fffn43J9UmaNWtWdo6tW7cWrwnlso9s2wtsf9f2/baX235Pdf3Fttfavrv6ec3gLxcAypG/ALSj5EhSj6Q/jYi7bE+RdKftm6qxT0TERwdveQDQFvIXgJZli6SIWCdpXXW52/YKSfMGe2EA0C7yF4B2DOiD27YXSTpF0o+rq95t+x7bV9qeUffiAKAu5C8AA1VcJNmeLOl6SX8cEVslXS5psaSlarxS+1g/t7vI9h2272h/uQAwcOQvAK0oKpJsj1EjwVwTEV+RpIjYEBH7IqJX0mclnZq6bURcERHLImJZXYsGgFLkLwCtKvl2myV9XtKKiPh4n+vn9gl7vaT76l8eALSO/AWgHSXfbjtD0psl3Wv77uq690s63/ZSSSFplaR3DML6AKAd5C8ALSv5dtvtkpwY+mb9ywGA+pC/hsbkyZOzMV1dXdmYiGg6Pnp0Pf2PS5pf1mXChAnZmKeffrrtOZ599tnSJWEAOC0JAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAQj2duQAAh6zHHnssG7Nz585szKRJk5qOb9iwoXhNzfT29mZj6mo4+cwzz2Rjxo0b13S8pFFkd3d36ZIwABxJAgAASKBIAgAASKBIAgAASKBIAgAASKBIAgAASKBIAgAASKBIAgAASKBIAgAASHBEDN3G7E2SHu9z1WGSnhqyBbRvpK1XGnlrZr2Da7DWe1REHD4I83aMRP6S+PsPNtY7uFhvQ7/5a0iLpF/ZuH1HRCwbtgUM0EhbrzTy1sx6B9dIW2+nG2n7k/UOLtY7uIZjvbzdBgAAkECRBAAAkDDcRdIVw7z9gRpp65VG3ppZ7+AaaevtdCNtf7LewcV6B9eQr3dYP5MEAADQqYb7SBIAAEBHGrYiyfY5th+0/bDt9w3XOkrZXmX7Xtt3275juNdzINtX2t5o+74+1820fZPth6p/ZwznGvvqZ70X215b7eO7bb9mONfYl+0Ftr9r+37by22/p7q+I/dxk/V27D4eSchf9SOHDS5yWIvrGI6322x3SVop6ZWS1kj6qaTzI+L+IV9MIdurJC2LiI7sKWH7JZK2SfqniDixuu5vJG2OiMuqRD4jIv5iONe5Xz/rvVjStoj46HCuLcX2XElzI+Iu21Mk3SnpPEkXqgP3cZP1vlEduo9HCvLX4CCHDS5yWGuG60jSqZIejohHI2KPpC9Jet0wreWgEBHfk7T5gKtfJ+nq6vLVajzAOkI/6+1YEbEuIu6qLndLWiFpnjp0HzdZL9pH/hoE5LDBRQ5rzXAVSfMkre7z+xp1fgIPSTfavtP2RcO9mEKzI2JddXm9pNnDuZhC77Z9T3UouyMO+x7I9iJJp0j6sUbAPj5gvdII2Mcdjvw1dDr++ZXQ8c8vclg5Prhd7syIeKGkcyX9YXWodcSIxvuqnf5VxsslLZa0VNI6SR8b1tUk2J4s6XpJfxwRW/uOdeI+Tqy34/cxBsWIzl9SZz6/Ejr++UUOG5jhKpLWSlrQ5/f51XUdKyLWVv9ulHSDGofcO92G6n3d/e/vbhzm9TQVERsiYl9E9Er6rDpsH9seo8aT9ZqI+Ep1dcfu49R6O30fjxDkr6HTsc+vlE5/fpHDBm64iqSfSjrO9tG2x0p6k6SvDdNasmxPqj44JtuTJL1K0n3Nb9URvibpguryBZK+Ooxrydr/RK28Xh20j21b0uclrYiIj/cZ6sh93N96O3kfjyDkr6HTkc+v/nTy84sc1uI6hquZZPW1vU9K6pJ0ZURcMiwLKWD7GDVefUnSaEnXdtp6bX9R0tlqnCV5g6QPSfo3SddJWqjG2cvfGBEd8UHDftZ7thqHUEPSKknv6PNe+bCyfaak2yTdK6m3uvr9arxH3nH7uMl6z1eH7uORhPxVP3LY4CKHtbgOOm4DAAD8Kj64DQAAkECRBAAAkECRBAAAkECRdJCyfZXtv64uv9j2g0O03bB9bM1z/uK+DOVtAQwfclj7t0X7KJKGkRsnndxpe5vtDdWTYXLd24mI2yLihIL1XGj79rq332f+W2y/fbDmr5vtN7lxEtMtbpzI8mrbU4d7XUCnIId1NnJY+yiSht9rI2KypBdKWibpAwcG2B495KuCJH1f0hkRMU3SMWp8fZpXdMBzkcM6FzmsTRRJHaLqiPstSfvPJh22/9D2Q5Ieqq77Ldt3237W9g9sn7T/9rZPsX2X7W7b/yJpfJ+xs22v6fP7Attfsb3J9tO2/8728yV9RtLp1avCZ6vYcbY/avuJ6pXiZ2xP6DPXe22vs/2k7T9o9f7b/rLt9dUrnu/ZfsEBIYfZvqm6f7faPqrPbZ9XjW2uXjW9sdV19BURqw84a/o+SbUehgcOFuQwctjBiCKpQ9heIOk1kn7W5+rzJJ0maYntUyRdKekdkmZJ+gdJX6sSwFg1mq79s6SZkr4s6Q39bKdL0tfVaBq2SI0Tc34pIlZIeqekH0bE5IiYXt3kMknHq9G869gq/q+quc6R9GeSXinpOEmvaGMXfKua4whJd0m65oDx35f0YTUat929f9yNDsI3Sbq2uu2bJH3a9pLcBm0vrJL1wiYxZ9reIqlbjX36yQHdK+AQQQ4jhx2UIoKfYfpRo1voNknPqvGE/7SkCdVYSHpZn9jLJX34gNs/KOksSS+R9KSq5qDV2A8k/XV1+WxJa6rLp0vaJGl0Yj0XSrq9z++WtF3S4j7XnS7pserylZIu6zN2fLXuY/u5v7dIenvBfplezTOt+v0qNZLg/vHJarwiWiDpdyXddsDt/0HSh/rc9q9r+FvNk3SxpOOH+3HDDz+d8kMO63e/kMMOkh/eJx5+50XEf/QztrrP5aMkXWD7j/pcN1bSkWo8GddG9UyoPN7PnAskPR4RPQVrO1zSREl32t5/ndU4FYOqbd9ZsM2mqleGl0j6b9U297egP0zSluryL/ZFRGyzvbna/lGSTtt/aL0yWo1XpLWJiLW2vy3pS2p89gJAAzmMHHbQokjqbH0TxmpJl0TinEu2z5I0z7b7JJmFkh5JzLla0kLboxNJ5sBz1DwlaaekF0R1FvEDrNNzz4be7yHfjN+T9Do1DnWvkjRN0jNqJLP9frEdN749M1ONV56rJd0aEa9scdsDMVrS4iHYDnCwIIf9EjlsBOIzSSPHZyW90/Zpbphk+zfdOLv3DyX1SPpftsfY/h1Jp/Yzz0/USAyXVXOMt31GNbZB0vzq8wGKiN5qu5+wfYQk2Z5n+9VV/HWSLrS9xPZENU7wmDO62ub+nzGSpkjaLelpNV71/d/E7V5Tvbc+Vo339X8UEavV+GzC8bbfXN33MbZfVH2Isy22f3//e/3VhywvkXRzu/MChyhyGDlsxKFIGiEi4g5J/0PS36nxCuVhNd5/V0TskfQ71e+b1XiP+yv9zLNP0mvV+ADjE5LWVPGS9J+Slktab3v/NyL+otrWj2xvlfQfkk6o5vqWGh8C/M8q5j8L7srlaryy2//zj5L+SY3D3Gsl3S/pR4nbXatGAtss6dck/fdqDd2SXqXGhx2flLRe0kckjcstpPrQ47YmH3pcIukHtrer8VXaB9X4GwAYIHIYOWwk8nPfAgYAAIDEkSQAAIAkiiQAAIAEiiQAAIAEiiQAAIAEiiQUs32x7S/UPOciN87xNOCeXe3cFsChhfyFVlAkjSC2b7H9jO3sV0Or+Att3z7Y66q29ZwTUI4Etr/rxgkyt9r+ue3XDfeagIMV+ate5K+hQZE0QtheJOnFanSU/e3hXc1B4z2S5kbEVEkXSfqC7bnDvCbgoEP+GhTkryFAkTRyvEWNBmVXSbqg74DtBba/Ur2qeNr231XdWj8j6fSq2dizVewttt/e57bPebVm+1O2V1evTu60/eJ2F1511f1ZNedq2xcnwv7A9pO219n+sz63HWX7fbYfqe7bdbZntrsmSYqIe/qc1iAkjdFzT1EAoB7kL/LXiESRNHK8RdI11c+rbc+WfnFixa+r0e11kRpnev5SRKyQ9E5JP4yIyRExvXA7P5W0VI3zCl0r6cu2x7e59u3V+qdL+k1J/9P2eQfEvFTScWp0nv0L26+orv8jSeepcabwI9Xo1Pv3JRu1/Wnbn87EfN32Lkk/VuMM33eUzA1gQMhf5K8RiSJpBLB9phpnir4uIu5U46SPv1cNn6rGk++9EbE9InZFRMvv40fEFyLi6YjoiYiPqdEa/4R21h8Rt0TEvRHRGxH3SPqiGkmjr/9drf9eNdr8n19d/05JfxkRayJit6SLJf3Xkg87RsS7IuJdmZjfUuO8S6+RdGN1ricANSF/kb9GMoqkkeECNZ4A+89FdK1+ech6gaTHE2fDbontP7O9wvaW6hD3NEmHtTnnaX0+ZLhFjcRx4Jyr+1x+XI3EKTWS6w22n63Ws0LSPkmz21lTXxGxtzqH06ts83kJoF7kL/LXiMVXDzuc7QmS3iipy/b66upxkqbbPlmNJ+dC26MTiSZ1Yr7tapyler85fbb1Ykl/LunlkpZHRK/tZyS5zbtxrRontTw3InbZ/qR+NckskPRAdXmhGid6lBr37w8i4vsHTlp9GLROoyUtrnlO4JBF/iJ/jXQcSep856nxymOJGu+1L5X0fEm3qfE++U8krZN0me1JtsfbPqO67QZJ822P7TPf3ZJ+x/ZE28dKelufsSmSeiRtkjTa9l9JmjqQxVbb7/vjat7NVYI5Vb881N7XB6s1vUDSWyX9S3X9ZyRdYvuoav7DXcNXXW0/z/a5tifYHmP7v0t6iaRb250bwC+cJ/IX+WsEo0jqfBdI+seIeCIi1u//UeOVze+r8SrptZKOlfSEpDWSfre67X9KWi5pve39h7o/IWmPGgnoajU+SLnfdyR9W9JKNQ4Z79JzDyPnzJO084CfxZLeJen/2O6W9FeSrkvc9lZJD0u6WdJHI+LG6vpPSfqapBur2/9I0mkli7H9Gduf6W9Yjc8HbFQjqb5H0u9GxF0lcwMoQv4if41ojkgd0QQAADi0cSQJAAAggSIJAAAggSIJAAAggSIJAAAggSIJAAAgoa1mkrbPUeMrjl2SPhcRl2XiD7qv0o0ala8zp02blo2ZPn16Nmbfvn3ZmCeeeCIbcyg69thjszF79+7NxmzatCkbs2PHjqI1HWwiot2mfUNuIDnsYMxfABr6y18ttwCoTky4UtIr1eht8VNJ50fE/U1uM2RJptEDrPVxSertzZ8GZ8qUKdmYc845Jxvz27+d7yZf8p/vO97xjmzMoejf//3fszHr1q3Lxnzuc5/LxvzkJz8pWlNOyWO0k1p4jLQiaaA5jCIJOHj1l7/aebvtVEkPR8SjEbFH0pcktd1JFACGCDkMQFPtFEnz9Nxupmuq6wBgJCCHAWhq0E9wa/siSRcN9nYAoG7kL+DQ1k6RtFaNMx/vN7+67jki4gpJV0i8pw+go2RzGPkLOLS183bbTyUdZ/vo6izNb1LjRH4AMBKQwwA01fKRpIjosf1uNc683CXpyohYXtvKAGAQkcMA5LTcAqCljQ3h4equrq6m4yU9h5YsWZKN+fjHP56NGTduXDZm165d2ZgxY8ZkY+bPn990/LbbbsvOcdddd2VjNm/enI3ZunVrNubwww/Pxpx77rnZmBNPPLHp+Pr167NzlCj5W5Z8df9lL3tZNqakb1OuT1dJG4u6jLQWAAPF223AwWswWgAAAAActCiSAAAAEiiSAAAAEiiSAAAAEiiSAAAAEiiSAAAAEiiSAAAAEiiSAAAAEg7aZpJ1+H//7/9lY0466aRszFNPPZWNmThxYjampAFmHdsZP358NubZZ5/NxuzcuTMbU9KcsWTNO3bsaDqea7ooST09PdmYkudLSYPMr3/969mYSy+9NBszenTzpvkl96kuNJMEMFLRTBIAAGAAKJIAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAASmneiO8TNmTMnG9Pb25uNyTX8kyQ734dvzJgx2Zi9e/c2Hd+9e3d2jlxjRknavHlzNmbChAnZmLFjx9aynpJ9U4eSv/eePXuyMfPnz69jOUPaLBIADjUcSQIAAEigSAIAAEigSAIAAEigSAIAAEigSAIAAEigSAIAAEigSAIAAEg4ZPskjRs3Lhszfvz4bExJf6NRo/K1aHd3dzZm6tSp2Zhc36GSPj8l/Y2mTZuWjenq6srGlCjppZTrF1TydyrpZ1USs3PnzmxMSQ8uAMDw4kgSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAwiHbTHLBggXZmIkTJ9ayrZJmiCXNJHft2pWNyTWuLFnL7t27szEljTa3b9+ejYmIbExJA8dc48qSxpYlDUZL1luy/0oeWyX7uOQxAQBoTVtFku1Vkrol7ZPUExHL6lgUAAwFchiAZuo4kvTSiHiqhnkAYDiQwwAk8ZkkAACAhHaLpJB0o+07bV9Ux4IAYAiRwwD0q923286MiLW2j5B0k+0HIuJ7fQOqxEPyAdCJmuYw8hdwaGvrSFJErK3+3SjpBkmnJmKuiIhlfCASQKfJ5TDyF3Boa7lIsj3J9pT9lyW9StJ9dS0MAAYTOQxATjtvt82WdIPt/fNcGxHfrmVVADD4yGEAmmq5SIqIRyWdXONahtQxxxyTjamSZ1M9PT3ZmJkzZ2ZjNm7cmI0psW/fvqbjJc0HS+733r17i9fUzJ49e7IxdTRnLGkU2dvbm40ZM2ZMNqZEyTxz5szJxqxataqG1RyaRnoOAzD4aAEAAACQQJEEAACQQJEEAACQQJEEAACQQJEEAACQQJEEAACQQJEEAACQQJEEAACQ0O4JbkesI488MhtT0lSxpDnj7NmzszElzQVHjWq/pi25TyXbKWmi2dXVVUtMRLS9npKmldOnT8/GlOy/EiX3+4QTTsjG0EwSAAYPR5IAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAASDtlmkpMnT87G1NUMcezYsdmYkiaF+/btq2U9dRg9Ov/Q2blzZzampIlmSePKcePGtT1HyX0qWW/J37K3tzcbc/zxx2djvvOd72RjAACt4UgSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAs0k21TSvDEisjElTQpLmh3mGk6OGpWvi0saHQ5lE82SmNw+Llnvnj17sjETJkzIxpTs45L7tHjx4mwMcDDJPS9Kcmkd+WIkGon3+61vfWvT8b1792bn+MIXvlDXcpI4kgQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJCQ7U5o+0pJvyVpY0ScWF03U9K/SFokaZWkN0bEM4O3zPrNmTMnG1PSFLCu5lxDNU9Jw7GSppUlTb5K7lOu+WXpPLmYkjl27dqVjTnmmGOyMevXr8/GlNxvmknW42DNYSNNST7NqSMXSGV5sKRx7M6dO2tZTx2GslHktGnTsjGvfe1rszGnnnpq0/HnP//52TlWr16djbn11luzMf0pedReJemcA657n6SbI+I4STdXvwNAJ7pK5DAALcgWSRHxPUmbD7j6dZKuri5fLem8epcFAPUghwFoVavHP2dHxLrq8npJs2taDwAMBXIYgKy2T3AbEWG73zdDbV8k6aJ2twMAg6FZDiN/AYe2Vo8kbbA9V5Kqfzf2FxgRV0TEsohY1uK2AKBuRTmM/AUc2lotkr4m6YLq8gWSvlrPcgBgSJDDAGRliyTbX5T0Q0kn2F5j+22SLpP0StsPSXpF9TsAdBxyGIBWZT+TFBHn9zP08prXMqRmz67nc5pjxoypZZ7e3t5a5sn1Iunq6mp7Dqmsz0hdSvo25f4OPT092TlK7tPEiRNrmadkPYsWLcrGIO9gzWF1KHmslsSU5K+6clzOzJkzszGTJ0/Oxmzfvj0bc/jhh9cS093d3XT80Ucfzc6xcOHCbMyv/dqvZWOWLFmSjTnyyCOzMbNmzcrG5PrtlTxmSv6W7aDjNgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQELbJ7gdqebOnVvLPCWNF0tiSppSRvR7HuHimHHjxmXn2LFjRzampCllyXrramaXa85Y0pBy165d2ZiSeepqtDl+/PhsTO7vuXv37lrWgobc37bkMT9USh6HdeSUUiXPnWnTpjUdL8nbuQaFkrRt27ZszL59+7IxRx11VDZm3rx52Zg9e/Y0Hf/IRz6SnWP16tXZmNz+lcqaQG7ZsiUbc//997e9rQcffDA7xze+8Y1sTDs4kgQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBwyDaTnDp1ajZm+/bt2ZiSRpETJ06sZZ6SZmy55oFD2eyu5D6VrCfXKFKSxo4d23S8t7c3O0dJQ8+SBo91NdEsWfOCBQuajj/88MPZOVAu97ctecyX/F3rUPI4LMkpz3ve82qZ58knn8zGbN26ten4I488kp2jroa5hx9+eDYmt16prIHj/Pnzm46XrPfII4/MxpTk0ttvvz0bc+mll2ZjSpx88slNxydMmFDLdtrBkSQAAIAEiiQAAIAEiiQAAIAEiiQAAIAEiiQAAIAEiiQAAIAEiiQAAIAEiiQAAICEg7aZZK7pX0mTqp07d2ZjShoQljT027ZtWzZm1qxZ2ZhcU7eurq7sHCX3ae/evdmYksZ6JevZt29fNibXJK2koWdJo7WSx0TJektiShpOHnXUUU3HaSY5tEoaRZY85nPPnZLHasnz+KSTTsrGzJkzJxuzYsWKbMzGjRuzMbkcd+GFF2bnKLlPJfng+9//fjbmBz/4QTYm9xyVpCeeeKLp+L/9279l51i8eHE25t///d+zMffdd182pi4///nPh2xbreJIEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQAJFEgAAQEK2maTtKyX9lqSNEXFidd3Fkv6HpE1V2Psj4puDtchW5Bqg1dVUsaThX0njyilTpmRjSho45prZDWWDx5J9UxJT8nfIKfkbrF69OhuzYcOGbMzs2bOzMY8++mg2pqRh4MyZM7Mxh7o6c1ju8RoR2fXU1Ww0p+Qxf8cdd7S9nVJvfetbszHnnXde0/G/+Zu/yc7xqU99KhtT0iDzT/7kT7Ixp59+ejampDljrvnx1KlTs3Ps2rWrlrXguUqOJF0l6ZzE9Z+IiKXVT0cVSADQx1UihwFoQbZIiojvSdo8BGsBgNqRwwC0qp3PJL3b9j22r7Q9o7YVAcDQIIcBaKrVIulySYslLZW0TtLH+gu0fZHtO2wP3ZvfANBcUQ4jfwGHtpaKpIjYEBH7IqJX0mclndok9oqIWBYRy1pdJADUqTSHkb+AQ1tLRZLtuX1+fb0kPjIPYMQghwEoUdIC4IuSzpZ0mO01kj4k6WzbSyWFpFWS3jF4SwSA1pHDALQqWyRFxPmJqz8/CGsBgNqRwwC0KlskjVS5hn51NGuTpNGj87uwu7s7G1PSMLGkUV2umWTJekuaGJY0gSxpXFmijvtdst6xY8dmYyZNmpSN2bJlSzZm9+7d2ZiS+33EEUdkY1CP8ePHa9GiRU1jli5dmp3n6aefzsbkGseW5IuTTjopG7Ny5cpszLZt27IxZ5xxRjbmwx/+cDZm3LhxTcf37NmTneOwww7LxpQ0Xrz22muzMR/4wAeyMaeddlo2JtfIdv78+dk5cvtOKsspdc1Tkv9zuXLixInZOUpy6ec+97mW5+C0JAAAAAkUSQAAAAkUSQAAAAkUSQAAAAkUSQAAAAkUSQAAAAkUSQAAAAkUSQAAAAkHbTPJmTNnNh0vaZjY1dWVjSlpzphrdCiVNd7asWNH2+spuU8l6y1pxlmyrRIl+6akuVkdc0yePDkbU3K/Sx5/JY3zco9z1Cv3/Bo/fnx2jpK/fe6xWLKdksfhkiVLsjElzfpyzS8l6fzzU43Pn+uFL3xh0/GSZp11NWpdt25dNuYjH/lINqbk713HHCX5YurUqdmYkvxf8n9RyeNvwoQJ2Zic4447Lhtz5JFHNh1fs2ZNv2McSQIAAEigSAIAAEigSAIAAEigSAIAAEigSAIAAEigSAIAAEigSAIAAEg4aPskTZs2rel4SZ+fkphJkyZlY7Zs2ZKNmT59ejampCdTrqdQyRy2szFjxozJxpQo6Vcybty4bEx3d3fT8ZL7VNKP6ZlnnsnGlOybkh4iJY+/uv4OyNu7d6/Wrl3bNGbu3LnZeRYuXJiNyT3m77nnnuwcq1evzsZs2rQpG5PLpZK0efPmbExJjjvssMOajt94443ZOWbMmJGNKVHy3Crp81PSd2js2LFNx0t6IJWstyQPlvS8Wrx4cTbm2GOPzcbceuutTcdL+jrl9p0kHXPMMU3Hmz0POJIEAACQQJEEAACQQJEEAACQQJEEAACQQJEEAACQQJEEAACQQJEEAACQQJEEAACQcNA2k5w8eXLT8ZJmfiWNDnft2pWNefrpp7Mx8+fPr2VbPT09bY1LZU3JShodlihpblnyd8j9PUsapOUeM5KyzQSlsoaCJU3dSh6jO3bsyMagHvv27cs2E73pppuy84wfPz4bs2jRoqbjRxxxRHaOBQsWZGPmzZuXjfmN3/iNbMzjjz+ejSkxe/bspuNr1qzJzlGyf7dt25aNKclNJY0MS/J/rillSdPKXENdqaw549atW7MxJTl59+7d2ZhZs2Y1Ha+rmWQu/ze7PxxJAgAASKBIAgAASKBIAgAASKBIAgAASKBIAgAASKBIAgAASKBIAgAASKBIAgAASDhom0mOGtW8/itpLljSzO+pp57KxpQ01SrZVm9vbzYm16SwpFFkyb4paSZWsq2Shm179uzJxuT+3iX7bsqUKdmYjRs3ZmNKmkmWNECrq9EmOktJU9gHHnigrfE6feMb3xiybQGdJnskyfYC29+1fb/t5bbfU10/0/ZNth+q/p0x+MsFgHLkLwDtKHm7rUfSn0bEEkm/LukPbS+R9D5JN0fEcZJurn4HgE5C/gLQsmyRFBHrIuKu6nK3pBWS5kl6naSrq7CrJZ03SGsEgJaQvwC0Y0Af3La9SNIpkn4saXZErKuG1ktqfmZCABhG5C8AA1X8wW3bkyVdL+mPI2Jr3w8IR0TYTn6C1PZFki5qd6EA0CryF4BWFB1Jsj1GjQRzTUR8pbp6g+251fhcScmv/UTEFRGxLCKW1bFgABgI8heAVpV8u82SPi9pRUR8vM/Q1yRdUF2+QNJX618eALSO/AWgHSVvt50h6c2S7rV9d3Xd+yVdJuk622+T9LikNw7KCgGgdeQvAC3LFkkRcbuk/joUvrze5dRn3LhxTcdLmguWNHhct25dNmbHjh3ZmJLmgrmGiVK+EWTJ/S5pYliyb0qaUpZsK9cgsyRm37592Tlmz85/dvemm27KxixatCgbM3Xq1GxMT09PNqbkfh3KRmr+AtAZOC0JAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAAkUSAABAQvEJbkeaiRMnNh3fvn17do6ZM2dmYzZs2FC8pmZyzS8lac+ePdmYXFPFkgaFJQ0eS5Q0nIxInlf0OUoabebuV8n9njFjRjZm5cqV2ZiNG5OnAXuOkn1c0oSUZpIAMHg4kgQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBAkQQAAJBw0DaTHDNmTNPx3t7etueQpE2bNmVjnn322WzM5MmTszElcmsuaapYcr937dqVjck19JTK/g4lTSlz8+SabJZu5+mnn87GPPXUU9mYOXPmZGNK0EwSAAYPR5IAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAASKJIAAAASDtpmkpMmTWo6PmpUvj4saUD4zDPPZGNWrlyZjVm3bl02pmTNuaaKJc0k62q0uWPHjmzM+PHjszF1/K1K7ndJE8iSx8Rjjz2WjVm0aFE2pqRhZ0lzSwBAaziSBAAAkECRBAAAkECRBAAAkECRBAAAkECRBAAAkECRBAAAkECRBAAAkHDQ9kmKiKbje/fuzc5R0ltn+/bt2ZgNGzZkYyZOnJiNKekplDN6dP5PPmHChGxMrg+VlP8bSPXcJ0nq6upqOj527NhatrN8+fJszMyZM7MxL3nJS7IxJf2h6rpfAIBflc3CthfY/q7t+20vt/2e6vqLba+1fXf185rBXy4AlCN/AWhHyZGkHkl/GhF32Z4i6U7bN1Vjn4iIjw7e8gCgLeQvAC3LFkkRsU7Suupyt+0VkuYN9sIAoF3kLwDtGNAHt20vknSKpB9XV73b9j22r7Q9o+7FAUBdyF8ABqq4SLI9WdL1kv44IrZKulzSYklL1Xil9rF+bneR7Tts39H+cgFg4MhfAFpRVCTZHqNGgrkmIr4iSRGxISL2RUSvpM9KOjV124i4IiKWRcSyuhYNAKXIXwBaVfLtNkv6vKQVEfHxPtfP7RP2ekn31b88AGgd+QtAO0q+3XaGpDdLutf23dV175d0vu2lkkLSKknvGIT1AUA7yF8AWlby7bbbJTkx9M36l1OfRx99tOn4ueeem52jpMHj1KlTszE///nPszE/+9nPsjF79uzJxkyZMqXpeEmDzO7u7mxMiTFjxmRjtm3blo3ZsmVLNia3bx566KHsHF/+8pezMY888kg25uyzz87GlDxudu/enY259957szGHspGavwB0Bk5LAgAAkECRBAAAkECRBAAAkECRBAAAkECRBAAAkECRBAAAkECRBAAAkECRBAAAkOCIGLqN2UO3sYzXv/712ZhRo/I15PXXX1/HcnAQmTEjf0L58847LxtT0vjzn//5n0uWNCQiItW08aDRSfkLQL36y18cSQIAAEigSAIAAEigSAIAAEigSAIAAEigSAIAAEigSAIAAEigSAIAAEigSAIAAEgY6maSmyQ93ueqwyQ9NWQLaN9IW6808tbMegfXYK33qIg4fBDm7RiJ/CXx9x9srHdwsd6GfvPXkBZJv7Jx+46IWDZsCxigkbZeaeStmfUOrpG23k430vYn6x1crHdwDcd6ebsNAAAggSIJAAAgYbiLpCuGefsDNdLWK428NbPewTXS1tvpRtr+ZL2Di/UOriFf77B+JgkAAKBTDfeRJAAAgI40bEWS7XNsP2j7YdvvG651lLK9yva9tu+2fcdwr+dAtq+0vdH2fX2um2n7JtsPVf/OGM419tXPei+2vbbax3fbfs1wrrEv2wtsf9f2/baX235PdX1H7uMm6+3YfTySkL/qRw4bXOSwFtcxHG+32e6StFLSKyWtkfRTSedHxP1DvphCtldJWhYRHdlTwvZLJG2T9E8RcWJ13d9I2hwRl1WJfEZE/MVwrnO/ftZ7saRtEfHR4Vxbiu25kuZGxF22p0i6U9J5ki5UB+7jJut9ozp0H48U5K/BQQ4bXOSw1gzXkaRTJT0cEY9GxB5JX5L0umFay0EhIr4nafMBV79O0tXV5avVeIB1hH7W27EiYl1E3FVd7pa0QtI8deg+brJetI/8NQjIYYOLHNaa4SqS5kla3ef3Ner8BB6SbrR9p+2LhnsxhWZHxLrq8npJs4dzMYXebfue6lB2Rxz2PZDtRZJOkfRjjYB9fMB6pRGwjzsc+WvodPzzK6Hjn1/ksHJ8cLvcmRHxQknnSvrD6lDriBGN91U7/auMl0taLGmppHWSPjasq0mwPVnS9ZL+OCK29h3rxH2cWG/H72MMihGdv6TOfH4ldPzzixw2MMNVJK2VtKDP7/Or6zpWRKyt/t0o6QY1Drl3ug3V+7r739/dOMzraSoiNkTEvojolfRZddg+tj1GjSfrNRHxlerqjt3HqfV2+j4eIchfQ6djn18pnf78IocN3HAVST+VdJzto22PlfQmSV8bprVk2Z5UfXBMtidJepWk+5rfqiN8TdIF1eULJH11GNeStf+JWnm9Omgf27akz0taEREf7zPUkfu4v/V28j4eQchfQ6cjn1/96eTnFzmsxXUMVzPJ6mt7n5TUJenKiLhkWBZSwPYxarz6kqTRkq7ttPXa/qKks9U4S/IGSR+S9G+SrpO0UI2zl78xIjrig4b9rPdsNQ6hhqRVkt7R573yYWX7TEm3SbpXUm919fvVeI+84/Zxk/Werw7dxyMJ+at+5LDBRQ5rcR103AYAAPhVfHAbAAAggSIJAAAggSIJAAAggSIJAAAggSIJAAAggSIJAAAggSIJAAAggSIJAAAg4f8HgHC/K80NSr0AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 720x720 with 4 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "start_time = time.time()\n",
+    "correct = []\n",
+    "for i in range(len(y_test)):\n",
+    "    if(Y_pred_classes[i] == Y_true[i]):\n",
+    "        correct.append(i)\n",
+    "    if(len(correct) == 4):\n",
+    "        break\n",
+    "        \n",
+    "\n",
+    "fig, ax = plt.subplots(2,2, figsize=(12,6))\n",
+    "fig.set_size_inches(10,10)\n",
+    "ax[0,0].imshow(x_test[correct[0]].reshape(28,28), cmap='gray')\n",
+    "ax[0,0].set_title(\"Predicted Label : \" + str(clothing2[Y_pred_classes[correct[0]]]) + \"\\n\"+\"Actual Label : \" + \n",
+    "                 str(clothing2[Y_true[correct[0]]]))\n",
+    "ax[0,1].imshow(x_test[correct[1]].reshape(28,28), cmap='gray')\n",
+    "ax[0,1].set_title(\"Predicted Label : \" + str(clothing2[Y_pred_classes[correct[1]]]) + \"\\n\"+\"Actual Label : \" + \n",
+    "                 str(clothing2[Y_true[correct[1]]]))\n",
+    "ax[1,0].imshow(x_test[correct[2]].reshape(28,28), cmap='gray')\n",
+    "ax[1,0].set_title(\"Predicted Label : \" + str(clothing2[Y_pred_classes[correct[2]]]) + \"\\n\"+\"Actual Label : \" + \n",
+    "                 str(clothing2[Y_true[correct[2]]]))\n",
+    "ax[1,1].imshow(x_test[correct[3]].reshape(28,28), cmap='gray')\n",
+    "ax[1,1].set_title(\"Predicted Label : \" + str(clothing2[Y_pred_classes[correct[3]]]) + \"\\n\"+\"Actual Label : \" + \n",
+    "                 str(clothing2[Y_true[correct[3]]]))\n",
+    "\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "great-occupation",
+   "metadata": {
+    "papermill": {
+     "duration": 0.08927,
+     "end_time": "2021-04-26T04:14:23.769279",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:23.680009",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Incorrectly Predicted Classes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "english-circle",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:23.996077Z",
+     "iopub.status.busy": "2021-04-26T04:14:23.994474Z",
+     "iopub.status.idle": "2021-04-26T04:14:24.417837Z",
+     "shell.execute_reply": "2021-04-26T04:14:24.417086Z"
+    },
+    "papermill": {
+     "duration": 0.55502,
+     "end_time": "2021-04-26T04:14:24.417966",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:23.862946",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.08302950859069824 seconds ---\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkkAAAJeCAYAAACgU5EXAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAABJlklEQVR4nO3de5ycdZXn8e9J0rl3bsSEEDoJEAQjM1yMIAs6cRkdQF2QHRnRcWDVAcfL6ngZXWdRZtRddl5e5+UIwoowK+iAwoC3UUZUdLxxMXKVq8Ek5B6SdK6d7j77x/O0VsKv6/xS9XR3Vfrzfr36le56Tv2eU09XnZx6qvqUubsAAACwrzEjnQAAAEArokkCAABIoEkCAABIoEkCAABIoEkCAABIoEkCAABIoEk6iJnZtWb20fL7F5vZI8O0XzezxRWv+bvbMpzXBTAyqF/NXxfNo0kaYWa2wsx2mdl2M1tXPiCmVr0fd/+Rux+Tkc9FZvbjqvdfs/4PzOzNQ7V+1crj0Vf+fga+lo10XkAroH61NupX82iSWsOr3H2qpJMkLZX0P/cPMLNxw54VBvzU3afWfP1gpBMCWgj1q7VRv5pAk9RC3H21pG9LOk763Wnft5nZY5IeKy97pZktN7MtZvYTM/vDgeub2Ylmdq+ZdZvZv0iaWLNtmZmtqvm5y8xuNrMNZrbJzD5rZs+TdKWkU8tnHFvK2Alm9nEz+235bPFKM5tUs9b7zGyNmT1tZm9s9Pab2U1mttbMtprZnWb2/P1CZpvZ7eXt+6GZLay57rHlts1m9oiZnd9oHgAOHPWL+nUwoklqIWbWJelsSb+sufhcSadIWmJmJ0q6RtIlkg6R9HlJt5VFYLykf5X0/yTNknSTpP86yH7GSvqGpKckLZI0X9JX3P1hSW/R7595zCivcrmk50o6QdLiMv5D5VpnSnqvpJdJOlrSHzdxCL5drjFH0r2Srt9v++slfUTSbEnLB7ab2RRJt0u6obzuayV9zsyWRDs0swVlwV5QJ+xEM9toZo+a2aU8KwaejfpF/ToouTtfI/glaYWk7ZK2qHjQf07SpHKbS/rPNbFXSPrIftd/RNIfSXqJpKclWc22n0j6aPn9Mkmryu9PlbRB0rhEPhdJ+nHNzyZph6Sjai47VdJvyu+vkXR5zbbnlnkvHuT2/kDSmzOOy4xynenlz9eqKIQD26dK6pPUJenPJP1ov+t/XtKHa6770QZ/P0dKOkLFE4o/kPSQpP8x0vcbvvhqhS/q16DHhfp1kHzRUbaGc9393wfZtrLm+4WSLjSzd9RcNl7SYSoekKu9fGSUnhpkzS5JT7l7b0Zuz5E0WdI9ZjZwmUkaW35/mKR7MvZZV/ns8GOSXlPus7/cNFvS1vL73x0Ld99uZpvL/S+UdMrA6fXSOBXPSpvi7k/W/Hi/mf29pPdJ+t/Nrg0cJKhf1K+DFk1S66stGislfczdP7Z/kJn9kaT5ZmY1hWaBpCcSa66UtMDMxiUKje/380ZJuyQ934v3HOxvjYqiNaDead96XifpHBWnu1dImi7pGRUFbcDv9mPFX9DMUvHsc6WkH7r7yxrc94Hw/XICMDjq1+9Rv9oQ70lqL1dLeouZnWKFKWb2CjPrlPRTSb2S/ruZdZjZeZJOHmSdX6goDpeXa0w0s9PKbeskHV6+R0Du3l/u91NmNkeSzGy+mf1JGX+jpIvMbImZTZb04YzbMa7c58BXh6ROSXskbVLxzO9/Ja53tpmdXub2EUk/c/eVKt6f8Fwze0N52zvM7IXlGzmbYmZnmdnc8vtjJV0q6dZm1wVGIeoX9avt0CS1EXe/W9JfSvqsimcpj6t4DV7u3iPpvPLnzSpe5755kHX6JL1KxZsYfytpVRkvSXdIelDSWjPbWF72/nJfPzOzbZL+XdIx5VrflvTp8nqPl/9GrlDx7G7g64uS/lnFqe7VKl43/1niejeoKGKbJb1A0p+XOXRLermKNzw+LWmtpP8jaUKUSPnGx+113vh4hqT7zGyHpG+pOKapAgigDuoX9asd2b4vAQMAAEDiTBIAAEASTRIAAEACTRIAAEACTRIAAEACTRKymdllZvalitdcZMVnPB3wzK5mrgtgdKF+oRE0SW3EzH5gZs+YWfinoWX8RWb246HOq9zXPh9A2U7M7I/KYvXRkc4FOFhRv4YG9Wto0SS1CTNbJOnFKiam/peRzebgUQ6C+4ykn490LsDBivo1NKhfQ48mqX38hYoBZddKurB2g5l1mdnNZrbBzDaZ2WfLaa1XSjq1HDa2pYz9gZm9uea6+zxbM7PPmNlKM9tmZveY2YubTbycqvvLcs2VZnZZIuyNZva0ma0xs/fWXHeMmX3AzJ4ob9uNZjar2ZxqvEfSdyX9usI1AeyL+kX9aks0Se3jLyRdX379Sc2o+bEqxto/JWmRpPkqPm36YUlvkfRTd5/q7jMy93OXpBNUfK7QDZJuMrOJTea+o8x/hqRXSPorMzt3v5iXSjpaxeTZ95vZH5eXv0PSuSo+KfwwFZN6/ylnp2b2OTP7XJ3tCyW9UdLfZ94OAI2hflG/2hJNUhsws9NVfFL0je5+j4oPfXxduflkFQ++97n7Dnff7e4Nv47v7l9y903u3uvun1AxGv+YZvJ39x+4+/3u3u/u90n6soqiUevvyvzvVzHm/4Ly8rdI+lt3X+XueyRdJulPc97s6O5vdfe31gn5R0mXuvv2A71NAPJQv6hf7YwmqT1cKOm77j7wWUQ36PenrLskPZX4NOyGmNl7zexhM9tanuKeLml2k2ueYmbfL0+nb1VROPZfc2XN90+pKJxSUVxvMbMtZT4PS+qTNLfJnF4lqdPd/6WZdQCEqF/Ur7bFnx62ODObJOl8SWPNbG158QRJM8zseBUPzgVmNi5RaFIfzLdDxadUDzi0Zl8vlvQ3Kj4U8UF37zezZyRZkzfjBhUfanmWu+82s0/r2UWmS79/XX2Big96lIrb90Z3/4/9Fy3fDNqoMyQtrTmm0yX1mdkfuPs5TawLoET9on61O84ktb5zVTzzWKLitfYTJD1P0o9UvE7+C0lrJF1uZlPMbKKZnVZed52kw81sfM16yyWdZ2aTzWyxpDfVbOuU1Ctpg6RxZvYhSdMOJNly/7VfVq67uSwwJ+v3p9prXVrm9HxJ/03SwDOkKyV9rHz9XWb2HDOroghcKum5+v0xvU3S1eW+AVTjXFG/qF9tjCap9V0o6Yvu/lt3XzvwpeKZzetVPEt6laTFkn4raZWkPyuve4ekByWtNbOBU92fktSjogBdp+KNlAO+I+nfJD2q4pTxbu17GjkyX9Ku/b6OkvRWSX9vZt2SPiTpxsR1fyjpcUnfk/Rxd/9ueflnVBSA75bX/5mkU3KSMbMrzezK1DZ3797veO6StMPdN+fdVAAZqF/Ur7Zm7qkzmgAAAKMbZ5IAAAASaJIAAAASaJIAAAASaJIAAAASaJIAAAAShnWYpJnxp3RtoLOzM4yZMGFCGJPzl5Pbtm0LY/bu3RvGYOS5e7ND+1oa9Qs4eA1Wv5pqkszsTBVzIMZK+r/ufnkz66G+sWPHhjF9fX1N7+eUU+IxHkcccUQY09PTE8bccccdYczKlQcy6iStqmNXzJarj7Ea7YMaBqCehl9uKz+9+Z8knaVimuoFZrakqsQAYChRwwBEmnlP0smSHnf3J929R9JXJPGZMQDaBTUMQF3NNEnzte/I91XlZQDQDqhhAOoa8jdum9nFki4e6v0AQNWoX8Do1kyTtFpSV83Ph5eX7cPdr5J0lcRfhwBoKWENo34Bo1szL7fdJeloMzvCzMZLeq2KTzsGgHZADQNQlzXz58pmdrakT6v489lr3P1jQTzPxAZR1Z+oL126tO72v/mbvwnXWL36WScEn+XRRx8NY3IsWRL/MdG4cfEJz7/6q79qOpfhGrFwsGrHOUkHUsOoX8DBa0jmJLn7tyR9q5k1AGCkUMMA1MPHkgAAACTQJAEAACTQJAEAACTQJAEAACTQJAEAACTQJAEAACTQJAEAACQ0NUzygHc2Soex5QxD7O3tDWOOO+64MOYzn/lM3e2XXnppuMZPfvKTMGY4veY1rwljzjvvvLrbL7jggkpyGTMmfl7R399fyb7aTTsOkzwQo7V+5TCLf/U5/9dEj6+qHlsvf/nLm85FyhtAO2XKlDDmpJNOqrv9rrvuCtf42te+Fsa8/e1vD2OeeOKJMGbNmjVhzPbt28OYZ555pu72TZs2hWtUZbD6xZkkAACABJokAACABJokAACABJokAACABJokAACABJokAACABJokAACABJokAACABIZJDoOqBhB+8YtfDGO++tWv1t3+zW9+M1wjZzBcVXKOTV9fXxjznve8p+72yZMnh2t85CMfCWOqGgx6MGKYJJoV1Z6q/r9avXp1GLN58+YwpqurK4zJyXnGjBl1t3/nO98J14hqvyRdffXVYcz69evDmB07doQx3d3dYcyuXbvqbn/Ri14UrpEj537FMEkAAIADQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQEA99QV1jx44NY3Lm/CxevDiMmTJlShiTMwcpkjMnKWeuU46q5p584hOfqLv9c5/7XLhGZ2dnGJMz+6OquVgAhsaKFSvCmJ6enjAmZ5bS3r17w5hDDjmk7vaZM2eGa7zxjW8MY+69994wZvz48WHMli1bwpg9e/aEMV/5ylfCmMhQz67jTBIAAEACTRIAAEACTRIAAEACTRIAAEACTRIAAEACTRIAAEACTRIAAEACTRIAAEACwySbVNUwyeOPPz6M2bp1a1ZO9eTkmzPoMGfgZM6gyJx9TZgwIYyJBpf94he/CNdYtmxZGPP1r389jMkZbpYzqA4YbaK6UtXw2arkDI6dOnVqGBPVjGnTpoVr5NSUuXPnhjEbN24MY6oYkCnlDaWMNDMoMgdnkgAAABKaOpNkZiskdUvqk9Tr7kurSAoAhgM1DEA9Vbzc9lJ3j8/PAUBrooYBSOLlNgAAgIRmmySX9F0zu8fMLq4iIQAYRtQwAINq9uW20919tZnNkXS7mf3a3e+sDSgLD8UHQCuqW8OoX8Do1tSZJHdfXf67XtItkk5OxFzl7kt5QySAVhPVMOoXMLo13CSZ2RQz6xz4XtLLJT1QVWIAMJSoYQAizbzcNlfSLeXwr3GSbnD3f6skq1FoyZIlYcyGDRua3k9Vwy+HU87AyUjOsVuwYEHT+0FboYa1mJwhtVXYtWtXJetUMehWkqZMmVJ3+7Zt28I1Zs2aFcbkrLNy5cowZvfu3WFMzjDJrq6uMGakNdwkufuTkuIx0QDQgqhhACKMAAAAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEho9rPbUJFp06aFMU8++WTT+xmuYW1VqmKY5KZNm8KYU045pen9SJK7V7IOgAMXDWaU8h6je/fuDWNyhknmDOeNYnp7e8M1xoyJz3ls3LgxjBk/fnwl+5o8eXIY8/rXv77u9k996lPhGjmi//fq3R84kwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJDAMMkWMXHixDCmu7t7GDI5OK1duzaMOeywwyrZV84QOgDPVsWw25xaOn369DBmw4YNYUzOoMic4ZZz5sypu33lypXhGjkDMquKyRk4mfP/1RFHHFF3+7HHHhuu8etf/zqMaWbAL2eSAAAAEmiSAAAAEmiSAAAAEmiSAAAAEmiSAAAAEmiSAAAAEmiSAAAAEmiSAAAAEhgm2aRmhlTVGjcu/lXkxCCtp6cnjJk1a9YwZFLIGZpX1X0LaBdjxjT/vD0aUChJM2bMCGNWrVoVxkyePDmMyRk42dnZWXf7zp07wzVyBjz29/dXEjN16tQwpqOjI4yJhvxefPHF4Rrvfve7w5hmcCYJAAAggSYJAAAggSYJAAAggSYJAAAggSYJAAAggSYJAAAggSYJAAAggSYJAAAggemETRrOYZJjx46tZF+j0bp168KYnOFnVWGYJPBsOUNfI2eccUYYkzMosre3N4zJGX6ZM+QxsmvXrqbXkPL+D5k0aVIYkzNMcsKECWHM1q1b625/zWteE65x+eWXhzHr168PYwYT/obN7BozW29mD9RcNsvMbjezx8p/ZzacAQAMIWoYgEblvNx2raQz97vsA5K+5+5HS/pe+TMAtKJrRQ0D0ICwSXL3OyVt3u/icyRdV35/naRzq00LAKpBDQPQqEbfuD3X3deU36+VNLeifABgOFDDAISafuO2u7uZDfoOUzO7WFL8Ub4AMALq1TDqFzC6NXomaZ2ZzZOk8t9B3zru7le5+1J3X9rgvgCgalk1jPoFjG6NNkm3Sbqw/P5CSbdWkw4ADAtqGIBQ+HKbmX1Z0jJJs81slaQPS7pc0o1m9iZJT0k6fyiTbGV9fX2VrJMzd6K/v7+SfY1GOb+nnJknaD/UsNFlypQpYcyGDRvCmHnz5oUxOfPOJk+eHMZEtX3Pnj3hGjkxOTObJk6cGMbkzEB6+umnm97X5s37/73Fs33wgx8MY971rneFMYMJmyR3v2CQTfHELgAYYdQwAI3iqTMAAEACTRIAAEACTRIAAEACTRIAAEACTRIAAEACTRIAAEACTRIAAEBC05/ddjDLGRTmPujH1h2QnIFjPT09Te+nt7e36TWGWxXHOOd32dnZ2fR+cuXkAxxMhqueHnPMMWHM3Lnx5xnnDF7cu3dvGJMzyDYaJpkzvLGjoyOMmTZtWhize/fuMOaRRx4JY3bs2BHGHHvssU3ncuqpp4YxzeBMEgAAQAJNEgAAQAJNEgAAQAJNEgAAQAJNEgAAQAJNEgAAQAJNEgAAQAJNEgAAQALDJFvElClTwpic4VyRMWOq6YurGoYYDVGT8nKO1skZ1jlx4sQwZsaMGWHMli1bwpiqhpAC7SJnOOOePXvqbj/ppJPCNf7wD/8wjNmwYUMYkzO8t6r6FQ2c3LVrV7hGTk3JqU1PPvlkGJNTK7u6usKY6D6Rc7tz7lezZs2qu33r1q2DbuNMEgAAQAJNEgAAQAJNEgAAQAJNEgAAQAJNEgAAQAJNEgAAQAJNEgAAQAJNEgAAQALDJOtotYF/K1asaHqNvXv3Np/IMMsZ2BbJGcSZM5QsZxhbjipuE9BOooGJOV7xileEMd3d3WFMzqDInCGQY8eODWNyRHV5586d4Ro5MZ2dnWHMkiVLwpiZM2eGMTnHeO3atXW359xncup2vWGR0X44kwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJDAMMlhcPzxx4cxOQOxnve854Uxy5cvr7t90qRJ4Ro5A7xyBm3mDEysYsBcjmOOOSaM2bVrVxjzlre8JYy58sors3ICRpPe3t6m1zjttNPCmJyBuTm5jBsX//c4bdq0MGbChAlhTFR7cnKZPXt2GJMz4DHHmjVrwphNmzaFMdHgz8MPPzxcY9u2bWFMM//PhGeSzOwaM1tvZg/UXHaZma02s+Xl19kNZwAAQ4gaBqBROS+3XSvpzMTln3L3E8qvb1WbFgBU5lpRwwA0IGyS3P1OSZuHIRcAqBw1DECjmnnj9tvN7L7yVHb8aXcA0FqoYQDqarRJukLSUZJOkLRG0icGCzSzi83sbjO7u8F9AUDVsmoY9QsY3Rpqktx9nbv3uXu/pKslnVwn9ip3X+ruSxtNEgCqlFvDqF/A6NZQk2Rm82p+fLWkBwaLBYBWQw0DkCMcvmBmX5a0TNJsM1sl6cOSlpnZCZJc0gpJlwxdigDQOGoYgEZZzlDAynZmNnw7q8DcuXPDmFtuuSWMyRnylTOc64gjjghjtm7dWnf79u3bwzVy7hNmFsbkDGzLGTh55JFHhjHr1q2ru33y5MnhGk8//XQYs3DhwjBm4sSJYUxXV1cY027cPb5TtLF2q1/DaezYsWFMzkC/KVOm1N1+5513hmvkDEyM6qQkdXZ2hjEzZ8bv9+/o6Gg65kc/+lG4xsknD/qul995/PHHw5ic4YxTp04NY6ZPnx7GRP/H7tmzJ1xj8+b4D1eXLVsWxgxWv/hYEgAAgASaJAAAgASaJAAAgASaJAAAgASaJAAAgASaJAAAgASaJAAAgASaJAAAgIRw4vZotmTJkjBm8eLFYcxjjz0WxqxduzaMOeyww8KYaPhWzqCwqgaM5gyPyxm09utf/7rpXCZMmBDG5Ayhe+ihh8KY448/Pow59NBDw5ic+wTQjKqGQOYMl80RDUQcP358uEbOcMFJkyaFMTm3KSefnKGU0XDLDRs2hGusX78+jJk3b14Y85KXvCSM2b17dxiTM0wyGgK8c+fOcI2c+3AzOJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQwJykOl74wheGMTlzh8aNiw/ztGnTwpicWT979+6tu33MmLgvrmrmSc6+ent7w5ic2x3NdsqZizJjxoww5plnngljcuZ2PPe5zw1jmJOEodbf3x/GVPU4zvHnf/7ndbfv2rUrXCPn8RfVSSlvLt2cOXPCmJyasXHjxrrbc2rTaaedFsbk1PacWvnOd74zjLn88svDmOh+k3P/nDp1ahjTDM4kAQAAJNAkAQAAJNAkAQAAJNAkAQAAJNAkAQAAJNAkAQAAJNAkAQAAJNAkAQAAJDBMso5/+Id/CGNe97rXhTHRoEOpuqGKW7ZsaXqNnOGXOTE5tztnuFnOMLuenp6mc5k4cWIlufT19VWyDg5OOb/7KCZnjZz7fM5QxZx1crzyla8MY5YsWVJ3+5o1a8I1cgbzzpw5M4yZPXt2GLN+/fowZtWqVWFMVP8vuuiiSvazYMGCMCbHIYccEsZs3749jKnivpVTt5tBpQYAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEhgmGSTDj/88DDm/vvvD2OiYYiStG3btjAmGjI3ZcqUcI3+/v5KYnIGRebEVLGvjRs3hmvkHJucwWULFy4MY6Khn2hN0f2sqvtzTkwree1rXxvGXHDBBWFMNCxy+vTp4Ro5Awrnz58fxnR3d4cxOcMkt27dGsaceeaZdbfffffd4Ronn3xyGFOVnEGROUN1q3g8dXR0hDHNCM8kmVmXmX3fzB4yswfN7J3l5bPM7HYze6z8Nx5hCgDDiPoFoBk5L7f1SnqPuy+R9CJJbzOzJZI+IOl77n60pO+VPwNAK6F+AWhY2CS5+xp3v7f8vlvSw5LmSzpH0nVl2HWSzh2iHAGgIdQvAM04oDdum9kiSSdK+rmkue4+8ALyWklzq00NAKpD/QJwoLLfuG1mUyV9TdK73H1b7Ruq3N3NLPluOTO7WNLFzSYKAI2ifgFoRNaZJDPrUFFgrnf3m8uL15nZvHL7PEnJt/m7+1XuvtTdl1aRMAAcCOoXgEbl/HWbSfqCpIfd/ZM1m26TdGH5/YWSbq0+PQBoHPULQDNyXm47TdIbJN1vZsvLyz4o6XJJN5rZmyQ9Jen8IckQABpH/QLQsLBJcvcfSxpsotMZ1abTftatWxfGTJgwIYzJGYA2fvz4MCYadpgztDIaSFml3t7eMCYnnyhm0qRJ4Ro5A/xyctm5c2cYkzNwcvny5WEM6qu6fkWP05zHcY6jjjqq7vYlS5aEa8yaNSuMyXlcnHrqqWFMzuDAcePi5+SzZ8+uu33v3r3hGgsWLAhjch7rOQNf9+zZE8Ycd9xxTe+rqkGROfUr59jk/C5z7hM5MZGcYZLRoOBdu3YNuo2PJQEAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEjI/oDb0ShnCGTOMKycgYk5Q8lyBkFGcoax5Qznyjk2OfuqarjZ2LFj627fsWNHuEbOsM6c3/fmzZvDmGjoJ1rPmDFjwt/bFVdcEa6Tc3+OPP3002HM3XffHcYce+yxYUw0iE/Ku01VrDNjxoxwjagWSNL27dvDmJx6m3ObjjzyyDAm53ZFqqqlOXKOcRVyhrPm3O5oaGq9/385kwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJDAMMk6coZUmVkYs3Xr1jDm0EMPDWM2bdoUxkQ55wwxzLlNOUO+cuTsq4p1du/eHa5RxVAyKe/YVDXUDcNn7ty5uuSSS+rGvOQlLwnXWbFiRRgzblz90rxgwYJwjaOPPjqMyRmgOnny5DAmZ8hqFcMOp06d2vQaubnk3KbDDz88jHnzm98cxuT8HxEZzpoS3T+lavLJqaU5gy2jYZ3d3d2DbuNMEgAAQAJNEgAAQAJNEgAAQAJNEgAAQAJNEgAAQAJNEgAAQAJNEgAAQAJNEgAAQALDJOvYtWtXGNPR0RHG5AxAyxnqlpNPNFgrZ8BXzm3KGfKVM7AtZxBYTj7RMMmcNXKOb29vbxiTc5umT58exqC1bNq0Sddcc03dmGnTpoXrdHV1hTHRsMhoOJ4kzZkzJ4zJGbLa09MTxuTIqQc5w24jOTUu57F+1FFHhTE/+clPwpgvfOELYUwVhnMIcM79JmcYZxSTU2/37t0bxjSDM0kAAAAJNEkAAAAJNEkAAAAJNEkAAAAJNEkAAAAJNEkAAAAJNEkAAAAJzEmq4/DDDw9j1q9fH8bkzIvImTuRM0spkjNTImc2RY6q5iRVMSsj53aPGxc/HHbu3BnGPP3002HMcccdF8agtfT09Oi3v/1t3Zh3v/vdlexr0aJFdbeffvrp4RovfelLw5jjjz8+jFm8eHEYkzMfKmdWWU49GC433XRTGHP++edXsq/oduf8HzKccu43Of9fTZ48ue72nLlO0UwxKX4s3HLLLYNuC/8XM7MuM/u+mT1kZg+a2TvLyy8zs9Vmtrz8OjvMFACGEfULQDNyziT1SnqPu99rZp2S7jGz28ttn3L3jw9degDQFOoXgIaFTZK7r5G0pvy+28weljR/qBMDgGZRvwA044DeuG1miySdKOnn5UVvN7P7zOwaM5tZdXIAUBXqF4ADld0kmdlUSV+T9C533ybpCklHSTpBxTO1TwxyvYvN7G4zu7v5dAHgwFG/ADQiq0kysw4VBeZ6d79Zktx9nbv3uXu/pKslnZy6rrtf5e5L3X1pVUkDQC7qF4BG5fx1m0n6gqSH3f2TNZfPqwl7taQHqk8PABpH/QLQjJy/bjtN0hsk3W9my8vLPijpAjM7QZJLWiHpkiHIDwCaQf0C0DDLGdZU2c7Mhm9nFTjqqKPCmOuvvz6M6e7uDmOmTJkSxuQMFIuGkhVPrOuraghkVYPhcu6j0bDInp6eSvaTc/w6OzvDmA0bNoQxL3vZy8KYVuLu8cFpY+1Wv6qSc58/5phjwpicgZPRAMKcobs5w2cff/zxMGb79u1hzGj1t3/7t2HM3Llzw5jHHnus7vacur1169Yw5pvf/Gbd7Tt27FBfX1/yjs7HkgAAACTQJAEAACTQJAEAACTQJAEAACTQJAEAACTQJAEAACTQJAEAACTQJAEAACQwTLJJt956axizbdu2MCYahijlDWecNGlS02vkDJPcuXNnGJMzMDHn/jduXM5g+PpyBtnlDPTMOX45Q9RyhrF9//vfD2NaCcMkAbSrweoXZ5IAAAASaJIAAAASaJIAAAASaJIAAAASaJIAAAASaJIAAAASaJIAAAASaJIAAAAShnuY5AZJT9VcNFvSxmFLoHntlq/UfjmT79AaqnwXuvtzhmDdlpGoXxK//6FGvkOLfAuD1q9hbZKetXOzu9196YglcIDaLV+p/XIm36HVbvm2unY7nuQ7tMh3aI1EvrzcBgAAkECTBAAAkDDSTdJVI7z/A9Vu+UrtlzP5Dq12y7fVtdvxJN+hRb5Da9jzHdH3JAEAALSqkT6TBAAA0JJGrEkyszPN7BEze9zMPjBSeeQysxVmdr+ZLTezu0c6n/2Z2TVmtt7MHqi5bJaZ3W5mj5X/zhzJHGsNku9lZra6PMbLzezskcyxlpl1mdn3zewhM3vQzN5ZXt6Sx7hOvi17jNsJ9at61LChRQ1rMI+ReLnNzMZKelTSyyStknSXpAvc/aFhTyaTma2QtNTdW3KmhJm9RNJ2Sf/s7seVl/2DpM3ufnlZyGe6+/tHMs8Bg+R7maTt7v7xkcwtxczmSZrn7veaWaekeySdK+kiteAxrpPv+WrRY9wuqF9Dgxo2tKhhjRmpM0knS3rc3Z909x5JX5F0zgjlclBw9zslbd7v4nMkXVd+f52KO1hLGCTfluXua9z93vL7bkkPS5qvFj3GdfJF86hfQ4AaNrSoYY0ZqSZpvqSVNT+vUusXcJf0XTO7x8wuHulkMs119zXl92slzR3JZDK93czuK09lt8Rp3/2Z2SJJJ0r6udrgGO+Xr9QGx7jFUb+GT8s/vhJa/vFFDcvHG7fzne7uJ0k6S9LbylOtbcOL11Vb/U8Zr5B0lKQTJK2R9IkRzSbBzKZK+pqkd7n7ttptrXiME/m2/DHGkGjr+iW15uMroeUfX9SwAzNSTdJqSV01Px9eXtay3H11+e96SbeoOOXe6taVr+sOvL67foTzqcvd17l7n7v3S7paLXaMzaxDxYP1ene/uby4ZY9xKt9WP8Ztgvo1fFr28ZXS6o8vatiBG6km6S5JR5vZEWY2XtJrJd02QrmEzGxK+cYxmdkUSS+X9ED9a7WE2yRdWH5/oaRbRzCX0MADtfRqtdAxNjOT9AVJD7v7J2s2teQxHizfVj7GbYT6NXxa8vE1mFZ+fFHDGsxjpIZJln+292lJYyVd4+4fG5FEMpjZkSqefUnSOEk3tFq+ZvZlSctUfEryOkkflvSvkm6UtEDFp5ef7+4t8UbDQfJdpuIUqktaIemSmtfKR5SZnS7pR5Lul9RfXvxBFa+Rt9wxrpPvBWrRY9xOqF/Vo4YNLWpYg3kwcRsAAODZeOM2AABAAk0SAABAAk0SAABAAk3SQcrMrjWzj5bfv9jMHhmm/bqZLa54zd/dluG8LoCRQw1r/rpoHk3SCLLiQyd3mdl2M1tXPhimVr0fd/+Rux+Tkc9FZvbjqvdfs/4PzOzNQ7V+1czstVZ8iOlWKz7I8jozmzbSeQGtghrW2szsODP7jpltNDP+SqsBNEkj71XuPlXSSZKWSvqf+weY2bhhzwqS9B+STnP36ZKOVPHn0zyjA/ZFDWtde1X8ef+bRjqRdkWT1CLKibjfljTwadJuZm8zs8ckPVZe9kozW25mW8zsJ2b2hwPXN7MTzexeM+s2s3+RNLFm2zIzW1Xzc5eZ3WxmG8xsk5l91syeJ+lKSaeWzwq3lLETzOzjZvbb8pnilWY2qWat95nZGjN72sze2OjtN7ObzGxtedbmTjN7/n4hs83s9vL2/dDMFtZc99hy2+byzM/5jeZRy91X7vep6X2SKj0NDxwsqGEtWcMecfcvSHqwivVGI5qkFmFmXZLOlvTLmovPlXSKpCVmdqKkayRdIukQSZ+XdFtZAMarGLr2/yTNknSTpP86yH7GSvqGiqFhi1R8MOdX3P1hSW+R9FN3n+ruM8qrXC7puSqGdy0u4z9UrnWmpPdKepmkoyX9cROH4NvlGnMk3Svp+v22v17SR1QMbls+sN2KCcK3S7qhvO5rJX3OzJZEOzSzBWWxXlAn5nQz2yqpW8Ux/fQB3SpglKCGtWYNQ5Pcna8R+lIxLXS7pC0qHvCfkzSp3OaS/nNN7BWSPrLf9R+R9EeSXiLpaZXDQcttP5H00fL7ZZJWld+fKmmDpHGJfC6S9OOan03SDklH1Vx2qqTflN9fI+nymm3PLfNePMjt/YGkN2cclxnlOtPLn69VUQQHtk9VcVanS9KfSfrRftf/vKQP11z3oxX8ruZLukzSc0f6fsMXX63yRQ0b9Li0VA1T0Rz6SN9f2vGL14lH3rnu/u+DbFtZ8/1CSRea2TtqLhsv6TAVD8bVXj4aSk8NsmaXpKfcvTcjt+dImizpHjMbuMxUfBSDyn3fk7HPuspnhh+T9JpynwMj6GdL2lp+/7tj4e7bzWxzuf+Fkk4ZOLVeGqfiGWll3H21mf2bpK+oeO8FgAI1rA1qGBpDk9TaagvGSkkf88RnLpnZH0mab2ZWU2QWSHoiseZKSQvMbFyiyOz/1w8bJe2S9HwvP0V8P2u076ehN3rK93WSzlFxqnuFpOmSnlFRzAb8bj9W/PXMLBXPPFdK+qG7v6zBfR+IcZKOGob9AAcLatjvtUINwwHiPUnt42pJbzGzU6wwxcxeYcWne/9UUq+k/25mHWZ2nqSTB1nnFyoKw+XlGhPN7LRy2zpJh5fvD5C795f7/ZSZzZEkM5tvZn9Sxt8o6SIzW2Jmk1V8wGNkXLnPga8OSZ2S9kjapOJZ3/9KXO/s8v1B41W8rv8zd1+p4r0JzzWzN5S3vcPMXli+ibMpZvb6gdf6yzdZfkzS95pdFxilqGHDX8PMzCaqOGOnMt8Jza47mtAktQl3v1vSX0r6rIpnKI+reP1d7t4j6bzy580qXuO+eZB1+iS9SsVr1L+VtKqMl6Q7VPwVxFozG/irrveX+/qZmW2T9O+SjinX+raKNzLfUcbckXFTrlDxzG7g64uS/lnFae7Vkh6S9LPE9W5QUcA2S3qBpD8vc+iW9HIVb3Z8WtJaSf9HUlgIyjc9bq/zpsclkn5iZjtUjAN4RMXvAMABooaNSA1bWOY48Ndtu1TUMWSyfV8CBgAAgMSZJAAAgCSaJAAAgASaJAAAgASaJAAAgASaJGQzs8vM7EsVr7nIis94OuCZXc1cF8DoQv1CI2iS2oiZ/cDMnsmdc2FmF5nZj4c6r3Jf+3wAZaszszlm9mUrPtRyq5n9h5mdMtJ5AQcr6ld1qF/DhyapTZjZIkkvVjFR9r+MbDYHhamS7lIxr2SWpOskfbOchAugQtSvylG/hglNUvv4CxUDyq6VdGHtBjPrMrObzWyDmW0ys8+W01qvlHRqOWxsSxn7AzN7c81193m2ZmafMbOVZrbNzO4xsxc3m3g5VfeX5ZorzeyyRNgby2dFa8zsvTXXHWNmHzCzJ8rbdqOZzWo2J3d/0t0/6e5r3L3P3a9SMZX2mGbXBvAs1C/qV1uiSWoffyHp+vLrT8xsrvS7D1b8hoppr4tUfFr9V9z9YUlvkfRTd5/q7jMy93OXpBNUPDu5QdJN5Vj7Zuwo858h6RWS/srMzt0v5qWSjlYxefb9ZvbH5eXvkHSuik8KP0zFpN5/ytmpmX3OzD6XGXuCiiLzeE48gANC/aJ+tSWapDZgZqerGC9/o7vfo+JDH19Xbj5ZxYPvfe6+w913u3vDr+O7+5fcfZO797r7J1SMxm/q2Ym7/8Dd73f3fne/T9KXVRSNWn9X5n+/ijH/F5SXv0XS37r7KnffI+kySX+a82ZHd3+ru781ijOzaSo+cfvv3H1rFA8gH/WL+tXOaJLaw4WSvuvuA59FdIN+f8q6S9JTiU/DboiZvdfMHi7fDLhFxadZz25yzVPM7Pvl6fStKgrH/muurPn+KRWFUyqK6y1mtqXM52FJfZLmNpNTTW6TJH1dxYdN/u8q1gSwD+oX9att8aeHLa58EJwvaayZrS0vniBphpkdr+LBucDMxiUKTeqD+Xao+JTqAYfW7OvFkv5G0hmSHnT3fjN7RpI1eTNuUPGhlme5+24z+7SeXWS6JP26/H6Big96lIrb90Z3/4/9Fy3fDNowK/7K5l9VfEDmJc2sBeDZqF/Ur3bHmaTWd66KZx5LVLzWfoKk50n6kYrXyX8haY2ky81siplNNLPTyuuuk3S4mY2vWW+5pPPMbLKZLZb0ppptnZJ6JW2QNM7MPiRp2oEkW+6/9svKdTeXBeZk/f5Ue61Ly5yeL+m/SfqX8vIrJX3MzBaW6z/HzM45kJwGybND0ldVfCr2he7e3+yaAJ7lXFG/qF9tjCap9V0o6Yvu/lt3XzvwpeKZzetVPEt6laTFkn6r4lnFn5XXvUPSg5LWmtnAqe5PSepRUYCuU/FGygHfkfRvkh5Vccp4t/Y9jRyZr+JBW/t1lKS3Svp7M+uW9CFJNyau+0MVbzr8nqSPu/t3y8s/I+k2Sd8tr/8zSVnzQMzsSjO7cpDN/0nSK1W80XKLFX9Bs72Kv4YB8DvUL+pXWzP31BlNAACA0Y0zSQAAAAk0SQAAAAk0SQAAAAk0SQAAAAk0SQAAAAlNDZM0szNV/InjWEn/190vD+L5U7omTJwYfwTR/Pnz625fsWJFuEZfX19uSk3r6OgIYxYsWBDGrF69uu723bt3Z+eExrh7s0P7ht2B1DDqV3OmTJkSxsybN6/u9p07d4ZrPPPMM2HMrl27wpgcOfUr53Z3dnbW3Z5T+9evXx/GbN3Kp5YMZrD61fAIgPKDCR+V9DIVsy3uknSBuz9U5zoUmSYcd9xxYcxHPvKRutsvuuiicI3hfCB1dXWFMZ/+9KfDmEsvvbTu9oceGvRuiYq0W5N0oDWM+tWcF73oRWHMhz70obrb77nnnnCNr371q2HMr371qzAmR079esELXhDGLFu2rO72JUuWhGv84z/+YxjzjW98I4wZrQarX8283HaypMfd/Ul375H0FUlNTxIFgGFCDQNQVzNN0nztO810VXkZALQDahiAuob8A27N7GJJFw/1fgCgatQvYHRrpklareKTjwccXl62D3e/StJVEq/pA2gpYQ2jfgGjWzMvt90l6WgzO6L8lObXqvggPwBoB9QwAHU1fCbJ3XvN7O0qPnl5rKRr3P3ByjIDgCFEDQMQaXgEQEM7G6Wnq6dNmxbG5PyZ+9FHH910zJ49e8I1Jk+eHMb09/eHMTkzRDZu3BjG5OQczU954IEHwjX++q//OozZtm1bGDNatdsIgAM1WutXjttui0/ARX/mLsWP40MOOSRcI2cm2tSpU8OYqmzfvj2MieYg5cx+mjBhQhiTMx/q0EMPDWMORkMxAgAAAOCgRZMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQwDDJJr3vfe8LYy644IJK9rV58+YwZvz48XW3z549O1xjzJi4d967d28Y09fXF8b09PSEMTnDJHt7e+tuzxlCl5PLl770pTAmZzDowYhhkqPXL37xizBm+vTpYcymTZvqbp8zZ064Rs4w3J///OdhzC9/+csw5owzzghjTjzxxDAmut3r1q0L18ipcY8//ngYc9ZZZ4UxByOGSQIAABwAmiQAAIAEmiQAAIAEmiQAAIAEmiQAAIAEmiQAAIAEmiQAAIAEmiQAAIAEhknW0dnZGcb88Ic/DGN27NgRxuQMZ8z5XfX399fdPmHChHCNnGFsOYMXc4ZSRvlK8aDIHDnHt6OjI4yZOnVqGPPCF74wjMkZtFnV8RsuDJM8OI0bNy6MyRnOmHN/3rp1a93tH//4x8M1vv71r4cxOcMZt2/fHsbMnDkzjMn5fyQaOPyOd7wjXGP+/PlhzGOPPRbGnH322WHMwYhhkgAAAAeAJgkAACCBJgkAACCBJgkAACCBJgkAACCBJgkAACCBJgkAACAhHoAxiuXMnciZO7Rr164wJmfezdixY8OYaJZSznyenLlOZvFInJyYnNudk3P0e9i5c2e4Rs48mJxZSqeffnoYkzNfazhnmAGDyZlTtm3btjAmpx7MmTOn7vajjz46XOPWW28NY84555wwJqcezJo1K4y54447wpgXv/jFYUzkmWeeCWNy5kNhX5xJAgAASKBJAgAASKBJAgAASKBJAgAASKBJAgAASKBJAgAASKBJAgAASKBJAgAASGCYZB2nnnpqGJMzDLGzszOM2b59exiTM7gyGkCYM6AwZ3hjzmDLnHXGjIn79CqGUu7duzdcY+7cuWFMzvH70z/90zCGYZI4mEyfPj2MWb16dRizfv36uttzhi7m1NuNGzeGMTm1/cknnwxj9uzZE8Yce+yxdbfff//94RpHHnlkGDNx4sQwBvtqqkkysxWSuiX1Sep196VVJAUAw4EaBqCeKs4kvdTd47YcAFoTNQxAEu9JAgAASGi2SXJJ3zWze8zs4ioSAoBhRA0DMKhmX2473d1Xm9kcSbeb2a/d/c7agLLwUHwAtKK6NYz6BYxuTZ1JcvfV5b/rJd0i6eREzFXuvpQ3RAJoNVENo34Bo1vDTZKZTTGzzoHvJb1c0gNVJQYAQ4kaBiDSzMttcyXdUs6wGSfpBnf/t0qyAoChRw0DUFfDTZK7Pynp+ApzaTl/8Ad/EMb09vaGMTkDvHIGB+YMXozkDGbM2U/OoLXh1NHRUXd7zkC3nAGZu3fvDmNOOeWUMAYjbzTUsOGyadOmSmK2bt1ad3tOvc2pTT/72c/CmJxamTMwd9y4+L/ZaFDwpEmTwjV27NhRSQz2xQgAAACABJokAACABJokAACABJokAACABJokAACABJokAACABJokAACABJokAACAhGY/4Pag9vznPz+M2bVrVxgzfvz4MCYahpgrGkqZMyAtZxjbcA6czBnYNn/+/Lrbn3nmmXCNnHxzhlLmmDJlShjD4De0i9/85jdhzLRp08KYaPBuzsDXqgZO5sTkDIqsYihlTi579+4NY3KGFmNfnEkCAABIoEkCAABIoEkCAABIoEkCAABIoEkCAABIoEkCAABIoEkCAABIoEkCAABIYJhkHbNmzQpjenp6wpic4WY5wyRzBqlFQ8dyhkDm7CdnwGPOvnJicoaxRQM7Z8+eHa6R83vKMWnSpDBm8eLFYcyvfvWrKtIBhlzOsMPnPOc5YUxUV3KGN+YMVaxiwKNUXY2rIpecY/PII480nctow5kkAACABJokAACABJokAACABJokAACABJokAACABJokAACABJokAACABJokAACAhFE7THLGjBlhzOTJk8OYnMFlOXKGm1UxTNLdK8klR85wxmgIZK5HH3207vbNmzeHaxx22GFhTM7QvJyhbqecckoYwzBJtIuc++oLXvCCMKaKejpx4sQwJqcO5jzWc1QxTLKqXG655ZZK1hlNOJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQEE69M7NrJL1S0np3P668bJakf5G0SNIKSee7+zNDl2b1lixZEsbkDPDq6+urJCZnqGLOMMlIzhC1qlQ1lHLBggVhzI4dO+puz7ndOb+D3bt3hzE595uTTjopjEE1DtYa1ko+//nPhzEXXnhhGBMN+d25c2e4Rk6dHM46mCMaQJtTU3Lq15YtW3JTQinnTNK1ks7c77IPSPqeux8t6XvlzwDQiq4VNQxAA8Imyd3vlLT/ZzqcI+m68vvrJJ1bbVoAUA1qGIBGNfqepLnuvqb8fq2kuRXlAwDDgRoGINT0B9y6u5vZoC/wmtnFki5udj8AMBTq1TDqFzC6NXomaZ2ZzZOk8t/1gwW6+1XuvtTdlza4LwCoWlYNo34Bo1ujTdJtkgb+VOFCSbdWkw4ADAtqGIBQ2CSZ2Zcl/VTSMWa2yszeJOlySS8zs8ck/XH5MwC0HGoYgEaF70ly9wsG2XRGxbkMq8MOOyyM2bt3bxiTM5MjJ6aqmUxVzP8YM2b4Zozm3O6JEyeGMWvWrKm7fdKkSeEaVR3fnHUWLlwYxqAaB2sNayU5j+MJEyY0HZPz2MqpXzn5VjGXLld0u6ZPnx6usWHDhjCmu7s7OycUmLgNAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQ0PQH3LarQw45JIzJGVyWM3Bs3Lj4MOcMrqyCmYUxOfnu2bOnkn3lWLt2bRgzY8aMutufeOKJcI158+aFMTkD8XLuNwsWLAhjgHbR1dVVScyWLVvqbs8ZCltV3RlOUf3Pqck5/xft3r07OycUOJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQQJMEAACQMGqHSc6ZMyeMyRnwOH78+DCmqqGUvb29YUwVg9TGjIl755zhZu4+bPuKhlvmDIHM+R3k6OnpCWOmTZtWyb6AVjBr1qwwJufxFdWMnHqRUwNzalNVcvKJjk1O7Z8/f34Ys2jRojDmqaeeCmNGE84kAQAAJNAkAQAAJNAkAQAAJNAkAQAAJNAkAQAAJNAkAQAAJNAkAQAAJNAkAQAAJDBMso6cYZKTJ0+uIp1KhkBWJSeXqmKqUsUgyJwBcx0dHWHM7t27w5jOzs4wJue+tXPnzjAGGGozZ84MY3bt2tX0fnKGSeY8joezNlVRK3MGEuf8f5Vz/LAvjhgAAEACTRIAAEACTRIAAEACTRIAAEACTRIAAEACTRIAAEACTRIAAEACTRIAAEBCOEzSzK6R9EpJ6939uPKyyyT9paQNZdgH3f1bQ5XkUJgxY0YY09vbG8bkDOfKGSaWM6Swp6cnjKliqOK4cdXMGM05fjn55qwzYcKEuttzjm/OELqqhrHl3O5jjz02jLn33nurSOegdrDWsFYyf/78MKaK2jScQyBz6kFVotuVk0t3d3cYkzNwEvvKqfjXSjozcfmn3P2E8oviAqBVXStqGIAGhE2Su98pafMw5AIAlaOGAWhUM68dvN3M7jOza8ws/uAeAGgt1DAAdTXaJF0h6ShJJ0haI+kTgwWa2cVmdreZ3d3gvgCgalk1jPoFjG4NNUnuvs7d+9y9X9LVkk6uE3uVuy9196WNJgkAVcqtYdQvYHRrqEkys3k1P75a0gPVpAMAQ48aBiBHzgiAL0taJmm2ma2S9GFJy8zsBEkuaYWkS4YuRQBoHDUMQKPCJsndL0hc/IUhyAUAKkcNA9CoaqYGtqFJkyaFMTmDy6oavJijimGHOWtUNfyyqn1VMdQtZ5BdX19fGJMzTHLPnj1hTH9/fxgzd+7cMAZoBVXVweEcFlmFqvKN6unu3bvDNXL+TzvssMOyc0KBjyUBAABIoEkCAABIoEkCAABIoEkCAABIoEkCAABIoEkCAABIoEkCAABIoEkCAABIYJhkHXv37g1jqhjwWKVouFnOEMMcObepqkFrrTRMMmdoXk6+OTFdXV1hDNAKFixYEMbkPAYjVT22cuTUr6piqjBx4sQw5oQTTghjbrzxxgqyOXhwJgkAACCBJgkAACCBJgkAACCBJgkAACCBJgkAACCBJgkAACCBJgkAACBh1M5JqmJmh5Q3L2jChAlhzO7du8OYPXv2hDHjx4+vu33Xrl3hGh0dHWFMzgypHFXNW4rmF+X8DnLmJOXMYMnJN+d3yZwktIuTTjopjKlixlHOYyunplQ1S2m45Mxn6+3tDWOOOeaYKtIZVTiTBAAAkECTBAAAkECTBAAAkECTBAAAkECTBAAAkECTBAAAkECTBAAAkECTBAAAkDBqh0lWMaCwynVy5Aw7nDRpUt3tO3furCSXnIFtOQM7c45NFQMcoyGbUt5Az5zfd84wzpx9zZkzJ4wBWsGLXvSiMKanpyeMyakrkZzHaFX6+/vDmCrqVxXHRZKWLFlSyTqjCWeSAAAAEmiSAAAAEmiSAAAAEmiSAAAAEmiSAAAAEmiSAAAAEmiSAAAAEmiSAAAAEkbtMMmcQYc5QwFzBjzmyBkWlhMT5VxVvlUNUcuJqSLnnN93Fcc3d509e/aEMQyTRLs49NBDw5innnoqjImGy1Y1KDKnfuU8jocrn5z95NTSRYsW5aaEUngvMLMuM/u+mT1kZg+a2TvLy2eZ2e1m9lj578yhTxcA8lG/ADQj5+W2Xknvcfclkl4k6W1mtkTSByR9z92PlvS98mcAaCXULwANC5skd1/j7veW33dLeljSfEnnSLquDLtO0rlDlCMANIT6BaAZB/TGbTNbJOlEST+XNNfd15Sb1kqaW21qAFAd6heAA5X9xm0zmyrpa5Le5e7bat9I5u5uZsl3jZnZxZIubjZRAGgU9QtAI7LOJJlZh4oCc72731xevM7M5pXb50lan7quu1/l7kvdfWkVCQPAgaB+AWhUzl+3maQvSHrY3T9Zs+k2SReW318o6dbq0wOAxlG/ADQj5+W20yS9QdL9Zra8vOyDki6XdKOZvUnSU5LOH5IMAaBx1C8ADQubJHf/saTBJlmdUW06wydn8FY02EySxo8fH8bkDCDMySdnoFhOPpGcIWo5+ebc7pyYnp6eMCZS1WC4nPvEhAkTwpicAZmzZs0KY1DfwVq/htOMGTOGbV9RXamqNg3noMgc0b6qGro7ceLEMCanJu/duzeMOVjwsSQAAAAJNEkAAAAJNEkAAAAJNEkAAAAJNEkAAAAJNEkAAAAJNEkAAAAJNEkAAAAJ2R9we7DJGbzV2dkZxvT29oYxmzdvDmN27NgRxowdOzaM2bZtW93tkyZNCtfYuXNnGJMzTCxnYFsVgyIlaffu3XW35/yecvJdvz75EV8HvK+cQXU5+QBDbeHChZWsU9XA3CrWyImpKt+cmP7+/iFfI1dXV1cY8+STT1ayr3ZAFQYAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEigSQIAAEgYtcMkc4wbFx+eVatWhTGzZ88OY+bPnx/G5AycjIaO5QykzBmiljNoM0fOwMSc30N0u6u6TU888UQYEw30lKSZM2eGMR0dHWEMMNRy6leO0TpAtYqhlMM5TPLII48MYxgmCQAAMMrRJAEAACTQJAEAACTQJAEAACTQJAEAACTQJAEAACTQJAEAACTQJAEAACSM2mGSOQO+cmzevDmMOeuss8KYl770pWHMunXrwpho8GLOwMTu7u4wpqenJ4zJGVyZMygyZ6hizr4iXV1dYcy3vvWtMOaWW24JY3LyzRkgBwy1Qw89dNj21W73+Zz/R3IGZEYxVQykzDWcv+92wJkkAACABJokAACABJokAACABJokAACABJokAACABJokAACABJokAACAhFE7J+k3v/lNGHPmmWeGMY899lgY09vbG8bcfvvtYQzaw/bt28OY6dOnhzE5M7iAoTZlypRK1smpg5GcWUA5c4mGU39/fxgTzUHq6+urZD/r168PY3Jm6Y0m4b3JzLrM7Ptm9pCZPWhm7ywvv8zMVpvZ8vLr7KFPFwDyUb8ANCPnTFKvpPe4+71m1inpHjMbOO3xKXf/+NClBwBNoX4BaFjYJLn7Gklryu+7zexhSfOHOjEAaBb1C0AzDujFWzNbJOlEST8vL3q7md1nZteY2cyqkwOAqlC/AByo7CbJzKZK+pqkd7n7NklXSDpK0gkqnql9YpDrXWxmd5vZ3c2nCwAHjvoFoBFZTZKZdagoMNe7+82S5O7r3L3P3fslXS3p5NR13f0qd1/q7kurShoAclG/ADQq56/bTNIXJD3s7p+suXxeTdirJT1QfXoA0DjqF4Bm5Px122mS3iDpfjNbXl72QUkXmNkJklzSCkmXDEF+ANAM6heAhuX8dduPJaUmeH2r+nSGz0033RTGvOAFLwhjbrjhhirSUUdHRxiTMywMQytnqNujjz4axixevDiMWbduXVZOGNzBWr+G0znnnFPJOjkDVMeOHVt3+969e8M1coZJ5jyOc/aVM9xy0qRJYUyUc3RcJGnnzp1hzJw5c8KYs8+OR4ZdccUVYczBorVGkwIAALQImiQAAIAEmiQAAIAEmiQAAIAEmiQAAIAEmiQAAIAEmiQAAIAEmiQAAIAEc/fh25nZ8O0MwLBy93iyXhsbrfXr3HPPDWPOO++8MGbu3LlhzCGHHFJ3e87Q3alTp4Yx48ePD2P27NkTxuQM+N29e3cYEw2C7O7uDtd4+umnw5i1a9eGMddff30Yc99994Ux7Waw+sWZJAAAgASaJAAAgASaJAAAgASaJAAAgASaJAAAgASaJAAAgASaJAAAgASaJAAAgIThHia5QdJTNRfNlrRx2BJoXrvlK7VfzuQ7tIYq34Xu/pwhWLdlJOqXxO9/qJHv0CLfwqD1a1ibpGft3Oxud186YgkcoHbLV2q/nMl3aLVbvq2u3Y4n+Q4t8h1aI5EvL7cBAAAk0CQBAAAkjHSTdNUI7/9AtVu+UvvlTL5Dq93ybXXtdjzJd2iR79Aa9nxH9D1JAAAArWqkzyQBAAC0pBFrkszsTDN7xMweN7MPjFQeucxshZndb2bLzezukc5nf2Z2jZmtN7MHai6bZWa3m9lj5b8zRzLHWoPke5mZrS6P8XIzO3skc6xlZl1m9n0ze8jMHjSzd5aXt+QxrpNvyx7jdkL9qh41bGhRwxrMYyRebjOzsZIelfQySask3SXpAnd/aNiTyWRmKyQtdfeWnClhZi+RtF3SP7v7ceVl/yBps7tfXhbyme7+/pHMc8Ag+V4mabu7f3wkc0sxs3mS5rn7vWbWKekeSedKukgteIzr5Hu+WvQYtwvq19Cghg0talhjRupM0smSHnf3J929R9JXJJ0zQrkcFNz9Tkmb97v4HEnXld9fp+IO1hIGybdlufsad7+3/L5b0sOS5qtFj3GdfNE86tcQoIYNLWpYY0aqSZovaWXNz6vU+gXcJX3XzO4xs4tHOplMc919Tfn9WklzRzKZTG83s/vKU9ktcdp3f2a2SNKJkn6uNjjG++UrtcExbnHUr+HT8o+vhJZ/fFHD8vHG7Xynu/tJks6S9LbyVGvb8OJ11Vb/U8YrJB0l6QRJayR9YkSzSTCzqZK+Juld7r6tdlsrHuNEvi1/jDEk2rp+Sa35+Epo+ccXNezAjFSTtFpSV83Ph5eXtSx3X13+u17SLSpOube6deXrugOv764f4Xzqcvd17t7n7v2SrlaLHWMz61DxYL3e3W8uL27ZY5zKt9WPcZugfg2fln18pbT644saduBGqkm6S9LRZnaEmY2X9FpJt41QLiEzm1K+cUxmNkXSyyU9UP9aLeE2SReW318o6dYRzCU08EAtvVotdIzNzCR9QdLD7v7Jmk0teYwHy7eVj3EboX4Nn5Z8fA2mlR9f1LAG8xipYZLln+19WtJYSde4+8dGJJEMZnakimdfkjRO0g2tlq+ZfVnSMhWfkrxO0ocl/aukGyUtUPHp5ee7e0u80XCQfJepOIXqklZIuqTmtfIRZWanS/qRpPsl9ZcXf1DFa+Qtd4zr5HuBWvQYtxPqV/WoYUOLGtZgHkzcBgAAeDbeuA0AAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJBAkwQAAJDw/wHOE1wB8z5OigAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 720x720 with 4 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    " start_time = time.time()\n",
+    "incorrect = []\n",
+    "for i in range(len(y_test)):\n",
+    "    if(not Y_pred_classes[i] == Y_true[i]):\n",
+    "        incorrect.append(i)\n",
+    "    if(len(incorrect) == 4):\n",
+    "        break\n",
+    "        \n",
+    "fig, ax = plt.subplots(2,2, figsize=(12,6))\n",
+    "fig.set_size_inches(10,10)\n",
+    "ax[0,0].imshow(x_test[incorrect[0]].reshape(28,28), cmap='gray')\n",
+    "ax[0,0].set_title(\"Predicted Label : \" + str(clothing2[Y_pred_classes[incorrect[0]]]) + \"\\n\"+\"Actual Label : \" + \n",
+    "                 str(clothing2[Y_true[incorrect[0]]]))\n",
+    "ax[0,1].imshow(x_test[incorrect[1]].reshape(28,28), cmap='gray')\n",
+    "ax[0,1].set_title(\"Predicted Label : \" + str(clothing2[Y_pred_classes[incorrect[1]]]) + \"\\n\"+\"Actual Label : \" + \n",
+    "                 str(clothing2[Y_true[incorrect[1]]]))\n",
+    "ax[1,0].imshow(x_test[incorrect[2]].reshape(28,28), cmap='gray')\n",
+    "ax[1,0].set_title(\"Predicted Label : \" + str(clothing2[Y_pred_classes[incorrect[2]]]) + \"\\n\"+\"Actual Label : \" + \n",
+    "                 str(clothing2[Y_true[incorrect[2]]]))\n",
+    "ax[1,1].imshow(x_test[incorrect[3]].reshape(28,28), cmap='gray')\n",
+    "ax[1,1].set_title(\"Predicted Label : \" + str(clothing2[Y_pred_classes[incorrect[3]]]) + \"\\n\"+\"Actual Label : \" + \n",
+    "                 str(clothing2[Y_true[incorrect[3]]]))\n",
+    "\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "stable-clone",
+   "metadata": {
+    "papermill": {
+     "duration": 0.084053,
+     "end_time": "2021-04-26T04:14:24.587091",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:24.503038",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "activated-inside",
+   "metadata": {
+    "papermill": {
+     "duration": 0.083947,
+     "end_time": "2021-04-26T04:14:24.754042",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:24.670095",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4.12 Classification Report\n",
+    "\n",
+    "The classification report visualizer displays the precision, recall, F1, and support scores for the model.\n",
+    "\n",
+    "1. Precision :\n",
+    "    - Precision is the ability of a classiifer not to label an instance positive that is actually negative. \n",
+    "    - Basically, it is defined as as the ratio of true positives to the sum of true and false positives. “For all instances classified positive, what percent was correct?”\n",
+    "\n",
+    "2. Recall :\n",
+    "\n",
+    "    - Recall is the ability of a classifier to find all positive instances. \n",
+    "    - For each class it is defined as the ratio of true positives to the sum of true positives and false negatives. “For all instances that were actually positive, what percent was classified correctly?”\n",
+    "\n",
+    "3. F1 Score:\n",
+    "\n",
+    "    - The F1 score is a weighted harmonic mean of precision and recall such that the best score is 1.0 and the worst is 0.0 . \n",
+    "    - Generally speaking, F1 scores are lower than accuracy measures as they embed precision and recall into their computation.\n",
+    "\n",
+    "4. Supprt :\n",
+    "\n",
+    "    - Support is the number of actual occurrences of the class in the specified dataset. \n",
+    "    - Imbalanced support in the training data may indicate structural weaknesses in the reported scores of the classifier and could indicate the need for stratified sampling or rebalancing.\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "continued-spyware",
+   "metadata": {
+    "papermill": {
+     "duration": 0.08328,
+     "end_time": "2021-04-26T04:14:24.922105",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:24.838825",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "gross-attack",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:25.094805Z",
+     "iopub.status.busy": "2021-04-26T04:14:25.094277Z",
+     "iopub.status.idle": "2021-04-26T04:14:25.112540Z",
+     "shell.execute_reply": "2021-04-26T04:14:25.111699Z"
+    },
+    "papermill": {
+     "duration": 0.105877,
+     "end_time": "2021-04-26T04:14:25.112656",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:25.006779",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "              precision    recall  f1-score   support\n",
+      "\n",
+      "           1       0.91      0.91      0.91      1221\n",
+      "           2       0.88      0.82      0.85      1197\n",
+      "           3       0.82      0.81      0.82      1203\n",
+      "           4       0.86      0.92      0.89      1225\n",
+      "           5       0.94      0.97      0.95      1154\n",
+      "\n",
+      "    accuracy                           0.88      6000\n",
+      "   macro avg       0.88      0.88      0.88      6000\n",
+      "weighted avg       0.88      0.88      0.88      6000\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "classes = ['1','2','3','4','5']\n",
+    "print(classification_report(Y_true, Y_pred_classes, target_names = classes,zero_division=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "progressive-pottery",
+   "metadata": {
+    "papermill": {
+     "duration": 0.084676,
+     "end_time": "2021-04-26T04:14:25.280847",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:25.196171",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4.13 Other models :\n",
+    "\n",
+    "- Resnet Model (4.14)\n",
+    "- ML model ( RandomForest ) (4.15)\n",
+    "- Simple Neural Networks (4.16)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "recorded-playing",
+   "metadata": {
+    "papermill": {
+     "duration": 0.083657,
+     "end_time": "2021-04-26T04:14:25.449295",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:25.365638",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4.14 Resnet Published Architecture\n",
+    "\n",
+    "**Disadvantages of CNN :**\n",
+    "1. When we increase the number of layers in CNN, there is a common problem in deep learning associated with that called Vanishing/Exploding gradient.\n",
+    "2. This causes the gradient to become 0 or too large. Thus when we increases number of layers, the training and test error rate also increases.\n",
+    "\n",
+    "**Solution : Residuals blocks**\n",
+    "- In order to solve the problem of the vanishing/exploding gradient, this architecture introduced the concept called Residual Network.\n",
+    "- Residuals network we use a technique called skip connections . The skip connection skips training from a few layers and connects directly to the output.\n",
+    "\n",
+    "![](https://miro.medium.com/max/477/0*sGlmENAXIZhSqyFZ)\n",
+    "\n",
+    "- The picture above is the most important thing to learn in Resnet Architecture.\n",
+    "- We implemented this and test it out, the most important modification to understand is the ‘Skip Connection’, identity mapping.\n",
+    "- The Skip Connections between layers add the outputs from previous layers to the outputs of stacked layers.This results in the ability to train much deeper networks than what was previously possible.\n",
+    "- This identity mapping does not have any parameters and is just there to add the output from the previous layer to the layer ahead.\n",
+    "\n",
+    "\n",
+    "**Identity mapping work in Resnet :**\n",
+    "\n",
+    "- During backpropagation, there are two pathways for the gradients to transit back to the input layer while traversing a residual block.\n",
+    "    1. pathway-1 is the identity mapping way\n",
+    "    2. pathway-2 is the residual mapping way.\n",
+    "\n",
+    "![](https://cdn-5f733ed3c1ac190fbc56ef88.closte.com/wp-content/uploads/2019/07/Grad_path.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "sharing-azerbaijan",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:25.632652Z",
+     "iopub.status.busy": "2021-04-26T04:14:25.631815Z",
+     "iopub.status.idle": "2021-04-26T04:14:25.984366Z",
+     "shell.execute_reply": "2021-04-26T04:14:25.983569Z"
+    },
+    "papermill": {
+     "duration": 0.452019,
+     "end_time": "2021-04-26T04:14:25.984554",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:25.532535",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: \"model\"\n",
+      "__________________________________________________________________________________________________\n",
+      "Layer (type)                    Output Shape         Param #     Connected to                     \n",
+      "==================================================================================================\n",
+      "input_1 (InputLayer)            [(None, 28, 28, 1)]  0                                            \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_4 (Conv2D)               (None, 14, 14, 64)   3200        input_1[0][0]                    \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_5 (BatchNor (None, 14, 14, 64)   256         conv2d_4[0][0]                   \n",
+      "__________________________________________________________________________________________________\n",
+      "activation (Activation)         (None, 14, 14, 64)   0           batch_normalization_5[0][0]      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_5 (Conv2D)               (None, 14, 14, 64)   36928       activation[0][0]                 \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_6 (BatchNor (None, 14, 14, 64)   256         conv2d_5[0][0]                   \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_1 (Activation)       (None, 14, 14, 64)   0           batch_normalization_6[0][0]      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_6 (Conv2D)               (None, 14, 14, 64)   36928       activation_1[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_7 (BatchNor (None, 14, 14, 64)   256         conv2d_6[0][0]                   \n",
+      "__________________________________________________________________________________________________\n",
+      "add (Add)                       (None, 14, 14, 64)   0           activation[0][0]                 \n",
+      "                                                                 batch_normalization_7[0][0]      \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_2 (Activation)       (None, 14, 14, 64)   0           add[0][0]                        \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_7 (Conv2D)               (None, 14, 14, 64)   36928       activation_2[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_8 (BatchNor (None, 14, 14, 64)   256         conv2d_7[0][0]                   \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_3 (Activation)       (None, 14, 14, 64)   0           batch_normalization_8[0][0]      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_8 (Conv2D)               (None, 14, 14, 64)   36928       activation_3[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_9 (BatchNor (None, 14, 14, 64)   256         conv2d_8[0][0]                   \n",
+      "__________________________________________________________________________________________________\n",
+      "add_1 (Add)                     (None, 14, 14, 64)   0           activation_2[0][0]               \n",
+      "                                                                 batch_normalization_9[0][0]      \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_4 (Activation)       (None, 14, 14, 64)   0           add_1[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_9 (Conv2D)               (None, 7, 7, 128)    73856       activation_4[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_10 (BatchNo (None, 7, 7, 128)    512         conv2d_9[0][0]                   \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_5 (Activation)       (None, 7, 7, 128)    0           batch_normalization_10[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_10 (Conv2D)              (None, 7, 7, 128)    147584      activation_5[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_11 (Conv2D)              (None, 7, 7, 128)    8320        activation_4[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_11 (BatchNo (None, 7, 7, 128)    512         conv2d_10[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_2 (Add)                     (None, 7, 7, 128)    0           conv2d_11[0][0]                  \n",
+      "                                                                 batch_normalization_11[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_6 (Activation)       (None, 7, 7, 128)    0           add_2[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_12 (Conv2D)              (None, 7, 7, 128)    147584      activation_6[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_12 (BatchNo (None, 7, 7, 128)    512         conv2d_12[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_7 (Activation)       (None, 7, 7, 128)    0           batch_normalization_12[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_13 (Conv2D)              (None, 7, 7, 128)    147584      activation_7[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_13 (BatchNo (None, 7, 7, 128)    512         conv2d_13[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_3 (Add)                     (None, 7, 7, 128)    0           activation_6[0][0]               \n",
+      "                                                                 batch_normalization_13[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_8 (Activation)       (None, 7, 7, 128)    0           add_3[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_14 (Conv2D)              (None, 4, 4, 256)    295168      activation_8[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_14 (BatchNo (None, 4, 4, 256)    1024        conv2d_14[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_9 (Activation)       (None, 4, 4, 256)    0           batch_normalization_14[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_15 (Conv2D)              (None, 4, 4, 256)    590080      activation_9[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_16 (Conv2D)              (None, 4, 4, 256)    33024       activation_8[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_15 (BatchNo (None, 4, 4, 256)    1024        conv2d_15[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_4 (Add)                     (None, 4, 4, 256)    0           conv2d_16[0][0]                  \n",
+      "                                                                 batch_normalization_15[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_10 (Activation)      (None, 4, 4, 256)    0           add_4[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_17 (Conv2D)              (None, 4, 4, 256)    590080      activation_10[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_16 (BatchNo (None, 4, 4, 256)    1024        conv2d_17[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_11 (Activation)      (None, 4, 4, 256)    0           batch_normalization_16[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_18 (Conv2D)              (None, 4, 4, 256)    590080      activation_11[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_17 (BatchNo (None, 4, 4, 256)    1024        conv2d_18[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_5 (Add)                     (None, 4, 4, 256)    0           activation_10[0][0]              \n",
+      "                                                                 batch_normalization_17[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_12 (Activation)      (None, 4, 4, 256)    0           add_5[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_19 (Conv2D)              (None, 2, 2, 512)    1180160     activation_12[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_18 (BatchNo (None, 2, 2, 512)    2048        conv2d_19[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_13 (Activation)      (None, 2, 2, 512)    0           batch_normalization_18[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_20 (Conv2D)              (None, 2, 2, 512)    2359808     activation_13[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_21 (Conv2D)              (None, 2, 2, 512)    131584      activation_12[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_19 (BatchNo (None, 2, 2, 512)    2048        conv2d_20[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_6 (Add)                     (None, 2, 2, 512)    0           conv2d_21[0][0]                  \n",
+      "                                                                 batch_normalization_19[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_14 (Activation)      (None, 2, 2, 512)    0           add_6[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_22 (Conv2D)              (None, 2, 2, 512)    2359808     activation_14[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_20 (BatchNo (None, 2, 2, 512)    2048        conv2d_22[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_15 (Activation)      (None, 2, 2, 512)    0           batch_normalization_20[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_23 (Conv2D)              (None, 2, 2, 512)    2359808     activation_15[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_21 (BatchNo (None, 2, 2, 512)    2048        conv2d_23[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_7 (Add)                     (None, 2, 2, 512)    0           activation_14[0][0]              \n",
+      "                                                                 batch_normalization_21[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_16 (Activation)      (None, 2, 2, 512)    0           add_7[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "average_pooling2d (AveragePooli (None, 1, 1, 512)    0           activation_16[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "flatten_1 (Flatten)             (None, 512)          0           average_pooling2d[0][0]          \n",
+      "__________________________________________________________________________________________________\n",
+      "dense_3 (Dense)                 (None, 5)            2565        flatten_1[0][0]                  \n",
+      "==================================================================================================\n",
+      "Total params: 11,183,621\n",
+      "Trainable params: 11,175,813\n",
+      "Non-trainable params: 7,808\n",
+      "__________________________________________________________________________________________________\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_size = (28, 28,1)\n",
+    "num_filters = 64\n",
+    "use_max_pool = False\n",
+    "num_blocks = 4\n",
+    "num_sub_blocks = 2\n",
+    "num_classes = 5\n",
+    "inputs = Input(shape=input_size)\n",
+    "con_x = Conv2D(num_filters, padding='same', \n",
+    "           kernel_initializer='he_normal', \n",
+    "           kernel_size=7, strides=2,\n",
+    "           kernel_regularizer=l2(1e-4))(inputs)\n",
+    "con_x = BatchNormalization()(con_x)\n",
+    "con_x = Activation('relu')(con_x)\n",
+    "\n",
+    "#Check by applying max pooling later (setting it false as size of image is small i.e. 28x28)\n",
+    "if use_max_pool:\n",
+    "    con_x = MaxPooling2D(pool_size=3,padding='same', strides=2)(con_x)\n",
+    "    num_blocks =3\n",
+    "#Creating Conv base stack \n",
+    "\n",
+    "# Instantiate convolutional base (stack of blocks).\n",
+    "for i in range(num_blocks):\n",
+    "    for j in range(num_sub_blocks):\n",
+    "        strides = 1\n",
+    "        is_first_layer_but_not_first_block = j == 0 and i > 0\n",
+    "        if is_first_layer_but_not_first_block:\n",
+    "            strides = 2\n",
+    "        #Creating residual mapping using y\n",
+    "        con_y = Conv2D(num_filters,\n",
+    "                   kernel_size=3,\n",
+    "                   padding='same',\n",
+    "                   strides=strides,\n",
+    "                   kernel_initializer='he_normal',\n",
+    "                   kernel_regularizer=l2(1e-4))(con_x)\n",
+    "        con_y = BatchNormalization()(con_y)\n",
+    "        con_y = Activation('relu')(con_y)\n",
+    "        con_y = Conv2D(num_filters,\n",
+    "                   kernel_size=3,\n",
+    "                   padding='same',\n",
+    "                   kernel_initializer='he_normal',\n",
+    "                   kernel_regularizer=l2(1e-4))(con_y)\n",
+    "        con_y = BatchNormalization()(con_y)\n",
+    "        if is_first_layer_but_not_first_block:\n",
+    "            con_x = Conv2D(num_filters,\n",
+    "                       kernel_size=1,\n",
+    "                       padding='same',\n",
+    "                       strides=2,\n",
+    "                       kernel_initializer='he_normal',\n",
+    "                       kernel_regularizer=l2(1e-4))(con_x)\n",
+    "        #Adding back residual mapping\n",
+    "        con_x = keras.layers.add([con_x, con_y])\n",
+    "        con_x = Activation('relu')(con_x)\n",
+    "\n",
+    "    num_filters = 2 * num_filters\n",
+    "\n",
+    "# Add classifier on top.\n",
+    "con_x = AveragePooling2D()(con_x)\n",
+    "con_y = Flatten()(con_x)\n",
+    "outputs = Dense(num_classes,\n",
+    "                activation='softmax',\n",
+    "                kernel_initializer='he_normal')(con_y)\n",
+    "\n",
+    "# Instantiate and compile model.\n",
+    "resmodel = Model(inputs=inputs, outputs=outputs)\n",
+    "resmodel.compile(loss='categorical_crossentropy',\n",
+    "              optimizer='adam',\n",
+    "              metrics=['accuracy'])\n",
+    "resmodel.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "clean-solution",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:26.166182Z",
+     "iopub.status.busy": "2021-04-26T04:14:26.165307Z",
+     "iopub.status.idle": "2021-04-26T04:14:26.170363Z",
+     "shell.execute_reply": "2021-04-26T04:14:26.169591Z"
+    },
+    "papermill": {
+     "duration": 0.098693,
+     "end_time": "2021-04-26T04:14:26.170528",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:26.071835",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/kaggle/working/saved_model/fmnist_resnet_model.h5\n"
+     ]
+    }
+   ],
+   "source": [
+    "save_dir = os.path.join(os.getcwd(), 'saved_model')\n",
+    "model_name = 'fmnist_resnet_model.h5'\n",
+    "if not os.path.isdir(save_dir):\n",
+    "    os.makedirs(save_dir)\n",
+    "filepath = os.path.join(save_dir,model_name)\n",
+    "print(filepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "preliminary-course",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:26.348268Z",
+     "iopub.status.busy": "2021-04-26T04:14:26.346569Z",
+     "iopub.status.idle": "2021-04-26T04:14:26.348829Z",
+     "shell.execute_reply": "2021-04-26T04:14:26.349249Z"
+    },
+    "papermill": {
+     "duration": 0.092645,
+     "end_time": "2021-04-26T04:14:26.349379",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:26.256734",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "checkpoint = ModelCheckpoint(filepath=filepath,\n",
+    "                             verbose=1,\n",
+    "                             save_best_only=True)\n",
+    "lr_reducer = ReduceLROnPlateau(factor=np.sqrt(0.1),\n",
+    "                               cooldown=0,\n",
+    "                               patience=5,\n",
+    "                               min_lr=0.5e-6)\n",
+    "callbacks = [checkpoint, lr_reducer]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "polyphonic-armor",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:14:26.525860Z",
+     "iopub.status.busy": "2021-04-26T04:14:26.524972Z",
+     "iopub.status.idle": "2021-04-26T04:19:18.489598Z",
+     "shell.execute_reply": "2021-04-26T04:19:18.490281Z"
+    },
+    "papermill": {
+     "duration": 292.055615,
+     "end_time": "2021-04-26T04:19:18.490477",
+     "exception": false,
+     "start_time": "2021-04-26T04:14:26.434862",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/25\n",
+      "375/375 [==============================] - 15s 32ms/step - loss: 1.6820 - accuracy: 0.7596 - val_loss: 1.2298 - val_accuracy: 0.8082\n",
+      "\n",
+      "Epoch 00001: val_loss improved from inf to 1.22979, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 2/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 1.0116 - accuracy: 0.8678 - val_loss: 0.8698 - val_accuracy: 0.8732\n",
+      "\n",
+      "Epoch 00002: val_loss improved from 1.22979 to 0.86977, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 3/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.7827 - accuracy: 0.8951 - val_loss: 0.7868 - val_accuracy: 0.8610\n",
+      "\n",
+      "Epoch 00003: val_loss improved from 0.86977 to 0.78685, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 4/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.6456 - accuracy: 0.9054 - val_loss: 0.6776 - val_accuracy: 0.8732\n",
+      "\n",
+      "Epoch 00004: val_loss improved from 0.78685 to 0.67758, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 5/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.5667 - accuracy: 0.9121 - val_loss: 0.6469 - val_accuracy: 0.8623\n",
+      "\n",
+      "Epoch 00005: val_loss improved from 0.67758 to 0.64695, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 6/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.4993 - accuracy: 0.9210 - val_loss: 0.6036 - val_accuracy: 0.8720\n",
+      "\n",
+      "Epoch 00006: val_loss improved from 0.64695 to 0.60361, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 7/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.4775 - accuracy: 0.9174 - val_loss: 0.6161 - val_accuracy: 0.8680\n",
+      "\n",
+      "Epoch 00007: val_loss did not improve from 0.60361\n",
+      "Epoch 8/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.4364 - accuracy: 0.9282 - val_loss: 0.5329 - val_accuracy: 0.8855\n",
+      "\n",
+      "Epoch 00008: val_loss improved from 0.60361 to 0.53287, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 9/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.4021 - accuracy: 0.9353 - val_loss: 0.5221 - val_accuracy: 0.8907\n",
+      "\n",
+      "Epoch 00009: val_loss improved from 0.53287 to 0.52208, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 10/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.3947 - accuracy: 0.9346 - val_loss: 0.6084 - val_accuracy: 0.8567\n",
+      "\n",
+      "Epoch 00010: val_loss did not improve from 0.52208\n",
+      "Epoch 11/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.3781 - accuracy: 0.9384 - val_loss: 0.5153 - val_accuracy: 0.8905\n",
+      "\n",
+      "Epoch 00011: val_loss improved from 0.52208 to 0.51527, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 12/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.3649 - accuracy: 0.9404 - val_loss: 0.5756 - val_accuracy: 0.8645\n",
+      "\n",
+      "Epoch 00012: val_loss did not improve from 0.51527\n",
+      "Epoch 13/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.3521 - accuracy: 0.9450 - val_loss: 0.5187 - val_accuracy: 0.8970\n",
+      "\n",
+      "Epoch 00013: val_loss did not improve from 0.51527\n",
+      "Epoch 14/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.3408 - accuracy: 0.9472 - val_loss: 0.5952 - val_accuracy: 0.8648\n",
+      "\n",
+      "Epoch 00014: val_loss did not improve from 0.51527\n",
+      "Epoch 15/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.3264 - accuracy: 0.9514 - val_loss: 0.5585 - val_accuracy: 0.8838\n",
+      "\n",
+      "Epoch 00015: val_loss did not improve from 0.51527\n",
+      "Epoch 16/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.3335 - accuracy: 0.9488 - val_loss: 0.5695 - val_accuracy: 0.8688\n",
+      "\n",
+      "Epoch 00016: val_loss did not improve from 0.51527\n",
+      "Epoch 17/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.2679 - accuracy: 0.9713 - val_loss: 0.5490 - val_accuracy: 0.8945\n",
+      "\n",
+      "Epoch 00017: val_loss did not improve from 0.51527\n",
+      "Epoch 18/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.2156 - accuracy: 0.9851 - val_loss: 0.5908 - val_accuracy: 0.8947\n",
+      "\n",
+      "Epoch 00018: val_loss did not improve from 0.51527\n",
+      "Epoch 19/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.2031 - accuracy: 0.9873 - val_loss: 0.5655 - val_accuracy: 0.9003\n",
+      "\n",
+      "Epoch 00019: val_loss did not improve from 0.51527\n",
+      "Epoch 20/25\n",
+      "375/375 [==============================] - 12s 31ms/step - loss: 0.1922 - accuracy: 0.9874 - val_loss: 0.5693 - val_accuracy: 0.8988\n",
+      "\n",
+      "Epoch 00020: val_loss did not improve from 0.51527\n",
+      "Epoch 21/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.1797 - accuracy: 0.9891 - val_loss: 0.6406 - val_accuracy: 0.8910\n",
+      "\n",
+      "Epoch 00021: val_loss did not improve from 0.51527\n",
+      "Epoch 22/25\n",
+      "375/375 [==============================] - 11s 31ms/step - loss: 0.1679 - accuracy: 0.9931 - val_loss: 0.5968 - val_accuracy: 0.9013\n",
+      "\n",
+      "Epoch 00022: val_loss did not improve from 0.51527\n",
+      "Epoch 23/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.1522 - accuracy: 0.9967 - val_loss: 0.5966 - val_accuracy: 0.9045\n",
+      "\n",
+      "Epoch 00023: val_loss did not improve from 0.51527\n",
+      "Epoch 24/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.1441 - accuracy: 0.9983 - val_loss: 0.6098 - val_accuracy: 0.9068\n",
+      "\n",
+      "Epoch 00024: val_loss did not improve from 0.51527\n",
+      "Epoch 25/25\n",
+      "375/375 [==============================] - 11s 31ms/step - loss: 0.1421 - accuracy: 0.9975 - val_loss: 0.6334 - val_accuracy: 0.9027\n",
+      "\n",
+      "Epoch 00025: val_loss did not improve from 0.51527\n",
+      "--- 291.9615297317505 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time()\n",
+    "resmodel.fit(x_train, y_train, batch_size=batch_size,\n",
+    "              epochs=epochs,\n",
+    "              validation_data=(x_val, y_val),\n",
+    "              shuffle=True,\n",
+    "              callbacks=callbacks)\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time)) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "heard-italian",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:19:21.388933Z",
+     "iopub.status.busy": "2021-04-26T04:19:21.388037Z",
+     "iopub.status.idle": "2021-04-26T04:19:22.850332Z",
+     "shell.execute_reply": "2021-04-26T04:19:22.849822Z"
+    },
+    "papermill": {
+     "duration": 2.802726,
+     "end_time": "2021-04-26T04:19:22.850458",
+     "exception": false,
+     "start_time": "2021-04-26T04:19:20.047732",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "188/188 [==============================] - 1s 7ms/step - loss: 0.6334 - accuracy: 0.9027\n",
+      "Loss: 0.6334\n",
+      "Accuracy: 0.9027\n",
+      "--- 1.459258794784546 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "score = resmodel.evaluate(x_val, y_val)\n",
+    "\n",
+    "print('Loss: {:.4f}'.format(score[0]))\n",
+    "print('Accuracy: {:.4f}'.format(score[1]))\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "related-soviet",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:19:26.031075Z",
+     "iopub.status.busy": "2021-04-26T04:19:26.030170Z",
+     "iopub.status.idle": "2021-04-26T04:19:27.364967Z",
+     "shell.execute_reply": "2021-04-26T04:19:27.365570Z"
+    },
+    "papermill": {
+     "duration": 3.198847,
+     "end_time": "2021-04-26T04:19:27.365769",
+     "exception": false,
+     "start_time": "2021-04-26T04:19:24.166922",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "188/188 [==============================] - 1s 7ms/step - loss: 0.6334 - accuracy: 0.9027\n",
+      "Test loss: 0.633379340171814\n",
+      "Test accuracy: 0.9026666879653931\n"
+     ]
+    }
+   ],
+   "source": [
+    "scores = resmodel.evaluate(x_val, y_val, verbose=1)\n",
+    "print('Test loss:', scores[0])\n",
+    "print('Test accuracy:', scores[1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "parental-fiction",
+   "metadata": {
+    "papermill": {
+     "duration": 1.545326,
+     "end_time": "2021-04-26T04:19:30.275611",
+     "exception": false,
+     "start_time": "2021-04-26T04:19:28.730285",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Advantages of Resnet :**\n",
+    "\n",
+    "1. ResNet uses Batch Normalization at its core. The Batch Normalization adjusts the input layer to increase the performance of the network. \n",
+    "2. ResNet makes use of the Identity Connection, which helps to protect the network from vanishing gradient problem.\n",
+    "3. Deep Residual Network uses bottleneck residual block design to increase the performance of the network."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dramatic-december",
+   "metadata": {
+    "papermill": {
+     "duration": 1.336231,
+     "end_time": "2021-04-26T04:19:32.954826",
+     "exception": false,
+     "start_time": "2021-04-26T04:19:31.618595",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4.15 Machine Learning model (Random Forest with Gridsearch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "regulation-overview",
+   "metadata": {
+    "papermill": {
+     "duration": 1.342898,
+     "end_time": "2021-04-26T04:19:35.671544",
+     "exception": false,
+     "start_time": "2021-04-26T04:19:34.328646",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "- In this model we use **GridSearchCV** for tuning hyperparameter of the classifier to evaluate the best accuaracy for the best max_depth value from [3,5,10,None] and best number of trees from [5,10,50,150,200] (Which values we supposed to selected in previous assignment).\n",
+    "- Here we use 3-fold validation else we are going to face MemoeryLeak or TimeOut error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "opposed-contrary",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:19:38.365951Z",
+     "iopub.status.busy": "2021-04-26T04:19:38.364122Z",
+     "iopub.status.idle": "2021-04-26T04:19:38.366529Z",
+     "shell.execute_reply": "2021-04-26T04:19:38.366912Z"
+    },
+    "papermill": {
+     "duration": 1.364932,
+     "end_time": "2021-04-26T04:19:38.367067",
+     "exception": false,
+     "start_time": "2021-04-26T04:19:37.002135",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "param_grid = {\n",
+    "    'bootstrap': [True],\n",
+    "    'max_depth': [3,5,10, None],\n",
+    "    'n_estimators': [5,10,50,150, 200]\n",
+    "}\n",
+    "# Create a based model\n",
+    "rfc = RandomForestClassifier()\n",
+    "# Instantiate the grid search model\n",
+    "grid_search = GridSearchCV(estimator = rfc, param_grid = param_grid, \n",
+    "                          cv = 3, n_jobs = -1, verbose = 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "cloudy-throw",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:19:41.338256Z",
+     "iopub.status.busy": "2021-04-26T04:19:41.337498Z",
+     "iopub.status.idle": "2021-04-26T04:38:34.162428Z",
+     "shell.execute_reply": "2021-04-26T04:38:34.162910Z"
+    },
+    "papermill": {
+     "duration": 1134.460502,
+     "end_time": "2021-04-26T04:38:34.163191",
+     "exception": false,
+     "start_time": "2021-04-26T04:19:39.702689",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 3 folds for each of 20 candidates, totalling 60 fits\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'bootstrap': True, 'max_depth': None, 'n_estimators': 200}"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grid_search.fit(x_train1,y_train)\n",
+    "grid_search.best_params_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lesser-falls",
+   "metadata": {
+    "papermill": {
+     "duration": 1.339142,
+     "end_time": "2021-04-26T04:38:36.853910",
+     "exception": false,
+     "start_time": "2021-04-26T04:38:35.514768",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Note :** \n",
+    "\n",
+    "- We have test this model using different combinations of max_depth, n_ estimators and k-fold cross validation and encounter that we should make these values limited else we face below error of timeout/mermory leak :\n",
+    "\n",
+    "/opt/conda/lib/python3.7/site-packages/joblib/externals/loky/process_executor.py:691: UserWarning: A worker stopped while some jobs were given to the executor. This can be caused by a too short worker timeout or by a memory leak.\n",
+    "  \"timeout or by a memory leak.\", UserWarning\n",
+    "  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "genetic-exhibit",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:38:39.592420Z",
+     "iopub.status.busy": "2021-04-26T04:38:39.591510Z",
+     "iopub.status.idle": "2021-04-26T04:38:40.252189Z",
+     "shell.execute_reply": "2021-04-26T04:38:40.251406Z"
+    },
+    "papermill": {
+     "duration": 1.994756,
+     "end_time": "2021-04-26T04:38:40.252323",
+     "exception": false,
+     "start_time": "2021-04-26T04:38:38.257567",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "y_pred_rf = grid_search.predict(x_val1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "piano-oasis",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:38:42.939750Z",
+     "iopub.status.busy": "2021-04-26T04:38:42.938981Z",
+     "iopub.status.idle": "2021-04-26T04:38:42.946957Z",
+     "shell.execute_reply": "2021-04-26T04:38:42.947482Z"
+    },
+    "papermill": {
+     "duration": 1.34388,
+     "end_time": "2021-04-26T04:38:42.947616",
+     "exception": false,
+     "start_time": "2021-04-26T04:38:41.603736",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy for random forest: 0.8116666666666666\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Accuracy for random forest:',metrics.accuracy_score(y_val,y_pred_rf))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "smaller-tower",
+   "metadata": {
+    "papermill": {
+     "duration": 1.598242,
+     "end_time": "2021-04-26T04:38:45.882131",
+     "exception": false,
+     "start_time": "2021-04-26T04:38:44.283889",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Additional point in Machine Learning model about performance :\n",
+    "We can achieve **more accuracy** in this model if we apply **dimensionality reduction techniques (e.g PCA )** on data as we have too many number of features available to predict labels."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wooden-singles",
+   "metadata": {
+    "papermill": {
+     "duration": 1.325331,
+     "end_time": "2021-04-26T04:38:49.005768",
+     "exception": false,
+     "start_time": "2021-04-26T04:38:47.680437",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4.16 Simple Neural Networks\n",
+    "\n",
+    "1) In our simple neural network model, we are not adding any convolutional, maxpooling, batch normalization or dropout layer.\n",
+    "\n",
+    "2) Firstly we used Sequential Keras API which is just a linear stack of layers.\n",
+    "\n",
+    "3) Then we include Flatten layer to map the input to a 1D vector.\n",
+    "\n",
+    "4) Lastly, we add the Dense (Output) Layer. It has units equal to the number of classes to be identified.Here, we use 'softmax' function since it is Multi-Class Classification. For binary classification we can use 'sigmoid' function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "regulation-clark",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:38:51.717095Z",
+     "iopub.status.busy": "2021-04-26T04:38:51.714651Z",
+     "iopub.status.idle": "2021-04-26T04:38:51.737833Z",
+     "shell.execute_reply": "2021-04-26T04:38:51.737403Z"
+    },
+    "papermill": {
+     "duration": 1.405981,
+     "end_time": "2021-04-26T04:38:51.737953",
+     "exception": false,
+     "start_time": "2021-04-26T04:38:50.331972",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from tensorflow import keras\n",
+    "model3 = keras.Sequential([\n",
+    "    keras.layers.Flatten(input_shape=(28, 28)),\n",
+    "    keras.layers.Dense(128, activation='relu'),\n",
+    "    keras.layers.Dense(5, activation='softmax')\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "negative-liquid",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:38:54.390699Z",
+     "iopub.status.busy": "2021-04-26T04:38:54.389795Z",
+     "iopub.status.idle": "2021-04-26T04:38:54.394877Z",
+     "shell.execute_reply": "2021-04-26T04:38:54.394359Z"
+    },
+    "papermill": {
+     "duration": 1.332225,
+     "end_time": "2021-04-26T04:38:54.395004",
+     "exception": false,
+     "start_time": "2021-04-26T04:38:53.062779",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: \"sequential_1\"\n",
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "flatten_2 (Flatten)          (None, 784)               0         \n",
+      "_________________________________________________________________\n",
+      "dense_4 (Dense)              (None, 128)               100480    \n",
+      "_________________________________________________________________\n",
+      "dense_5 (Dense)              (None, 5)                 645       \n",
+      "=================================================================\n",
+      "Total params: 101,125\n",
+      "Trainable params: 101,125\n",
+      "Non-trainable params: 0\n",
+      "_________________________________________________________________\n"
+     ]
+    }
+   ],
+   "source": [
+    "model3.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "growing-color",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:38:57.296679Z",
+     "iopub.status.busy": "2021-04-26T04:38:57.295726Z",
+     "iopub.status.idle": "2021-04-26T04:38:57.300592Z",
+     "shell.execute_reply": "2021-04-26T04:38:57.300101Z"
+    },
+    "papermill": {
+     "duration": 1.475527,
+     "end_time": "2021-04-26T04:38:57.300704",
+     "exception": false,
+     "start_time": "2021-04-26T04:38:55.825177",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model3.compile(optimizer='adam', loss=\"categorical_crossentropy\", metrics=[\"accuracy\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "french-publication",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:39:00.045988Z",
+     "iopub.status.busy": "2021-04-26T04:39:00.044943Z",
+     "iopub.status.idle": "2021-04-26T04:45:07.114331Z",
+     "shell.execute_reply": "2021-04-26T04:45:07.115119Z"
+    },
+    "papermill": {
+     "duration": 368.417514,
+     "end_time": "2021-04-26T04:45:07.115327",
+     "exception": false,
+     "start_time": "2021-04-26T04:38:58.697813",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/25\n",
+      "375/375 - 14s - loss: 0.9608 - accuracy: 0.5939 - val_loss: 0.7760 - val_accuracy: 0.6875\n",
+      "Epoch 2/25\n",
+      "375/375 - 15s - loss: 0.7777 - accuracy: 0.6824 - val_loss: 0.6751 - val_accuracy: 0.7293\n",
+      "Epoch 3/25\n",
+      "375/375 - 14s - loss: 0.7201 - accuracy: 0.7059 - val_loss: 0.6495 - val_accuracy: 0.7388\n",
+      "Epoch 4/25\n",
+      "375/375 - 15s - loss: 0.6873 - accuracy: 0.7221 - val_loss: 0.6172 - val_accuracy: 0.7490\n",
+      "Epoch 5/25\n",
+      "375/375 - 14s - loss: 0.6551 - accuracy: 0.7365 - val_loss: 0.6147 - val_accuracy: 0.7463\n",
+      "Epoch 6/25\n",
+      "375/375 - 15s - loss: 0.6466 - accuracy: 0.7386 - val_loss: 0.5981 - val_accuracy: 0.7545\n",
+      "Epoch 7/25\n",
+      "375/375 - 15s - loss: 0.6322 - accuracy: 0.7458 - val_loss: 0.5727 - val_accuracy: 0.7645\n",
+      "Epoch 8/25\n",
+      "375/375 - 14s - loss: 0.6202 - accuracy: 0.7533 - val_loss: 0.5832 - val_accuracy: 0.7555\n",
+      "Epoch 9/25\n",
+      "375/375 - 15s - loss: 0.6151 - accuracy: 0.7546 - val_loss: 0.5599 - val_accuracy: 0.7838\n",
+      "Epoch 10/25\n",
+      "375/375 - 15s - loss: 0.6064 - accuracy: 0.7580 - val_loss: 0.5552 - val_accuracy: 0.7782\n",
+      "Epoch 11/25\n",
+      "375/375 - 15s - loss: 0.5972 - accuracy: 0.7617 - val_loss: 0.5517 - val_accuracy: 0.7833\n",
+      "Epoch 12/25\n",
+      "375/375 - 14s - loss: 0.5950 - accuracy: 0.7645 - val_loss: 0.5424 - val_accuracy: 0.7827\n",
+      "Epoch 13/25\n",
+      "375/375 - 16s - loss: 0.5905 - accuracy: 0.7675 - val_loss: 0.5467 - val_accuracy: 0.7907\n",
+      "Epoch 14/25\n",
+      "375/375 - 14s - loss: 0.5878 - accuracy: 0.7677 - val_loss: 0.5513 - val_accuracy: 0.7898\n",
+      "Epoch 15/25\n",
+      "375/375 - 15s - loss: 0.5844 - accuracy: 0.7681 - val_loss: 0.5295 - val_accuracy: 0.7973\n",
+      "Epoch 16/25\n",
+      "375/375 - 15s - loss: 0.5758 - accuracy: 0.7729 - val_loss: 0.5360 - val_accuracy: 0.7855\n",
+      "Epoch 17/25\n",
+      "375/375 - 15s - loss: 0.5758 - accuracy: 0.7718 - val_loss: 0.5314 - val_accuracy: 0.8028\n",
+      "Epoch 18/25\n",
+      "375/375 - 14s - loss: 0.5719 - accuracy: 0.7733 - val_loss: 0.5263 - val_accuracy: 0.7845\n",
+      "Epoch 19/25\n",
+      "375/375 - 15s - loss: 0.5731 - accuracy: 0.7755 - val_loss: 0.5299 - val_accuracy: 0.7978\n",
+      "Epoch 20/25\n",
+      "375/375 - 15s - loss: 0.5692 - accuracy: 0.7750 - val_loss: 0.5184 - val_accuracy: 0.7997\n",
+      "Epoch 21/25\n",
+      "375/375 - 14s - loss: 0.5657 - accuracy: 0.7769 - val_loss: 0.5232 - val_accuracy: 0.8017\n",
+      "Epoch 22/25\n",
+      "375/375 - 16s - loss: 0.5640 - accuracy: 0.7792 - val_loss: 0.5152 - val_accuracy: 0.8022\n",
+      "Epoch 23/25\n",
+      "375/375 - 14s - loss: 0.5619 - accuracy: 0.7795 - val_loss: 0.5303 - val_accuracy: 0.7983\n",
+      "Epoch 24/25\n",
+      "375/375 - 14s - loss: 0.5611 - accuracy: 0.7778 - val_loss: 0.5115 - val_accuracy: 0.8067\n",
+      "Epoch 25/25\n",
+      "375/375 - 15s - loss: 0.5623 - accuracy: 0.7789 - val_loss: 0.5127 - val_accuracy: 0.8038\n"
+     ]
+    }
+   ],
+   "source": [
+    "history3 = model3.fit(datagen.flow(x_train, y_train, batch_size = batch_size), epochs = epochs, \n",
+    "                              validation_data = (x_val, y_val), verbose=2, \n",
+    "                              steps_per_epoch=x_train.shape[0] // batch_size,\n",
+    "                              callbacks = [reduce_lr])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "ideal-union",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:45:10.134501Z",
+     "iopub.status.busy": "2021-04-26T04:45:10.133462Z",
+     "iopub.status.idle": "2021-04-26T04:45:10.544242Z",
+     "shell.execute_reply": "2021-04-26T04:45:10.543586Z"
+    },
+    "papermill": {
+     "duration": 2.022165,
+     "end_time": "2021-04-26T04:45:10.544411",
+     "exception": false,
+     "start_time": "2021-04-26T04:45:08.522246",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "188/188 [==============================] - 0s 2ms/step - loss: 0.5127 - accuracy: 0.8038\n",
+      "Loss: 0.5127\n",
+      "Accuracy: 0.8038\n",
+      "--- 0.40688180923461914 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "score = model3.evaluate(x_val, y_val)\n",
+    "\n",
+    "print('Loss: {:.4f}'.format(score[0]))\n",
+    "print('Accuracy: {:.4f}'.format(score[1]))\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "dutch-review",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T04:45:13.358852Z",
+     "iopub.status.busy": "2021-04-26T04:45:13.325836Z",
+     "iopub.status.idle": "2021-04-26T04:45:13.459285Z",
+     "shell.execute_reply": "2021-04-26T04:45:13.458312Z"
+    },
+    "papermill": {
+     "duration": 1.516213,
+     "end_time": "2021-04-26T04:45:13.459412",
+     "exception": false,
+     "start_time": "2021-04-26T04:45:11.943199",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEWCAYAAAB1xKBvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAA4r0lEQVR4nO3dd3zU9f3A8dc7CUkgkySEFQJhI6Kgce+998JRoa5qnbW2avuzpba21mpttVZrLXWL1gE4ceJEWaJIQCBhBRlZhAyyLu/fH59v4IwJXMJdLsm9n4/HPe7uO9/fHNz7PuP7+YiqYowxxuxKVLgDMMYY0zVYwjDGGBMQSxjGGGMCYgnDGGNMQCxhGGOMCYglDGOMMQGxhGEinogMEREVkZgAtp0sIp90RFzGdDaWMEyXIiKrRaRORDKaLf/S+9IfEqbQ/GNJFJFKEXkz3LEYE0yWMExXtAq4sOmNiIwDeoUvnB84B6gFjhORfh154kBKSca0lyUM0xU9BVzq934S8KT/BiKSIiJPikiRiKwRkf8TkShvXbSI3CsixSJSAJzSwr7/EZENIrJeRP4gItFtiG8S8AjwNXBJs2MfKiKficgWEVknIpO95T1F5D4v1nIR+cRbdqSIFDY7xmoROdZ7PUVEXhSRp0VkKzBZRPYXkTneOTaIyD9EJNZv/7Ei8o6IlIrIJhH5lYj0E5FqEUn3224f7+/Xow3XbroxSximK/ocSBaRMd4X+UTg6WbbPAikAEOBI3AJ5sfeuiuBU4EJQC5wbrN9HwcagOHeNscDVwQSmIgMBo4EnvEelzZb96YXWx9gPLDIW30vsC9wMJAG/BJoDOScwBnAi0Cqd04f8DMgAzgIOAb4qRdDEvAu8BYwwLvG91R1IzAbON/vuD8CpqlqfYBxmG7OEobpqppKGccBS4H1TSv8ksjtqlqhqquB+3BfgOC+FP+mqutUtRT4k9++fYGTgZtUtUpVNwP3e8cLxI+Ar1U1D5gGjBWRCd66i4B3VfU5Va1X1RJVXeSVfC4DblTV9arqU9XPVLU2wHPOUdXpqtqoqttUdYGqfq6qDd61/wuXNMElyo2qep+q1nh/ny+8dU/glYi8v+GFuL+zMQBYfafpqp4CPgJyaFYdhftl3QNY47dsDTDQez0AWNdsXZPB3r4bRKRpWVSz7XfmUuDfAKq6XkQ+xFVRfQkMAvJb2CcDiG9lXSC+F5uIjAT+iis99cL9P1/grW4tBoAZwCMikgOMAspVdW47YzLdkJUwTJekqmtwjd8nAy83W10M1OO+/Jtks6MUsgH3xem/rsk6XIN1hqqmeo9kVR27q5hE5GBgBHC7iGwUkY3AAcBFXmP0OmBYC7sWAzWtrKvCr0Hf++Xfp9k2zYecfhhYBoxQ1WTgV0BT9luHq6b7AVWtAV7AlTJ+hJUuTDOWMExXdjlwtKpW+S9UVR/ui+8uEUny2g5uZkc7xwvADSKSJSK9gdv89t0AvA3cJyLJIhIlIsNE5Ah2bRLwDrAHrn1iPLAn0BM4Cde+cKyInC8iMSKSLiLjVbURmAr8VUQGeI3yB4lIHLAciBeRU7zG5/8D4nYRRxKwFagUkdHANX7rXgP6i8hNIhLn/X0O8Fv/JDAZOB1LGKYZSximy1LVfFWd38rq63G/zguAT4BncV/K4KqMZgFfAQv5YQnlUiAWyAPKcA3K/XcWi4jE49pGHlTVjX6PVbgv3kmquhZXIvo5UIpr8N7bO8QtwGJgnrfuz0CUqpbjGqwfw5WQqoDv9ZpqwS249pIK71qfb1qhqhW4dp/TgI3ACuAov/Wf4hrbF3qlOGO2E5tAyRjjT0TeB55V1cfCHYvpXCxhGGO2E5H9cNVqg7zSiDHbWZWUMQYAEXkCd4/GTZYsTEushGGMMSYgVsIwxhgTkG5z415GRoYOGTIk3GEYY0yXsmDBgmJVbX5vT4u6TcIYMmQI8+e31sPSGGNMS0Qk4O7TViVljDEmIJYwjDHGBMQShjHGmIB0mzaMltTX11NYWEhNTU24Qwm5+Ph4srKy6NHD5roxxoRGt04YhYWFJCUlMWTIEPyGqu52VJWSkhIKCwvJyckJdzjGmG6qW1dJ1dTUkJ6e3q2TBYCIkJ6eHhElKWNM+HTrhAF0+2TRJFKu0xgTPt26SsoYY7qU4pWw/E3IGAUD94GEjHBH9D2WMEKopKSEY445BoCNGzcSHR1Nnz7uhsq5c+cSGxvb6r7z58/nySef5IEHHuiQWI0xYVS/DT6+Dz79O/jqdixPzYYB+7jkMWAfGDAe4pLCFqYljBBKT09n0aJFAEyZMoXExERuueWW7esbGhqIiWn5I8jNzSU3N7cjwjTGhNPyt+GNW2DLGhh3Phx5G2z9Dr5bCOsXuue86d7GAhkjXQIZuK9LIv32hJhdTcIYHJYwOtjkyZOJj4/nyy+/5JBDDmHixInceOON1NTU0LNnT/773/8yatQoZs+ezb333strr73GlClTWLt2LQUFBaxdu5abbrqJG264IdyXYozZHVvWwVu3wbLXXBKY9CrkHO7WpQ+DnMN2bFtVDN996RLI+gWw8l346jm3LqoHjDgeLnw25CGHNGGIyInA34Fo4DFVvbvZ+mzgCSDV2+Y2VX3DW3c7bs5mH3CDqs7anVh+9+oS8r7bujuH+IE9BiTz29PGtnm/wsJCPvvsM6Kjo9m6dSsff/wxMTExvPvuu/zqV7/ipZde+sE+y5Yt44MPPqCiooJRo0ZxzTXX2D0XpmNtXAwvXwXH/R5GHBvuaILPV++qhhpqoL4a6mugYZtb1vRI7g/9x0NU9O6d5/N/wuy7QRWO+Q0cdD3EtF5FTUIGjDjOPcDtV164oxQSm9D+eNogZAlDRKKBh3DzBxcC80Rkpqrm+W32f8ALqvqwiOwBvAEM8V5PBMYCA4B3RWSkqvpCFW9HOu+884iOdv/gysvLmTRpEitWrEBEqK+vb3GfU045hbi4OOLi4sjMzGTTpk1kZWV1ZNgmkm0rg+cvgbLV8PKVcPUnkDIw3FEFpr4GylZBST6UrITSfPe6vHBHImjYBo0NgR2vZxoMOxqGH+uek/oGHsvqT+H1n0PRUhh1Mpx4N/Qe3PZrEoHUQe6xxxlt37+dQlnC2B9YqaoFACIyDTgD8E8YCiR7r1OA77zXZwDTVLUWWCUiK73jzWlvMO0pCYRKQsKOXwN33HEHRx11FK+88gqrV6/myCOPbHGfuLgddZTR0dE0NAT4j9uY3dXYCC9dCeXr4cxHXH37S5fDpNcgupPUavvqYcvaZklhJZQUQPk63FeNJ6EPpA+HQQe4X+Y9ekJMPPToBT3im73u6dY3bVOy0lUHrXwPvnnRHa/fOJc8hh/rjhndQsm/sgje+Q189SykZMPE52D0yR3ypwmmUH7aA4F1fu8LgQOabTMFeFtErgcSgKZy7kDg82b7/uDnjIhcBVwFkJ2dHZSgO1p5eTkDB7pLe/zxx8MbjDEt+fBuWPkOnHIfjL8QomLg5Stg9h9ddUpHqdnqSgplq6HUey5b7ZZtWQf+FRBxKa4dIPtASL/YJYi0oW5ZfEr7YxgwHsad65Lopm92JI/PHoRP7ofYJBh6BAw/BoYdAylZsOBxeO93UFcNh94Mh9/SYVVIwRbunwcXAo+r6n0ichDwlIjsGejOqvoo8ChAbm5ul5xr9pe//CWTJk3iD3/4A6ecckq4wzHm+759Cz78M4y/GHIvd8v2Og9WfQgf/xUGH+K+HIOpdBWs/uSHyWFb6fe365kGaTmut9Ce50DaMJcY0odBr3RXbRMqUVHQfy/3OOxml8xWfbQjgSx7bUeM20phyGEu4fYZFbqYOkDI5vT2EsAUVT3Be387gKr+yW+bJcCJqrrOe18AHIhr7N6+rYjM8o7VapVUbm6uNp9AaenSpYwZMyaYl9WpRdr1Gk91qevDX5IPpz8AiZnBOW5JPjx6FKQNgctmuWqZJnXV8O+joaoIrvkUkvoF55xrPoNnzoO6SpBoV0ffOwd6D3HJofeQHY/dKSmEkuqOqqt1X7i2inHnhTaB7QYRWaCqAfXhD2UJYx4wQkRygPW4RuyLmm2zFjgGeFxExgDxQBEwE3hWRP6Ka/QeAcwNYazGdD31NTD3Ufj4XvcLNzoWHjsGLn5x93/J1lW5Ru6oKDj/qe8nC4DYXnDe4/Dvo+ClK+DSGbvXcwjcL/RnL3DVOOc/CekjOk8bSVuIQMYI9zjwmnBHE1QhG0tKVRuA64BZwFJcb6glInKniJzubfZz4EoR+Qp4DpiszhLgBVwD+VvAtd2lh5Qxu62xEb5+Af6xH7xzB2Tt737lX/aWSyL/Oc59+baXKsy8HoqWwblTW+/FkzkaTr4XVn8MH/2l/ecDV43zzHmQOhgmvw6ZY7pmsujmQvqJePdUvNFs2W/8XucBh7Sy713AXaGMz5gup+BDlyQ2fAX99oIzHoShR+5Yf6X3xfvU2XD6g66Ruq0+/yd885Jr0B529M63HX+RS06z74bBB++48awtlr/tSjMZI+HS6Z1u/CSzQ7cfrdaYbmHzUpcInjzdtVmc9Shc9eH3kwW4sYcumwWDD4LpV8PsP7sSQ6BWfwJv3wGjT3U9enZFxDXmZoxwVVOVRW26LJa9DtMuciWKSTMtWXRyljCM6cy2boAZ18HDB8PaL+C4O+G6+bD3Ba59oSU9U+Hil2Dvi1zX1+k/hYa6lrf1V74e/jfZdT898+HAG2njEuHc/0JNObxylasyC8SS6fDCpdB/b9cG0istsP1M2FgloTGhtG0LzHkIKjdCXDLEp7rePfHJ3nOKt9x7HZvoEkFtBXz6AMz5h7sp7YCr4fBfBP6lGhMLZ/7T9Saa/Ud389oFT7tk0pKGWvjfJHfX8+TXXXxt0W9Pd9fyazfBp/fDYT/f+faLX3TDjGTlukb6tp7PhIUljBDaneHNAWbPnk1sbCwHH3xwyGM1QdbYCIuehnd/B9UlrqtrzVY3BMVOifvybPS5rqVjz3ZtCWntmHpXBI681TVaz7gOpp4AF73QciP2W7dB4TzXO6m9Paz2newawN+/C7IPdtViLVn0HMz4KWQf5OKJS2zf+UyHs4QRQrsa3nxXZs+eTWJioiWMrmbdXHjzl2500UEHwo9edtUu4KqGare66hv/x/eWbXVzIkz4EWTtu/vx7D0RkgfAtEvgsWPhoufd8NhNvnwa5k+FQ27avXGJRODUv7nrfvEyN95UQvr3t1n4JMy8wTWOX/hcl73jOVJZwuhgCxYs4Oabb6ayspKMjAwef/xx+vfvzwMPPMAjjzxCTEwMe+yxB3fffTePPPII0dHRPP300zz44IMcdthhuz6BCZ+KjfDuFDfsdFJ/OPsxN4yEf1tATCzEZHR8427O4XD5267h/PFT4Jz/uLGMvvsSXrsZco6Ao+/Y/fPEJ7v2jP8cB9OvgQun7WhrmfcfeP1mN+bSBU//8N4O0+lFTsJ48zY3PHMw9RsHJ9296+08qsr111/PjBkz6NOnD88//zy//vWvmTp1KnfffTerVq0iLi6OLVu2kJqaytVXX93mUokJg4Y6+OJh+PAeVzI49GZXh9/ZqloyR8MV78JzE13PpGPugPn/ddVl504N3n0PA8bD8XfBm79wbTCH3ACfPwJv3QojT4Lzn+iwCX9McEVOwugEamtr+eabbzjuODemvc/no3///gDstddeXHzxxZx55pmceeaZYYzStMmKd1z9f8lK92V4wl1uLKPOKqmva9R+6Qp4706IjnM3/AW7xLP/lbD6IzfoXtkqV+U1+lRX+tjZvA+mU4uchNGGkkCoqCpjx45lzpwfDon1+uuv89FHH/Hqq69y1113sXhxkEtDXU11KVRudr+KO6OSfJj1K1j+lhvw7uIXd0xu09nF9oILnoLPHoA+o7/fnhEsInD6P+Bfh7lkMfYsOPvfLQ/9bbqMyEkYnUBcXBxFRUXMmTOHgw46iPr6epYvX86YMWNYt24dRx11FIceeijTpk2jsrKSpKQktm4N7iyBXcaLl0HBB24k0v2udF84PeKDd/zSAlj0rCshREW77qxxSa4RNjbRPbf2fuW7rqtsdKybfe6Aq7ver+aoaDj0Z6E9R89UuOh/7u91wNU21Ec3YJ9gB4qKiuLFF1/khhtuoLy8nIaGBm666SZGjhzJJZdcQnl5OarKDTfcQGpqKqeddhrnnnsuM2bMiKxG73XzXLIYfSoUL3d3LM/6FUy4BHIva18XU4DaSsibAYuegTWfAuKGs4iJc4PtVRW7rqx1le59Q03rx9r7Ijj2t8EbpbW7yhzdeUuJps1CNrx5R7PhzbvR9T57gRsW+qZv3C/61R/DvMdg6Wugja6Xzf5XuuddjZCq6obMXvSMu7O4vsrNmzD+Itj7wp1PM+qrd4mjKYHUVbqkk5jphrIwphvoLMObG9N2Gxe7doGjfr2jl1HO4e6x9TtY8ISbwezZ8924SbmXufsVmjfalhe6G8QWPeMaXWMTYc+zXSll0AGBDXsR3cNVq7R2d7SJKKpKna8RX6NS71N8jUpDYyMN218rDb5GGhrV26aRRoU+iXH0S4knNqbrj8RkCcN0Lh/f56a53P/KH65LHgBH3e6muFz2muvX/+4U+OCP7o7ofSfD1vXuRrSC2YC6mc6OuBX2ON1uEjMBK6uqY9nGCpZvqtj+vHxjBRW1De06ngj0S44nq3dPBqb2JKt3L/e6t3s9IDWeuJiWS8t1DY2UVtVRXFlLSVUdJZW13nv3uqSqjoGpPfn9mQFPVtpu3T5hqCrSSWe6CqZuUbVYtNxVGx16E/Ts3fp20T1cI/jYs2DzMldd9dU0+HqaW5+S7ZLE3hPb395hIsK2Oh/LN1Xw7aYKvvVLEEUVtdu3SenZg1H9kjhzwkD6pcQTEyVER4l7jo6iR9P7aCEmKmr7+h7RUSBQVFFLYdk21pdto7Csmnmry3j16w34Gr//fzYzKY6s3j1JS4ijfFsdJZUuSWytaTlJxUZHkZ4YS3piLP1TgtghZCe6dcKIj4+npKSE9PT0bp00VJWSkhLi4zvmH03IfHI/xMTDgdcGvk/maDjlXtcAvex1d4f1kMNaH8nVRJyaeh9rS6tZU1LN2tJq1pZUsaa0mlXFVawtrd4++ntcTBQj+yZx+Ig+jO6XxMh+SYzul0RmUlzQvz8afI1s3FrjJRH3WL+l2ntdTe9esewxIJmMxDjSE2JJT4wjPTGWjMRY0hLc66S4mA7/XuvWCSMrK4vCwkKKito4Rn8XFB8fT1ZWVrjDaL+y1fD187D/VZDYp+37xyW5EoXpkmobfKwurmbl5kpWbq6kur6B+JhoesZGEx8T5Z57RBPntyy+R9PraHrECBvKa1jnJQaXHFxC2LS19nvnSoyLITutF2MHJHPWhIGM7pfEqH7JZKf1IjqqY76AY6KjvGqpXhzQIWcMjm6dMHr06EFOjlVJdAmf/h0kCg6+PtyRmBCqrmsgf3MVK4sqWLGpcnuCWFNavb2KRgR6REdR1xDgvBot6Jscx+C0BA4b0YfBab3ITu9FdlovBqcn0LtXj25d4xBK3TphmC5i6wbXUD3h4p13czVBVV5dz7Z6H2kJsUHrwdPYqJRU1bGxvIbvyrex0fvVv8JLDOu37BjePSZKGJKRwMi+SZyyV3+GZyYyPDORoRmJ9IyNprFRqWnwUVPfSE29j231Pmq2PxrZVufbvr62wUffpHgGp/diUFov4nvsoru1aRdLGCb8PnvQzf9wyE3hjqTbq65r4J28TUz/cj0fryimwftVnxQfs72uPC2hqa48lnSvvjw9wS1P6dWDsqo6vtuyjY1ba/huSw0by7fxXXkNG8q3sam8ljrf90sG8T2iGJqRSO6Q3kzsM4gRfV1iGJye4BqGWxEVJfSKjaFXF7uJvjuzhGHCq6oEFvzXDQNuPZpCosHXyCcri5n+5XrezttEdZ2P/inxXH5YDtlpvSitrHPdNb0um+tKq/ly7RbKqut+0JOnuR7RQr+UePon92Sf7N70S4lnQErP7c/9U+NJ6xVLVAe1DZjQsoRhwuvzf7ppQQ+9OdyRdCuqyqJ1W5ix6Dte+/o7iivrSI6P4YzxAzhj/ED2H5K2yy/xxkalfFs9JVV1lHrJZMu2enr3imVAajz9UuLJSIizZBBBLGGY8Nm2BeY+CmNOs/GGgqSgqJLpi75jxqL1rCmpJjYmimPHZHLG+IEcOapPqzeHtSQqSuidEEvvBKsTMo4lDBM+8/7tpiY9vHtPEFVaVceW6joaFRrVDRvha1QaVWlUtr/evqwRfKrUNTRS1+AadN1zs/e+RmrrG6nznldsruDrwnJE4OBh6Vx71HBO3LMfyfE2pLgJDksYJjzqqmDOP2HE8Tvmu+4GGnyNLNtYwZdry1i4dgsL15axpqQ6JOeKi4kiNiaKuJgo4mKi6ZMUx69PHsNpew+gXwfd+WsiiyUMEx7z/wvbSuGwrl26KKms5UsvMSxcW8bXheVU1/kA6JMUxz7ZqVy0fzb9UuIREaJFiI7C77UQFSVECURL02u3TWx0NHE9ooiN3pEYYr3k0CNa7F4C0+EsYZi2K1zgejT1Smvf/vU1rivtkMMgu+vc51rX0Mi3GytYVLiFL9e4BLHaKz3ERAl7DEjm/NxBTMhOZZ/s3mT17mlf6qZbsYRhAle/Dd663XWD7ZXhxnAae1bbj7PoGajcCGf/K/gxBklTcli8vpzF68v5Zn05yzZupd7nuplmJMYyIbs3F+yXzT7ZqeyVlUrPWLtZzHRvljBMYDYvddOmbs6D/X8ChXPhf5Phm5fhlPvcpEKB8NXDJ3+DgbmQc0QoIw7YrpJDcnwM47JSuOzQHMYNTGGvgakMSrPSg4k8ljDMzqnCwifgzdvchEaXvORmuvM1wJwH4YM/uRnxTroHxp2364mJFv8PytfCyfcENolRCNQ2+Ji/uoyPVhQxJ7+EpRtaTw7jBqaQndbLkoMxdPMpWs1u2rYFXr0R8qbD0KPgrH9BUt/vb1P0Lcy4FgrnwciT4NT7Ibl/y8dr9MFDB7ghzK/+uMMShqqSX1TFR8uL+HhFEZ8XlLKt3kePaGFCdm8mZKdacjARy6ZoNbtv3Tx46TI3LeqxU+DgG1ueY6LPKLhsFnz+MLz/e5cQTvwjjL/4hwkhbwaUrIBz/xvyZFFeXc+n+cV8vKKIj5YXbx/0LicjgfNzszh8ZB8OHJpOQpz9FzAmUFbCMN/X2Aif/R3e/4ObEvWcqTBov8D2LcmHGdfB2s9g2DFw2t8hdZBbpwqPHAYNNXDtFxAV3AbiuoZGFq/fwscrivloeRGL1m2hUSEpLoaDh6dz+Mg+HD6iD4PSegX1vMZ0dVbCMO1TsQle+QkUfAB7nOm+8HumBr5/+jCY/LqbMvXdKfDPg+D4O2HfH8PyWbBpMZz5cFCSRU29jy/XbmHuqlK+WFXCwrVl1NQ3IgJ7ZaVy3VHDOWxkH8YPSt3piKjGmMBZwjDOyvdcsqitcIlin0ntqzaKioIDroKRx8PM6+G1n8GSV1x7SGq2axhvh6raBhauLeOLglLmripl0bot1PlcghjTL5mJ+2VzQE4aBw5Nt7GPjAkRSxiRzlfv2h4+/Tv0GQOTXoXMMbt/3N5D4NKZsOBxePsOqKtw3W+jdz2uUW2Dj6KKWpZvquCLglK+WFXKN+vLaWhUoqOEPQemMPmQIRyQk0bu4DRSetlYScZ0BEsYkWzt5/D6La6qKPcyOOGP0KNn8I4vArk/dt1wl79FzbiLKSqtZnNFDZu21rJ5aw2bKmrZvLWWzRU125/Lquu3HyI2Ooq9B6XwkyOGckBOOvsM7k2iNVQbExb2Py8SVW6Gd34DXz0HyVlwwTMw5tTQnKq2gX/NrebZL4ZQ8vL7P1gfEyVkJsXRJzme7PRe7JfTm8ykePomx5GdlsCE7FSbbtOYTiKkCUNETgT+DkQDj6nq3c3W3w8c5b3tBWSqaqq3zgcs9tatVdXTQxlrRPA1uAbpD+7aMWnR4bdAbELQT1Xva2Ta3LX87d0VlFTVccLYvowbmEJmcjyZSXHbk0Jvm43NmC4jZAlDRKKBh4DjgEJgnojMVNW8pm1U9Wd+218PTPA7xDZVHR+q+CLOms/gjV/Apm9cl9eT7oGM4UE/jarydt4m/vzmMgqKq9g/J43/nDyG8YNSg34uY0zHCmUJY39gpaoWAIjINOAMIK+V7S8EfhvCeCJTxUZX/fT185AyCC54GkafGpIb5xauLeNPbyxl3uoyhvVJ4LFLczlmTKbdOW1MNxHKhDEQWOf3vhBocSxrERkM5AD+ldzxIjIfaADuVtXpLex3FXAVQHZ2dnCi7izWfg6v/9z1Kuq/945H5ljoEcDkOL56N/3pB38CX62bd+Kwn0Ns8G9cW11cxT2zlvHG4o1kJMZx11l7ckHuIGLs/gdjupXO0ug9EXhRVX1+ywar6noRGQq8LyKLVTXffydVfRR4FNyd3h0Xbgg1NsKn98P7d7m7pFMHw5LprnsqgES7bq/+SaTvnm5gwCarP3HVT5vzYPhxcNKf3U11QVZaVccD763gmS/WEBMVxY3HjOCqw4facBvGdFOh/J+9Hhjk9z7LW9aSicC1/gtUdb33XCAis3HtG/k/3LUbqSyCV66C/Pdh7NnuBrr4ZDesxpa1sOGrHY8Vb7t5JQAQyBjhkoevzo3ZlJINE5+FUScHvfqppt7H1E9X8fAH+VTVNXDBftn87NgRZCbbtKDGdGehTBjzgBEikoNLFBOBi5pvJCKjgd7AHL9lvYFqVa0VkQzgEOCeEMYafqs+hpeugJotcOrfYN/JO77oRaD3YPfYw+sspuraJ/yTyJo5UF0Ch/8SDv1Z0Kuf6n2NvLSgkL+/t4IN5TUcOyaTW08czYi+SUE9jzGmcwpZwlDVBhG5DpiF61Y7VVWXiMidwHxVneltOhGYpt8fBXEM8C8RaQSicG0YrTWWd22NPvjoXvjwbkgb5uab6LfnrvcTccOIJ/eHUSf6Ha+x5VFldyfERuW1xRu4/53lrCquYvygVP56/ngOGpYe1PMYYzo3G602nCo2wctXwKqPYK+JbugM/7aIMFNV3l+2mb/M+pZlGysY1TeJW04YxbHW88mYbsNGq+0K8j+Al6+E2ko446GW548Iozn5Jfxl1jIWrt3C4PRe/H3ieE7ba4DdZGdMBLOE0dF8Da766aN7oc9omPQaZI4Od1TbLVq3hXtnfcsnK4vplxzPH88ax3m5WTZEuDHGEkaH2vqda9he8ylMuARO+ktI7otoj283VnDf29/ydt4m0hJi+b9TxnDJgYNtHCdjzHaWMDrK8rdh+tVQXwNnPQp7XxDuiCirqmPF5kqem7uW6YvWkxgbw83HjeSyQ3NsRFhjzA/Yt0Ko1VW5+SDm/8fdYHfe4+6eiQ6iqmwor2Hl5kr3KHLP+ZsrKamqAyAuJoqrDh/K1YcPs8mHjDGtsoQRSoXz4eWroLQADr4ejvq/wIb1aKcGXyMfrShi2caK7Ukhv6iKytqG7dskx8cwPDORY8ZkMjwzkeGZieydlUp6YlzI4jLGdA+WMELBV+8atT/6CyQPcLPY5RwW2lM2KjdOW8TrizcA0Dc5juGZiZyzz0CGZyYyzEsOfRLjrEusMaZdLGEEW/EKV6r4bqG7t+LkeyA+JaSnbGxUbn3pa15fvIFfnDCKHx00mOR4m7bUGBNcljCCRdVNTvT2Ha7a6bzHYexZHXBa5XevLuHFBYXceMwIrj0q+HNcGGMMWMIIjoqNMONaWPmum5zojIfckB0hpqr8+a1veWLOGq48LIebju24xnRjTOSxhLG78mbAqze67rIn3wv7XdFhd2w/9MFKHvkwn4sPyOZXJ4+xtgljTEhZwmivmnJ481b46jkYMMHdW9FnZIed/j+frOLet5dz9oSB/P6MPS1ZGGNCzhJGe5Tkw5NnuDu3j7gVDv+Fmxmvg0ybu5bfv5bHiWP7cc+5e9n4TsaYDmEJoz0+fxiqiuCyWTBovw499YxF67n9lcUcOaoPD1w4waZBNcZ0GPu2aavGRlj6Kow4rsOTxdtLNnLzC19xQE4aj1yyL7Ex9vEZYzqOfeO0VeFcqNwIY87o0NN+tLyI6579knEDU3hs0n42KKAxpsNZwmirvJkQHQsjT+iwU85dVcpVT81nWGYiT/x4fxsY0BgTFpYw2kIVls6EYUdDfHKHnPLrwi1c9vg8BqT25KnL9yell93BbYwJD0sYbfHdQihfB3t0THXUso1buXTqXHon9ODZKw4kwwYINMaEkSWMtsibAVExMOqkkJ+qsKyaSx6bS3xMNM9ecSD9UkI3yq0xxgRilwlDRE4TEUssqq79IucI6Nk7pKeqrG3giifmU9vg46nL92dQWueYlc8YE9kCSQQXACtE5B4R6TyTT3e0jYuhbBXscXpIT+NrVG547ktWbK7knxfvw4i+SSE9nzHGBGqXCUNVLwEmAPnA4yIyR0SuEpHI+iZbOhMkCkafGtLT/OmNpby/bDNTTh/LYSP6hPRcxhjTFgFVNanqVuBFYBrQHzgLWCgi14cwts4lbwYMPgQSMkJ2iufmruWxT1Yx+eAh/OjAwSE7jzHGtEcgbRini8grwGygB7C/qp4E7A38PLThdRKbl0Hx8pD2jvosv5g7pn/DESP78H+njAnZeYwxpr0CuQPsHOB+Vf3If6GqVovI5aEJq5PJmwEIjDktJIcvKKrkmqcXkpORwIMX2fhQxpjOKZCEMQXY0PRGRHoCfVV1taq+F6rAOpWlMyH7QEjqF/RDb6mu44on5hMdJUydvJ9NrWqM6bQC+Sn7P6DR773PWxYZilfCpm9CUh1V72vkp88spLBsG//60b7WfdYY06kFkjBiVLWu6Y33OjZ0IXUyS2e45yBXR6kqv5mxhM/yS/jT2ePYb0haUI9vjDHBFkjCKBKR7TcfiMgZQHHoQupk8mbCwFxIyQrqYad+uprn5q7lp0cO45x9g3tsY4wJhUDaMK4GnhGRfwACrAMuDWlUnUXZatiwCI67M6iHfX/ZJv7wupsx75bjRwX12MYYEyq7TBiqmg8cKCKJ3vvKkEfVWSx91T2PCd7d3cs2buX6Z79k7IBk/nrB3ja9qjGmywhoYgUROQUYC8SLuC84VQ3uz+7OKG8G9NsL0nKCcriiilouf3w+ifExPHbpfvSKtXktjDFdRyA37j2CG0/qelyV1HlA978NuXw9FM4LWu+omnofP3lqPiVVtTx26X42+qwxpssJpNH7YFW9FChT1d8BBwEjQxtWJ9BUHRWkhPG7V5ewcO0W7j9/POOyUoJyTGOM6UiBJIwa77laRAYA9bjxpLq3pTMhcw/IGLHbh/pybRnPzV3HVYcP5aRx3f9PZ4zpngJJGK+KSCrwF2AhsBp4NoQxhV/FJljzWVAauxsblSkzl5CZFMcNx+x+8jHGmHDZacLwJk56T1W3qOpLuLaL0ar6m0AOLiInisi3IrJSRG5rYf39IrLIeywXkS1+6yaJyArvMaltl7Wblr0GaFCqo15aWMhXheXceuJoEuOskdsY03Xt9BtMVRtF5CHcfBioai1QG8iBRSQaeAg4DigE5onITFXN8zv+z/y2v77pPCKSBvwWyAUUWODtW9aGa2u/vBmQPhwyd2/U2Iqaev781reMH5TKWRMGBik4Y4wJj0CqpN4TkXOkqT9t4PYHVqpqgTecyDRgZz/ZLwSe816fALyjqqVekngHOLGN52+fqhJY/YkrXbT5kr/vHx+spLiylimnj7X7LYwxXV4gCeMnuMEGa0Vkq4hUiMjWAPYbiLsrvEmht+wHRGQwkAO835Z9vZn/5ovI/KKiogBCCsC3r4P6drs6alVxFVM/WcW5+2YxflBqcGIzxpgwCmSK1iRVjVLVWFVN9t4nBzmOicCLqupry06q+qiq5qpqbp8+QZrONG8mpA52N+zthj+8lkdcTDS/PNGG/jDGdA+7bIUVkcNbWt58QqUWrAcG+b3P8pa1ZCJwbbN9j2y27+xdnG/3bSuDgtlw4DW7VR01+9vNvLdsM7efNJrMJLtBzxjTPQTSbecXfq/jcW0TC4Cjd7HfPGCEiOTgEsBE4KLmG4nIaKA3MMdv8SzgjyLS23t/PHB7ALHunm/fgsb63aqOqmto5M7X8sjJSODHhwRnSBFjjOkMAhl88HsTQYjIIOBvAezXICLX4b78o4GpqrpERO4E5qvqTG/TicA0VVW/fUtF5Pe4pANwp6qWBnJBu2XpTEjOgoH7tvsQT85ZTUFRFVMn5xIbY1OtGmO6j/bcGFAIBNTfVFXfAN5otuw3zd5PaWXfqcDUdsTXPrUVsPI9yL2s3dVRRRW1/P3dFRw5qg9Hj+4b5ACNMSa8AmnDeBB3LwS4RvLxuDu+u5fls8BXu1vVUffO+pZt9T7uOHWPIAZmjDGdQyAljPl+rxuA51T10xDFEz55MyCxLww6oF27Ly4s54UF67ji0ByG9UkMcnDGGBN+gSSMF4Gapi6vIhItIr1UtTq0oXWguipY+S6Mvwii2t7uoKpMeXUJ6QmxXG/jRRljuqmA7vQGevq97wm8G5pwwmTlu1Bf3e7BBmcs+o4Fa8r45QmjSY7vEeTgjDGmcwgkYcT7T8vqve4VupDCIG8m9EqHwYe0edeq2gb+9OZS9spK4dx9s0IQnDHGdA6BJIwqEdmn6Y2I7AtsC11IHay+Bpa/BaNPgei2dxr75+yVbNpay29Ps/GijDHdWyDfkDcB/xOR73BTtPbDTdnaPWwrhZwjYM9z2rzr2pJq/v3xKs6aMJB9B/fe9Q7GGNOFBXLj3jzvbuymQZG+VdX60IbVgZIHwIXtmw/qD6/nERMl3Hri6CAHZYwxnc8uq6RE5FogQVW/UdVvgEQR+WnoQ+vcPllRzNt5m7j2qOH0S7Hxoowx3V8gbRhXquqWpjfe/BRXhiyiLqDe18jvXl1CdlovLj/UxosyxkSGQBJGtP/kSd5MerGhC6nze2PxBlZsruTXp4whvkd0uMMxxpgOEUij91vA8yLyL+/9T4A3QxdS57fku63ExkRx7BgbL8oYEzkCSRi3AlcBV3vvv8b1lIpYBUWV5KQnEG3daI0xESSQGfcagS+A1bi5MI4GloY2rM6toKiKoX0Swh2GMcZ0qFZLGCIyErjQexQDzwOo6lEdE1rnVNfQyJrSak4e1z/coRhjTIfaWZXUMuBj4FRVXQkgIj/rkKg6sbWl1fga1UoYxpiIs7MqqbOBDcAHIvJvETkGd6d3RMsvcsNq2RDmxphI02rCUNXpqjoRGA18gBsiJFNEHhaR4zsovk6noKgKwEoYxpiIE0ijd5WqPuvN7Z0FfInrORWR8osqyUyKI8mGMTfGRJg2zRakqmWq+qiqHhOqgDq7gqJKK10YYyJS26eXi2CqSn5RlbVfGGMikiWMNiitqqN8Wz1DLWEYYyKQJYw2yLcGb2NMBLOE0QYFXpfa4VbCMMZEIEsYbZBfVElsTBQDUnuGOxRjjOlwljDaoKCoiqEZNuigMSYyWcJog3zrUmuMiWCWMAJU2+BjXdk261JrjIlYljACtLbEBh00xkQ2SxgBaupSayUMY0yksoQRoIJi16U2J8NKGMaYyGQJI0D5m6vom2yDDhpjIpcljAAVFFcyNMOqo4wxkcsSRgBUlfzNlQzLtOooY0zksoQRgJKqOrbWNFgJwxgT0SxhBCB/szcta6YlDGNM5LKEEYCCYm+UWushZYyJYJYwApC/uZK4mCgG2qCDxpgIFtKEISInisi3IrJSRG5rZZvzRSRPRJaIyLN+y30issh7zAxlnLtSUFxFTkYCUTbooDEmgsWE6sAiEg08BBwHFALzRGSmqub5bTMCuB04RFXLRCTT7xDbVHV8qOJri/yiSvYckBLuMIwxJqxCWcLYH1ipqgWqWgdMA85ots2VwEOqWgagqptDGE+71Db4WFdazTAbQ8oYE+FCmTAGAuv83hd6y/yNBEaKyKci8rmInOi3Ll5E5nvLz2zpBCJylbfN/KKioqAG32RNSTWNis3jbYyJeCGrkmrD+UcARwJZwEciMk5VtwCDVXW9iAwF3heRxaqa77+zqj4KPAqQm5uroQiwaVpWG3TQGBPpQlnCWA8M8nuf5S3zVwjMVNV6VV0FLMclEFR1vfdcAMwGJoQw1lY1jVKbY1VSxpgIF8qEMQ8YISI5IhILTASa93aajitdICIZuCqqAhHpLSJxfssPAfIIg/yiSvolx5MYF+7CmDHGhFfIvgVVtUFErgNmAdHAVFVdIiJ3AvNVdaa37ngRyQN8wC9UtUREDgb+JSKNuKR2t3/vqo6UX1RlkyYZYwwhbsNQ1TeAN5ot+43fawVu9h7+23wGjAtlbIFQVQqKKjlzfPO2emOMiTx2p/dOFFfWUVHTYCUMY4zBEsZO5VsPKWOM2c4Sxk4UeD2krIRhjDGWMHYqv6iS+B5RDEixQQeNMcYSxk4UFFWSk5Fogw4aYwyWMHbKutQaY8wOljBaUVPvo7Cs2hq8jTHGYwmjFU2DDtootcYY41jCaIUNOmiMMd9nCaMVTfdg5Ng83sYYA1jCaFVBURX9U+JJsEEHjTEGsITRqvyiSushZYwxfixhtMANOlhl7RfGGOPHEkYLiipqqahtYKi1XxhjzHaWMFrQNMvesEwrYRhjTBNLGC1o6iE11KqkjDFmO0sYLSgoqqJnj2j6J8eHOxRjjOk0LGG0oKC4kpyMBBt00Bhj/FjCaIF1qTXGmB+yhNGMG3Rwm3WpNcaYZixhNLO6pApVm2XPGGOas4TRTNO0rFbCMMaY77OE0Uz+5qYutVbCMMYYf5YwmikormJASjy9Ym3QQWOM8WcJoxnXQ8qqo4wxpjlLGH52DDpo1VHGGNOcJQw/mytqqaxtsBKGMca0wBKGn3ybltUYY1plCcNP0yi11kPKGGN+yBKGn4KiSnrFRtPPBh00xpgfsIThJ7+oygYdNMaYVljC8FNgXWqNMaZVljA8NfU+1m/ZZl1qjTGmFZYwPKuKmwYdtBKGMca0xBKGZ8egg1bCMMaYlljC8DTdg5GTYQnDGGNaYgnDU1BUycDUnjbooDHGtCKkCUNEThSRb0VkpYjc1so254tInogsEZFn/ZZPEpEV3mNSKOME16XWbtgzxpjWhezntIhEAw8BxwGFwDwRmamqeX7bjABuBw5R1TIRyfSWpwG/BXIBBRZ4+5aFIlY36GAl5+UOCsXhjTGmWwhlCWN/YKWqFqhqHTANOKPZNlcCDzUlAlXd7C0/AXhHVUu9de8AJ4Yq0E1ba6mq81kJwxhjdiKUCWMgsM7vfaG3zN9IYKSIfCoin4vIiW3YFxG5SkTmi8j8oqKidgdaYIMOGmPMLoW70TsGGAEcCVwI/FtEUgPdWVUfVdVcVc3t06dPu4No6iFlJQxjjGldKBPGesC/USDLW+avEJipqvWqugpYjksggewbNPlFVTbooDHG7EIoE8Y8YISI5IhILDARmNlsm+m40gUikoGroioAZgHHi0hvEekNHO8tCwk3LWsCIjbooDHGtCZkvaRUtUFErsN90UcDU1V1iYjcCcxX1ZnsSAx5gA/4haqWAIjI73FJB+BOVS0NVawFRVXkDukdqsMbY0y3ENK71FT1DeCNZst+4/dagZu9R/N9pwJTQxkfwLY6N+jg+RnWpdYYY3Ym3I3eYVdV18Dpew9gn8Gp4Q7FGGM6tYgfByMjMY4HLpwQ7jCMMabTi/gShjHGmMBYwjDGGBMQSxjGGGMCYgnDGGNMQCxhGGOMCYglDGOMMQGxhGGMMSYgljCMMcYERNzoHF2fiBQBa3bjEBlAcZDC6Wrs2iNXJF9/JF877Lj+waoa0PwQ3SZh7C4Rma+queGOIxzs2iPz2iGyrz+Srx3ad/1WJWWMMSYgljCMMcYExBLGDo+GO4AwsmuPXJF8/ZF87dCO67c2DGOMMQGxEoYxxpiAWMIwxhgTkIhPGCJyooh8KyIrReS2cMfT0URktYgsFpFFIjI/3PGEkohMFZHNIvKN37I0EXlHRFZ4z912cvdWrn+KiKz3Pv9FInJyOGMMFREZJCIfiEieiCwRkRu95d3+89/Jtbf5s4/oNgwRiQaWA8cBhcA84EJVzQtrYB1IRFYDuara7W9gEpHDgUrgSVXd01t2D1Cqqnd7Pxh6q+qt4YwzVFq5/ilApareG87YQk1E+gP9VXWhiCQBC4Azgcl0889/J9d+Pm387CO9hLE/sFJVC1S1DpgGnBHmmEyIqOpHQGmzxWcAT3ivn8D9R+qWWrn+iKCqG1R1ofe6AlgKDCQCPv+dXHubRXrCGAis83tfSDv/kF2YAm+LyAIRuSrcwYRBX1Xd4L3eCPQNZzBhcp2IfO1VWXW7KpnmRGQIMAH4ggj7/JtdO7Txs4/0hGHgUFXdBzgJuNartohI6upnI62O9mFgGDAe2ADcF9ZoQkxEEoGXgJtUdav/uu7++bdw7W3+7CM9YawHBvm9z/KWRQxVXe89bwZewVXTRZJNXh1vU13v5jDH06FUdZOq+lS1Efg33fjzF5EeuC/MZ1T1ZW9xRHz+LV17ez77SE8Y84ARIpIjIrHARGBmmGPqMCKS4DWCISIJwPHANzvfq9uZCUzyXk8CZoQxlg7X9GXpOYtu+vmLiAD/AZaq6l/9VnX7z7+1a2/PZx/RvaQAvK5kfwOigamqeld4I+o4IjIUV6oAiAGe7c7XLyLPAUfihnXeBPwWmA68AGTjhsc/X1W7ZcNwK9d/JK5KQoHVwE/86vS7DRE5FPgYWAw0eot/havL79af/06u/ULa+NlHfMIwxhgTmEivkjLGGBMgSxjGGGMCYgnDGGNMQCxhGGOMCYglDGOMMQGxhGHMLoiIz29Ez0XBHNVYRIb4jx5rTGcWE+4AjOkCtqnq+HAHYUy4WQnDmHby5hK5x5tPZK6IDPeWDxGR971B3d4TkWxveV8ReUVEvvIeB3uHihaRf3tzFbwtIj297W/w5jD4WkSmhekyjdnOEoYxu9azWZXUBX7rylV1HPAP3IgBAA8CT6jqXsAzwAPe8geAD1V1b2AfYIm3fATwkKqOBbYA53jLbwMmeMe5OjSXZkzg7E5vY3ZBRCpVNbGF5auBo1W1wBvcbaOqpotIMW7Cmnpv+QZVzRCRIiBLVWv9jjEEeEdVR3jvbwV6qOofROQt3IRH04HpqloZ4ks1ZqeshGHM7tFWXrdFrd9rHzvaFk8BHsKVRuaJiLU5mrCyhGHM7rnA73mO9/oz3MjHABfjBn4DeA+4Btz0wCKS0tpBRSQKGKSqHwC3AinAD0o5xnQk+8VizK71FJFFfu/fUtWmrrW9ReRrXCnhQm/Z9cB/ReQXQBHwY2/5jcCjInI5riRxDW7impZEA097SUWAB1R1S5Cux5h2sTYMY9rJa8PIVdXicMdiTEewKiljjDEBsRKGMcaYgFgJwxhjTEAsYRhjjAmIJQxjjDEBsYRhjDEmIJYwjDHGBOT/AXPK/Hs4AcLsAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.14399313926696777 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time()\n",
+    "plt.plot(history3.history['accuracy'])\n",
+    "plt.plot(history3.history['val_accuracy'])\n",
+    "plt.title(\"Model Accuracy\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Accuracy')\n",
+    "plt.legend(['Train', 'Test'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pressed-lightning",
+   "metadata": {
+    "papermill": {
+     "duration": 1.405613,
+     "end_time": "2021-04-26T04:45:16.273909",
+     "exception": false,
+     "start_time": "2021-04-26T04:45:14.868296",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4.17 Analysis :\n",
+    "\n",
+    "- From above models it has been clear that we can achieve good accuracy on CNN and Resnet model.\n",
+    "- However we can also achieve 80% on Machine Learning model. We can achieve more performance we use Dimensionality Reduction method before Random forest as we have 784 features (28*28).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 2287.16724,
+   "end_time": "2021-04-26T04:45:21.209769",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "__notebook__.ipynb",
+   "output_path": "__notebook__.ipynb",
+   "parameters": {},
+   "start_time": "2021-04-26T04:07:14.042529",
+   "version": "2.3.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/CM5.ipynb
+++ b/CM5.ipynb
@@ -1,0 +1,2579 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "obvious-handy",
+   "metadata": {
+    "papermill": {
+     "duration": 0.032486,
+     "end_time": "2021-04-26T05:19:33.495705",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:33.463219",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# <div align=\"center\">CM5</div>\n",
+    "\n",
+    "## 5.1 Importing libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "eleven-dependence",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:33.567853Z",
+     "iopub.status.busy": "2021-04-26T05:19:33.567312Z",
+     "iopub.status.idle": "2021-04-26T05:19:39.373036Z",
+     "shell.execute_reply": "2021-04-26T05:19:39.373637Z"
+    },
+    "papermill": {
+     "duration": 5.848181,
+     "end_time": "2021-04-26T05:19:39.373991",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:33.525810",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/kaggle/input/fashionmnist/fashion_mnist_dataset_train.npy\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Handle table-like data and matrices :\n",
+    "import numpy as np \n",
+    "import pandas as pd \n",
+    "\n",
+    "\n",
+    "import os\n",
+    "for dirname, _, filenames in os.walk('/kaggle/input'):\n",
+    "    for filename in filenames:\n",
+    "        print(os.path.join(dirname, filename))\n",
+    "\n",
+    "        \n",
+    "# Modelling Helpers Libraries\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import confusion_matrix, classification_report\n",
+    "from sklearn.model_selection import GridSearchCV , KFold , cross_val_score\n",
+    "\n",
+    "# Deep Learning Libraries\n",
+    "import tensorflow as tf\n",
+    "from keras.utils import to_categorical\n",
+    "from keras.models import Sequential, load_model\n",
+    "from keras.layers import Dense, Dropout, Flatten\n",
+    "from keras.layers import Conv2D, MaxPooling2D, BatchNormalization\n",
+    "from keras.optimizers import Adam,SGD,Adagrad,Adadelta,RMSprop\n",
+    "from keras.preprocessing.image import ImageDataGenerator\n",
+    "from keras.callbacks import ReduceLROnPlateau, LearningRateScheduler\n",
+    "\n",
+    "# Resnet \n",
+    "import keras\n",
+    "from keras.layers import AveragePooling2D, Input, Flatten\n",
+    "from keras.layers import Dense, Conv2D, BatchNormalization, Activation\n",
+    "from keras.regularizers import l2\n",
+    "from keras.models import Model\n",
+    "import os\n",
+    "from keras.callbacks import ModelCheckpoint, ReduceLROnPlateau\n",
+    "\n",
+    "# Machine Learning Model\n",
+    "from sklearn.model_selection import GridSearchCV\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn import metrics\n",
+    "\n",
+    "# Visualisation\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Time library\n",
+    "import time \n",
+    "\n",
+    "\n",
+    "# Classification\n",
+    "from sklearn.metrics import accuracy_score,precision_score,recall_score,f1_score,confusion_matrix,classification_report\n",
+    "import itertools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "endless-consequence",
+   "metadata": {
+    "papermill": {
+     "duration": 0.046705,
+     "end_time": "2021-04-26T05:19:39.465989",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:39.419284",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5.2 Dataset Extract "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "facial-carrier",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:39.669483Z",
+     "iopub.status.busy": "2021-04-26T05:19:39.668947Z",
+     "iopub.status.idle": "2021-04-26T05:19:44.896584Z",
+     "shell.execute_reply": "2021-04-26T05:19:44.895693Z"
+    },
+    "papermill": {
+     "duration": 5.278841,
+     "end_time": "2021-04-26T05:19:44.896714",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:39.617873",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pixel0</th>\n",
+       "      <th>pixel1</th>\n",
+       "      <th>pixel2</th>\n",
+       "      <th>pixel3</th>\n",
+       "      <th>pixel4</th>\n",
+       "      <th>pixel5</th>\n",
+       "      <th>pixel6</th>\n",
+       "      <th>pixel7</th>\n",
+       "      <th>pixel8</th>\n",
+       "      <th>pixel9</th>\n",
+       "      <th>...</th>\n",
+       "      <th>pixel775</th>\n",
+       "      <th>pixel776</th>\n",
+       "      <th>pixel777</th>\n",
+       "      <th>pixel778</th>\n",
+       "      <th>pixel779</th>\n",
+       "      <th>pixel780</th>\n",
+       "      <th>pixel781</th>\n",
+       "      <th>pixel782</th>\n",
+       "      <th>pixel783</th>\n",
+       "      <th>target</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.003922</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.447059</td>\n",
+       "      <td>0.509804</td>\n",
+       "      <td>0.298039</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.086275</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.003922</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.129412</td>\n",
+       "      <td>0.376471</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 785 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   pixel0  pixel1  pixel2  pixel3  pixel4    pixel5  pixel6  pixel7    pixel8  \\\n",
+       "0     0.0     0.0     0.0     0.0     0.0  0.000000     0.0     0.0  0.000000   \n",
+       "1     0.0     0.0     0.0     0.0     0.0  0.003922     0.0     0.0  0.000000   \n",
+       "2     0.0     0.0     0.0     0.0     0.0  0.000000     0.0     0.0  0.000000   \n",
+       "3     0.0     0.0     0.0     0.0     0.0  0.000000     0.0     0.0  0.129412   \n",
+       "4     0.0     0.0     0.0     0.0     0.0  0.000000     0.0     0.0  0.000000   \n",
+       "\n",
+       "     pixel9  ...  pixel775  pixel776  pixel777  pixel778  pixel779  pixel780  \\\n",
+       "0  0.000000  ...  0.000000  0.000000  0.000000       0.0       0.0       0.0   \n",
+       "1  0.000000  ...  0.447059  0.509804  0.298039       0.0       0.0       0.0   \n",
+       "2  0.086275  ...  0.000000  0.003922  0.000000       0.0       0.0       0.0   \n",
+       "3  0.376471  ...  0.000000  0.000000  0.000000       0.0       0.0       0.0   \n",
+       "4  0.000000  ...  0.000000  0.000000  0.000000       0.0       0.0       0.0   \n",
+       "\n",
+       "   pixel781  pixel782  pixel783  target  \n",
+       "0       0.0       0.0       0.0     4.0  \n",
+       "1       0.0       0.0       0.0     1.0  \n",
+       "2       0.0       0.0       0.0     0.0  \n",
+       "3       0.0       0.0       0.0     1.0  \n",
+       "4       0.0       0.0       0.0     0.0  \n",
+       "\n",
+       "[5 rows x 785 columns]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = np.load('../input/fashionmnist/fashion_mnist_dataset_train.npy', allow_pickle=True).item()\n",
+    "data = np.array(data)\n",
+    "my_dict = data[()]\n",
+    "features = my_dict.get('features')\n",
+    "target = my_dict.get('target')\n",
+    "farray = features.reshape(features.shape[0], (features.shape[1]*features.shape[2]))\n",
+    "column_names = []\n",
+    "[column_names.append(\"pixel\"+str(x)) for x in range(0, 784)]\n",
+    "f1 = pd.DataFrame(farray , columns = column_names)\n",
+    "column_names = ['target']\n",
+    "t1  = pd.DataFrame(target , columns = column_names)\n",
+    "f1['target'] = t1['target'] - 1\n",
+    "f1.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "destroyed-syndicate",
+   "metadata": {
+    "papermill": {
+     "duration": 0.03175,
+     "end_time": "2021-04-26T05:19:44.960188",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:44.928438",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5.3 Dataset visualization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "hidden-parcel",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:45.026304Z",
+     "iopub.status.busy": "2021-04-26T05:19:45.025731Z",
+     "iopub.status.idle": "2021-04-26T05:19:45.029735Z",
+     "shell.execute_reply": "2021-04-26T05:19:45.029328Z"
+    },
+    "papermill": {
+     "duration": 0.038718,
+     "end_time": "2021-04-26T05:19:45.029889",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:44.991171",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "clothing2 = {0 : '1',\n",
+    "            1 : '2',\n",
+    "            2 : '3',\n",
+    "            3 : '4',\n",
+    "            4 : '5'}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cooked-worse",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:45.110884Z",
+     "iopub.status.busy": "2021-04-26T05:19:45.110105Z",
+     "iopub.status.idle": "2021-04-26T05:19:48.169149Z",
+     "shell.execute_reply": "2021-04-26T05:19:48.168709Z"
+    },
+    "papermill": {
+     "duration": 3.108709,
+     "end_time": "2021-04-26T05:19:48.169271",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:45.060562",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA04AAANNCAYAAACgNC4vAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAB4tUlEQVR4nO39eZhdZZ3u/39WKpXUPCVVlaEyzwkhDGEWCDIqQ7SdW9vWg23bDg3tafTr0fYgcA7dbavopS1iq63AscUZokKjR5QwySAEQmYyJ1VJzXNVhvX9A7qv7+/n536eXtsiu2rX+3VdXFf3vep51tpVa9gPW+6dpGlqAAAAAABtQr4PAAAAAABGOxZOAAAAABDBwgkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAIIKFU54kSXJXkiQHkyTpTpJka5Ik78v3MQGFJkmSh5IkGUySpPeVf7bk+5iAQpMkyYeTJHkqSZKhJEn+Nd/HAxQirrPRgYVT/txqZnPTNK0ys2vM7JYkSU7P8zEBhejDaZpWvPLPknwfDFCADpjZLWb2zXwfCFDAuM5GARZOeZKm6cY0TYf+4/995Z8FeTwkAAAyS9P0R2ma/sTM2vJ9LECh4jobHVg45VGSJP+cJEm/mW02s4Nm9vM8HxJQiG5NkqQ1SZJHkiRZk++DAQAAYxMLpzxK0/SDZlZpZueb2Y/MbCg8AkBGHzez+WY208zuMLP7kiThk10AAJAZC6c8S9P0WJqm682sycz+Kt/HAxSSNE2fSNO0J03ToTRNv21mj5jZ6/N9XAAAYOxh4TR6TDT+Gyfg1ZaaWZLvgwAAAGMPC6c8SJKkIUmStydJUpEkSVGSJJeb2TvM7Ff5PjagUCRJUpMkyeVJkpQkSTIxSZJ3mtkFZnZ/vo8NKCSvXF8lZlZkZkX/cc3l+7iAQsJ1NjokaZrm+xjGnSRJ6s3sB2a2yl5evO42sy+lafr1vB4YUEBeuc5+bmZLzeyYvVzC8ndpmj6Y1wMDCkySJDea2f/8/4s/k6bpjSf+aIDCxHU2OrBwAgAAAIAI/qd6AAAAABDBwgkAAAAAIlg4AQAAAEAECycAAAAAiAjWGCZJQnNEBieddJLcdtNNN7l5cXGxm//mN7+Rc/3TP/1TtgPLQZL4X3UzFstE0jQd9d/bw7WGQjDar7Wxdp2p+7CZ2YQJ/r/3PHbsWOb9fPjDH3bzlpYWOaa8vNzNe3p63Hzx4sVyrmeeecbNH3jgATlGCf3OPKFnWlFRkZsfP348p/lGCtfZ6PZ3f/d3bj44OOjmzz33nJxLXeft7e1u3t/fL+cqKSmR2zxPPfVUpp8vNOo64xMnAAAAAIhg4QQAAAAAESycAAAAACCChRMAAAAARLBwAgAAAICIYKveaHWiGt9U493b3vY2N//Sl76UeR8TJ/p/gp07d8oxb3zjG91cNbO89NJLmY8razOR2dhs3AOAfMvlmZZLe969996baa69e/fKuerr6918w4YNbv7Wt75VznX99de7eWNjoxyjZH0OhZ51qj0vtI9CaqRFbubNm+fmM2bMcPNp06bJuY4ePermqm1P5WZmra2tbt7c3Ozmzz//vJxraGhIbit0fOIEAAAAABEsnAAAAAAggoUTAAAAAESwcAIAAACACBZOAAAAABDBwgkAAAAAIsZkHblSVFQkt6m61Xe+851yzGc+8xk3nzlzppuHqltVdWNFRYWbz5kzR871P/7H/3DzkpISN7/77rvlXH//93/v5qqGNVR1qVDDCgCaukeGnmlLlixx8//23/6bHFNVVeXmTz31VKbczKy8vNzN29ra3Hzu3LlyLvXs/PGPf+zmW7dulXM9+OCDbv7rX//azUO17ur3r56PZvoZmUt9PEavyspKuW3p0qVu/qtf/crN1dfSmJm1t7e7eW9vb+DofJ2dnW6eS0367t27M++/UPCJEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABAREG16uXSWhNqIOru7nbz4eFhNy8tLZVzqXaeyZMnu3mozaS4uDjTPs444ww5l2o62rVrl5snSSLnCjUNAcB4ELpHqva8N73pTW7+9re/Xc519OjRTHmIeg7s2LFDjnnuuefc/NZbb3XzmpoaOdf3vvc9N6+trXXzUEOfeqZfe+21bv7FL35RzvX444+7eS4NvigsH/jAB+S2+vp6N1fX5tSpU+Vc6n3VwYMHM+3bTLfnKfPmzZPbaNUDAAAAAEgsnAAAAAAggoUTAAAAAESwcAIAAACACBZOAAAAABAxJlv1VDNRSEVFhZvn0gSnWu2am5vlGNXCo1pW+vv75VwlJSVuvnnzZjefNGmSnOtd73qXm99yyy1uHmoMUm1Sufy9AGA0U/f00D1y1apVbn7FFVe4+YEDB+Rc6r4eandV92g11//6X/9LzvWrX/3Kzevq6tw89FrOPPNMN3/44YfdPNTQ19nZ6eaqwfbNb36znEu16tGch1CzY0dHh5tPnOi/5Z4wQX+God67qvehoeNSbck9PT1uvmzZMjnXQw89JLcVOj5xAgAAAIAIFk4AAAAAEMHCCQAAAAAiWDgBAAAAQAQLJwAAAACIYOEEAAAAABFjso48l9rrFStWuHlZWZkcMzw87ObV1dVuPjg4KOdSNZCqOlJVUJqZTZkyxc3vvfdeNz/llFPkXCtXrpTbAAC+XCqpr732Wjc/fPhw5n20t7e7eaiqu7a21s3Vs05Vjpvp55Cq8Fav0czsyiuvdHP1dSHbt2+Xc6kx6ms8qqqq5FxvetOb3PyHP/yhHMPXcowPqlrczKylpcXNe3t73Tz0PjT0XtAza9YsuU29D1XH1djYmGnf4wWfOAEAAABABAsnAAAAAIhg4QQAAAAAESycAAAAACCChRMAAAAARIzJVr1c2mkuuugiNy8vL8+8n+eee87Nm5ub5VwzZsxw8wkT/LWraj8xM/vpT3/q5v39/W5eVFQk51JtSqqJ79lnn5VzAUChUfdP1Xi3fPlyOdfRo0fdXN2HS0tL5VyTJ09284GBATnmqaeecnPV6nXgwAE512WXXebmqqFrx44dcq4vfelLbl5XV+fmod9LcXGxm6vfV1tbm5zr8ssvd/NQq55630DbXmFR7Y1mZp2dnZnG7Nu3T86lGqEnTZrk5uqaCe1fNU6G7iVZ74uFhE+cAAAAACCChRMAAAAARLBwAgAAAIAIFk4AAAAAEMHCCQAAAAAixmSrXi7OOOMMN1ftJ2ZmP/rRj9z82muvdXPVWGSmG4VOP/10N9+2bZuc6+STT3bz+++/381Vy5CZ2ZEjR9z8yiuvdHNa9QCMJxMn+o9J1R51zjnnyLkGBwfdXDWuhahWK9WQZaZfi2r1mz9/vpxr+/btmeZasmSJnKujo8PN1bNLtdGaZf+9qH2b6fcHa9askWMeeuihTMelmhYxuk2ZMkVuU+eNOtf6+vrkXOoabGpqcvOKigo5V3d3t5sPDQ25uWruMxsf7XkKnzgBAAAAQAQLJwAAAACIYOEEAAAAABEsnAAAAAAggoUTAAAAAESwcAIAAACAiIKqI6+rq5PbVK1pQ0ODHPOlL33Jzf/2b//WzZcuXSrnam9vd3NV3VpeXi7nOvPMM9381ltvdfNZs2bJuVTV5Zw5c+QYJU3TzGMAYDRTVb3KzJkz5TZ1v1d15KWlpXIuVS2s9mGmv35C3bvVPsx0Jbh6doXmUpXcqj5dvQ4zXZOsquArKyvlXOpvf9ZZZ8kxqo58PNc3FyJ1PpnpGm91zYTODVV7rr5i59ChQ3IutZ/Jkye7eeh9aHV1tZt3dXXJMYWCT5wAAAAAIIKFEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACIKqlXv0ksvlduqqqrcPGtjkpluILngggvkmN27d7t5X1+fmzc1Ncm5du3a5eaPP/64m9fX18u5VDOL+n2FWlbUawHMdHOYmW71UmNGssFx9erVcltra6ub/8Vf/IWbP/jgg3Iu1baVixPxe0Fuampq5DbVeDV9+nQ3nzdvnpyrpaXFzUONc0VFRXKbp6OjQ25rbGx0c9U2po7XLHsLmfp5M93epxp01T7MzPbt2+fmob+LwrVZWEpKSuQ29b4y1Hip9PT0uLl6H6qaKM30daOu2ePHj8u5amtr3ZxWPQAAAAAACycAAAAAiGHhBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgIiCqiM/5ZRT5DZV6bhhw4bM+1GVsqq62Myst7fXzZcsWeLmzc3Nci5Vn3zVVVe5+bp16+Rc1113nZsfO3bMzVeuXCnnUnXogFludby5jDn99NPd/JprrnHz1772tXKuTZs2ufmyZcvcPPT1BlnryEM1yaGaWJwYlZWVbj5lyhQ55sknn3TzRYsWufnRo0flXKrauKKiQo7JpXZYUV9NoZ51oZp0VaGsnkMhqqpf1TeHKtrV7yv0tRzV1dVuPh5qmhGmzvPQV8a88MILbl5aWurmy5cvz3xc6joL3X/GMz5xAgAAAIAIFk4AAAAAEMHCCQAAAAAiWDgBAAAAQAQLJwAAAACIGJOteqo1Z8WKFXKMase566675BjVgKLa8371q1/JuVRrkmqiU21eZmZbtmxx84985CNuHmrVmzp1aqb9q0Y/M1r1xjJ1Tan8RLW6ve9973Pzuro6OWbOnDmZ9rF+/Xq5raGhwc2ff/55Nw9dH2effbabq+tmpH/Hl19+uZv/4z/+o5ure4OZ2bve9a4ROaaxTJ1nkyZNkmPUcyiXVjnVOBlqY1Rj1HGVlJTIuVTjljrmUHudOmbVxKcaxcx026Hav3rtZvoaDF2bqnGT5+P4ETrXPaHnmWriVNfMxRdfLOfKem2Grv/xjE+cAAAAACCChRMAAAAARLBwAgAAAIAIFk4AAAAAEMHCCQAAAAAixmSr3sknn+zmqk3HzKyqqsrNf/e738kxa9eudfP+/n43V81IZroFaMqUKW7+wgsvyLkOHz7s5qFmFuV73/uem1966aVurtoBMbapti2Vh1RXV7v5v/3bv8kxS5YscfPHHnvMzXt7ezPvf9WqVW7+0EMPyblUq+CaNWvcXLWAmZnddNNNbq5aMjdu3CjnUk1gF1xwgRyjtm3dutXN1X3OTLcdjif19fVurtrmzHQb29DQkJs3NjbKufr6+txcPVPMsrdkhhoC1TF3d3e7eajtT+1HnefqdZiZdXV1ublqyDx48KCcS/1e9uzZI8csWLDAzWnVKyyha0OdN+qaDb13VPfh3//+926uznMz/R6xpaUl83GFnnWFjk+cAAAAACCChRMAAAAARLBwAgAAAIAIFk4AAAAAEMHCCQAAAAAiWDgBAAAAQMSYrCNXldihitIvfvGLmfdzzTXXuPmxY8fcXNXTmpk1NTW5uaqBXLhwoZxLvU5VA/ua17xGznXrrbe6+TnnnOPmtbW1ci6MXXPnznXzmTNnuvmb3/xmOdd5553n5uXl5XLMoUOH3FxV+/7whz+Uc73rXe9y8/nz57t56CsJVLW5GqOO18xs1qxZbq5+x+r3aKav9dBXEqgx8+bNc/PQta7uW+NJqCpcUTXF6pmivsYiNNfAwIAco6rSi4qKMv18aJvKS0pK5Fwj+XUI7e3tbq6+rqSnp0fONTw87Obq92UWvgdgfFDV+6rCO3RtHDhwwM1zqTZXx5U1Dx3XeMAnTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIhg4QQAAAAAEWOyVW/atGlurlpGzMx+/OMfZ97P4sWL3XzXrl1uPjQ0JOcKNf55VHOgmdnu3bvdXDUQXXnllXKu9evXu/kTTzzh5meeeaacC7lT7W133XWXHKPaq/r7+9180qRJcq6ysjI3r6ioyLRvM7Pe3l43D10DqvFKtQ295S1vkXOpa13tP9Qe19bW5uaq7ezpp5+Wc6nfpWo0nDFjhpxLtXSGfseq1VA1uhUXF8u51GsZT6ZPn+7moedQqD3Lo65lM914Ffq7qWeEup4PHz4s57riiivcfMeOHW6unpshqjkw1Lan7nOqIS90zahrI9QQivEhdC2r61aNCbXXqWvz4MGDmX4+tP/BwcFMPz/e8YkTAAAAAESwcAIAAACACBZOAAAAABDBwgkAAAAAIlg4AQAAAEDEmGzVq6mpcfOenp4R3Y9qOps8ebKbh9p56urq3HzDhg1urprJzMymTJni5nv27HHzFStWyLmUdevWufmaNWvkmIaGBjc/dOhQ5v2PN+qcevDBB+UY1by4YMECNw815Kj9q4auUIOkalxT15OZbqlT+w/N9dd//ddurlq1Jk7Ut0HVdlRUVOTm6vdoFv6deVSjmFn4mBXVnKSOOfRaQsc2XqhzMHTvztpG2NjYKLepZrfQuaFa4lSrZqiha9OmTW7e0tLi5qEmOvXsVOds6LjU73jLli1uvnz5cjmX2o86LjOayMYLdc2Y6fc86rwJteplPZ9G8twMzaXaK7M+58YiPnECAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIhg4QQAAAAAEWOyjlzVcatK41xVVVVl2k+ohrG7u9vNVRXqM888I+dSlZJHjhxxc1XpbGa2dOlSN1dVs2effbaca+3atW7+9a9/XY7By1RN8Je//GU5RlVCq/Nj7ty5cq45c+a4+YwZM9x82rRpci5VS6+uJzNdbaoqsUO1qqomWu0jVCurrh1Vn6xqys3061fXbeh+on4vaq7QfOprHEKV77///e/d/NJLL5VjCo36Ww8MDMgx6jpXtb/79u2Tc6lzMFRtrKjrSVX4m+nXoirUDxw4IOdSXzGi6sBDdfhTp05185///Oduru59ZvqeEfrqEXXdqDFpmsq5MDapv7X6qoDQ+RyqBM/68+pZp/Yfupfkcp8pFOP3lQMAAADAfxELJwAAAACIYOEEAAAAABEsnAAAAAAggoUTAAAAAESMyVa9v/mbv3Hz6dOnj+h+9uzZ4+aVlZVurhp4zMx27drl5qrN6LTTTpNz7d+/383r6urcXLUMmZmddNJJbr5582Y3X7lypZxLvUbE9ff3u/n8+fMzz6Xa03bv3i3HbN261c1DbT/jAU1YPvV7+djHPnaCj+TVpxrflFCzorrfq+uvt7dXztXU1OTmbW1tckzW81a1gJnpVj3VOqt+3ky3Qar9q5ZaM93qt3PnTjdvbW2Vc6nXEmoUU8esnsOHDx+WcyH/VLNq6NpQ9wB13ww9Z1XrqaLeS5jpY86lIW88vzfgEycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgIgx2aqnHDx4cETnUw1IqhlF5WZm7e3tbq7a89TPm+mmH9VMFGpmWrhwodzmoTnv1TEwMODm27dvl2PU+abO21A72OTJk91cte2EGiRVc5dq+zPTx3z06NFMuZluDgqNGSmhpiUll+PKZT+qBSmXdiR1rylEDQ0Nbq7+BupcNst+nYWoe3fo3BgeHnbz0DEr6hxQ96WZM2fKuVRzmWon6+vrk3NVV1e7+ZIlSzLtOyR0/qv2wNraWjenVW90mzFjhpur92FmuV1PI2VwcFBuU/cGNSb0nFfbQs/5QsEnTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIhg4QQAAAAAESycAAAAACBiTNaRq+pWVV1qputDQ2NUTXBzc7Obl5eXy7nmzZvn5qq2MlR1OWXKFDdXteNPPvmknGvFihVyW1bq75JL3THiVO23qjZXOQCtsrLSzVXtbllZmZxL1YHfdNNNbv6Vr3xFzqVqtFtaWuQYdc9Q92hV7W1m1tjY6Obqubljxw45l3qmKf39/XKbeg4uX77czVXdtFlu9e3qdzx16lQ337p1q5wL+af+bqGqbkV9HUHoKymyvn9S56yZvmeo926hrzbI5fUXCj5xAgAAAIAIFk4AAAAAEMHCCQAAAAAiWDgBAAAAQAQLJwAAAACIGJOteqplRLXZhNTW1sptqolPtZaoxhQzs/r6ejdXDUChxhK1n7q6Ojfv7OyUcy1atEhuA4DxTrXqdXV1uXmoqbWqqsrNW1tb3byjo0POpdrzenp65BjV+Kf239DQIOfq7u5289mzZ7u5etaZ6bYv1VQbeqYtWbLEzdXvJdRqd9JJJ7l5qAVNvW8ItS1i9FLv3XJpC1bXgLovhMYofX19mX7ezCxJEjcPteqFthU6PnECAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIgoqFoM1Qxiphv3FixYIMdUV1e7eXNzs5uXlJTIuVRrkGraUY1JZrpVr6Kiws1VK4yZ2cyZM+U2ABjv1HNAteeFWrCmTp3q5tu3b3fzlStXyrkGBwfdPNTe1t/fn+m4Qg1d06ZNk9s8paWlcptqojt27Fim3Ew/h1WD7sGDB+Vca9ascfO9e/fKMarxL9Tgi9FLneehVrkJE/zPJNS1qZqazfS1oaj7gln2JrxQe+R4xidOAAAAABDBwgkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAIKKg6shzMXfuXLlN1ad2dXW5eajae9euXW6u6l4XL14s5xoaGnLzyspKN9+3b5+c6/Dhw26uqt1VrXtsGwCMRaqOXNUEd3R0yLnOO+88N9+/f7+b19TUyLlUhXl3d7cco+7R5eXlbh6qI29qanLz0OtX1FdsKKFnjaoqV1XQofp4VS0e+roQVfleVVUlx2D0Un9PVTkeot5TqvMsF7lUiKtr5vjx43KMujeFro1CwSdOAAAAABDBwgkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARBdWqF2oAUWbNmiW3qRYe1WqnGlPMdDtRUVFR5rmGh4czjSkuLpZzqTalRYsWufnWrVvlXLk08QHAaFZSUuLmqokq1JCl7veqCSvUkKWeKaG2L/XsmDjRfyugXruZ2ZYtW9x86tSpcoyifpfq9U+aNEnONTg46ObqORR633Do0CE3D/2OVUOgeo0Y3VR7Zui8Ue8d1TlYUVGR/cByoM5bdV8KXf+qxXk84BMnAAAAAIhg4QQAAAAAESycAAAAACCChRMAAAAARLBwAgAAAIAIFk4AAAAAEFFQdeS5WL58udymqiMbGxvdXFU6mplNmTLFzXfs2OHmu3btknOtXLnSzfv7+908VN2qqlPVPkJ15NSOAyg0qkZa3e8bGhrkXKp2uL293c0HBgbkXOprMUK116qOvLe3181DdcSq2lg9B0Jzqcpn9RUX6nWEtqm5enp65Fz79+938+rqajlGvc7Q+wOMXurvlsvX36gxoXr7rNRXC5iF3wt6Ql+HcKIq1EcjPnECAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIgYk616qh0nl1a34uLizPtRQvtXTSeqnSfUjBRqOvGotj0z3Rgze/bsTPsAgEKk2qO6urrcfMmSJXKutra2TPuePn263FZaWpp5H319fW6unoP19fVyLtUENmvWLDffu3evnEu1+qm5VG6mn51nnXWWmz/00ENyrqamJjcfHByUYzo6Otw89BzG6KValEPngBK6nk8E1fiorpms7zXHCz5xAgAAAIAIFk4AAAAAEMHCCQAAAAAiWDgBAAAAQAQLJwAAAACIGDetemrMNddcI8eoBiLVZrRo0SI51/Hjx9180qRJbj40NCTnUo1CAwMDbl5eXi7nUtauXevmX/jCF+SYXFoNAWA0mzlzppuffPLJbq6aSs3MbrvtNjf/7W9/6+YLFy6Uc02dOtXNQ41zqiGwu7vbzdevXy/nevTRR938yiuvdPO5c+fKuTZu3OjmP/7xj9183759ci7V9jdjxgw3f+GFF+Rc//AP/+DmV1xxhRzz2GOPufnhw4flGIxeq1atyjxGtdeVlZW5+fDwcOZ9KJWVlXKbus7nzJnj5g0NDXKu0PVc6PjECQAAAAAiWDgBAAAAQAQLJwAAAACIYOEEAAAAABEsnAAAAAAggoUTAAAAAEQkkQrvUdkvnUsduVJXVye3TZzot7W/853vdHNVD2um68V7enrcXFWqmpmtWLHCzY8dO+bmu3fvlnM9+eSTbr5z504337p1q5xrtErT1D9hRpHReq0BWYz2ay2X62zx4sVuru7DU6ZMkXP9n//zf9y8v78/62Ehj97znvfIbdu2bXPzPXv2uPnevXsz778Qr7PRqra21s0/+MEPyjEXX3yxm6va/QcffFDOde+99waO7g998YtflNvmzZvn5t/85jfdPPS1OE899ZSbF1LtvrrO+MQJAAAAACJYOAEAAABABAsnAAAAAIhg4QQAAAAAESycAAAAACAi2KoHAAAAAOATJwAAAACIYuEEAAAAABEsnAAAAAAggoUTAAAAAESwcAIAAACACBZOAAAAABDBwgkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIhg4QQAAAAAESycAAAAACCChRMAAAAARLBwyrMkSRYlSTKYJMld+T4WoNAkSfLhJEmeSpJkKEmSf8338QCFKkmSu5IkOZgkSXeSJFuTJHlfvo8JKCRJkkxOkuQbSZLsTpKkJ0mSZ5MkeV2+j2u8YeGUf18xsyfzfRBAgTpgZreY2TfzfSBAgbvVzOamaVplZteY2S1Jkpye52MCCslEM9trZheaWbWZfcrM7kmSZG4+D2q8YeGUR0mSvN3MOs3sV3k+FKAgpWn6ozRNf2Jmbfk+FqCQpWm6MU3Tof/4f1/5Z0EeDwkoKGma9qVpemOaprvSND2epuk6M9tpZvwLihOIhVOeJElSZWY3mdlH830sAAD8sZIk+eckSfrNbLOZHTSzn+f5kICClSRJo5ktNrON+T6W8YSFU/7cbGbfSNN0X74PBACAP1aaph80s0ozO9/MfmRmQ+ERAHKRJEmxmd1tZt9O03Rzvo9nPGHhlAdJkpxiZpeY2RfyfCgAAIyYNE2PpWm63syazOyv8n08QKFJkmSCmd1pZsNm9uE8H864MzHfBzBOrTGzuWa2J0kSM7MKMytKkmR5mqan5fG4AAAYCRON/8YJGFHJy28av2FmjWb2+jRNj+T5kMYdPnHKjzvs5QfKKa/8c7uZ/czMLs/fIQGFJ0mSiUmSlJhZkb38LydKkiThXxgBIyhJkoYkSd6eJElFkiRFSZJcbmbvMIqPgJH2VTNbZmZXp2k6kO+DGY9YOOVBmqb9aZo2/8c/ZtZrZoNpmh7O97EBBeZTZjZgZv+Pmb3rlf/7U3k9IqDwpPby/yxvn5l1mNk/mdn1aZrem9ejAgpIkiRzzOwv7eV/4d6cJEnvK/+8M79HNr4kaZrm+xgAAAAAYFTjEycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEBGt5kyShOQJjXpqmSb6PIWasXWsTJuh/53L8+PER28/pp5/u5tu3b5dj+vr63Ly4uNjNQ8c7b948N9+8mS9q94z2a22sXWchs2fPdvO3ve1tckxXV5eb79692833798v59q6daubl5SUuHlNTY2cq7+/P9OYU045Rc710EMPuXlra6scM9ZwnY1utbW1bj44OOjmAwMnplW8vr7ezTs7O938yJHx/RVR6jrjEycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEBMshAMATKlSYONG/raxevVqOecMb3uDmjY2Nbr5v3z45V3d3t5sfOnTIzcvKyjIf1+9+9zs3v/POO+Vc6j+mB9R5dvvtt8sx6tro7e2VY8rLy908Tf3/lj9UAvP73//ezdW9YeXKlXKuyy67zM0vuOACN7/pppvkXM3NzW6uii4+8YlPyLkefPBBuU1JEr+3Qf2OMTa95z3vkdtOPvlkN1fPRnWem5k9//zzbq6KHtrb2+VcbW1tbq5KWNavXy/n+trXvia3FTo+cQIAAACACBZOAAAAABDBwgkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARSagiM0kS+jMdI1k3evXVV7v5fffdl3ku+NI09f9go8hYu9bOOussuW3t2rVuXllZKceUlJS4uaoQHxoaknPNmzfPzXft2uXmtbW1cq7h4WG5zVNaWiq3qZr0f//3f3fz3/zmN5n2PRqM9mst39fZhz/8YTf/3Oc+5+adnZ1yro6ODjcPVYgrR48edfOmpiY5Rp23Tz/9tJv/7//9v+Vcu3fvdnN1z+jp6ZFzHTlyxM2rqqrcvKKiQs516623uvktt9wix5wIXGcnjvqqgFCF+HPPPefmq1atcnP1NQFmZn19fW5+xhlnuPlvf/tbOZeqKldfFTBjxgw519133+3m3/72t+WYsUZdZ3ziBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgAgWTgAAAAAQMTHfB3CiqKahUBOe2lZcXOzmoQau1atXZ8pDrXqquUs1jR0/flzOpRQVFWWeK5dWQYxuixcvdvP3ve99csyxY8fcPNQQduDAgUzHNTg4KLdt2LDBzadNm+bmO3bskHOp810196nmPDOzmTNnuvmf/dmfufnzzz8v51LtSKrx04zrM1cTJ/qPSdVEF2rI+sQnPuHmzc3Nbh66306ePFluU1TjnDpvBgYGMu9fNeGFrg3VHKba80K/Y/U76+/vd/PQa1QtiL/4xS/kGNUqqN6D5PJ8xokzffp0N1f3BTOz8847z80PHz7s5qFnozo/77zzTjdX17iZbvXbv3+/m6tWW7Pw6y90fOIEAAAAABEsnAAAAAAggoUTAAAAAESwcAIAAACACBZOAAAAABCRhJqWkiQZ1zVMqmlItYmE2kxOOukkN//Qhz7k5qoZzMysrq7OzWfPnu3mmzdvlnN94QtfkNuyUk18IaqBbSSlaaqrxkaJ0Xqt3X777W4earXr6upy89C9RjVFbt261c2XLl0q51LtXaq96sUXX5Rzqf2oe0BFRYWcSzWHqRaylpYWOdc//dM/yW35NNqvtVyuM3VfU/euv/mbv5FzfepTn3Lzjo4ON6+qqpJzqTGhZkX1jFKvMZfmPtUuG2rhUseVS3OX2r+6NkP3JfX6n3jiCTlm7dq1gaMbGYV4nY01K1askNtuvvlmN1eNzCHbtm1z8wsvvNDNVUOnmW7va21tdfPrrrsufHAFTl1nfOIEAAAAABEsnAAAAAAggoUTAAAAAESwcAIAAACACBZOAAAAABDBwgkAAAAAIrJ3fY4jqqY0VPeq7N69281VPeSUKVPkXKrW+JlnnnHzc889V861ePFiN1c10CEjWS2u6nFVpbRZuFYWYZMmTXLz/v5+N1eVv2Zm06dPd/P9+/fLMWVlZW6uroMdO3bIuebNm+fm6rWccsopcq6dO3e6+ZVXXunmjzzyiJxLmTFjRuYxOHGy3tcuueQSuU2dg+q+NjQ0JOdSXwkQqsRXr0XVgav7gplZb2+vm5eXl7t56J6hnqnq9YeewVkrn0O/Y/V7ufzyyzPtIyT0NR4n4us6kJuNGzfKbeo9mnqPUlJSIuf63e9+5+bqOgtds2r/mzZtkmPwh/jECQAAAAAiWDgBAAAAQAQLJwAAAACIYOEEAAAAABEsnAAAAAAggla9HKimnZCGhgY3Vw1IoZaV2tpaN9+3b5+bq0Y/M7M3velNbq5azkKtdqrp7L777pNjOjo63Jw2oRNLnZ8TJvj/biV0Hqi2oalTp8oxu3btyrT/yZMny7m2bdvm5uqcVu1EZmYrVqxwc3VNhe4NS5cudXPV6hW6B6jXH2oIw4lx9tlny22qia60tNTN1flvFm7PU1TjlmqiU+1gof2rlrijR4/KuSZO9N+KqBawUHOYugbVNaN+92Zmra2tbt7W1ibHzJo1y8337t0rx6CwqPvwGWec4eYvvPCCnEs1uKpmx1Dbn3q/pZpAb7/9djnXeMYnTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIhg4QQAAAAAEbTqBah2INX4VlVVJec69dRTM+071ECm9q/agUINRAMDA24+ODjo5qGWp9WrV7u5ahMz001Djz32mJs/++yzci7krq6uzs3r6+vdvL+/X85VWVnp5i+++KIcs2DBAjdXTVydnZ1yLvVaVEudahoyM0uSxM03bdrk5qqdzMysp6fHzdV1W1NTI+dqbGx08z179sgx0FSrm5k+B9X5pM4/M7Ouri43V+eZupbMdLOlau4LjVH3dfUMNNPtdbk8O9QY9bsPNeGpMeq1hJoo1XkRus5VqyKteuPH5s2b3XzlypVu3tLSIud65JFH3Fy9r1Lv6czMtm/f7ubt7e1yDP4QnzgBAAAAQAQLJwAAAACIYOEEAAAAABEsnAAAAAAggoUTAAAAAESwcAIAAACACOrIR9AVV1wht82aNcvNH330UTdXNdBmZtOmTXPzsrIyNw9V2qptw8PDbq6qXs10DW5o/6pSc/ny5W5+ww03yLlUpS3iZs+e7eaqPllVMZvp2t9Qxb6q6lbnzsKFC+VcbW1tbt7Q0ODmqt7fTNcOn3/++W6+c+dOOVd1dbWbq4roUOV6RUWF3IYTQ1XoNzc3yzGqknvy5MluHqpJV+dNqEJcjVF56Cs2VO2xekaUl5fLudQ1qF6/ul+E9qNy9awz07/L0O/4da97nZt///vfd/PQ/Qf5p74qIE1TOeapp55y83PPPdfN77//fjmX+uoP9Wz+zne+I+dSz0D1zAzJ5fdSKPjECQAAAAAiWDgBAAAAQAQLJwAAAACIYOEEAAAAABEsnAAAAAAgYty36qk2IzOzoaGhTHPl0oSn2vZCTTuqueuSSy5x88OHD8u5VMuTaiBSP2+mm4Y6OjrkGNWEpxqbrr32WjnXd7/7XbkNYfPmzXNz1SoXasgrLS1181BLXF1dnZurpsaDBw/KuVRDYF9fn5uHmsvU+a6a07q7u+VcZ511lpvv2LFDjlHUtf7iiy9mngu6VS5EnWfqmjHTjXOqiSr0DJo0aVKmfZjpe7Q6z9V9ODRG7SPUqqfuGeq1hK5ZdQ2q9rzQewD1HA418S1btkxuw/ig7gHqPA89A9avX+/mDz/8sJsvXrxYzqXaWLdt2ybH4A/xiRMAAAAARLBwAgAAAIAIFk4AAAAAEMHCCQAAAAAiWDgBAAAAQAQLJwAAAACIGPd15KHab2XOnDluruqOzcwef/xxN1+1alXm/U+ZMsXNTzvtNDf/+te/Lufq7+9386ampszHpSp1Kysr5RhVN6tqqN/3vvfJubq6ugJHhxD1u+vp6XHz0Pmh/nah86ClpSVwdH8oVB+tqsLVuZ4kiZxLVennUgX9+c9/3s0/+tGPunmoIjZ0r0F2udSRn3/++ZnnUhXeqhK7pKQk83EdOXIk8xglVLtdVlbm5up6Cn0thbpu1OsPvUZV+ayEvmJD1TeHvlpBfe0Axib1viZEfV2Hqim/8cYb5Vzq2awq+c844ww5l7o2nnzySTkGf4hPnAAAAAAggoUTAAAAAESwcAIAAACACBZOAAAAABDBwgkAAAAAIsZ9q16oBUvZvXu3m1900UVyjGpN+vWvf+3mL730kpzrzW9+s5urBrSVK1fKudSY1tZWN1dNSiGh37FqYJo3b56bHzhwQM511113ufmdd94ZODqYma1YscLNVetkUVGRnOvmm2928/e+971yjGrPUu1VofNQtWR1d3e7eX19vZxL7V8db6hR7aGHHnLzm266yc1DjWZLliyR23BinHLKKW4eanxT11NNTY2bP/DAA3Ku5cuXy22KapxU7XGhVj91PanrT7WAhfajnkN1dXWZ51LH29DQIOcaGhpyc9XQaWa2f/9+N58+fbqbHzx4UM6Fsek1r3mNm6vnprr+zMw2bdrk5up9VaglUr1/Uu8Rv//978u5cmkbLBR84gQAAAAAESycAAAAACCChRMAAAAARLBwAgAAAIAIFk4AAAAAEDHuW/VyMWPGDDdXrT1mZpdddpmbr1mzJvNc27dvd/Pf/OY3bl5ZWSnnUo1CVVVVbh5q+lINRPv27ZNjsjbDfOhDH5JzISzUtqPats4880w3v/TSS+Vc6lxfvXq1HHPeeee5uTrfQq1+bW1tbj5nzhw3DzWHqYa0jo4ONw81dKlz/dRTT3Xzbdu2ybnU/UG1VJqN7xakV8PChQvdPNSsGGqW86hGLTN93qjmPjP9LBgcHMw815QpUzKNUc+HEHXNFBcXyzHq3qCaaqdNmybnUn/L0L1UNeguWLDAzWnVy7/Q80Sdz6E2VnVtqPdCy5Ytk3Opa/a+++5z89LSUjmXetapczD0bFT3DPUMKqTnD584AQAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgIhxU0eu6iZDdasXXnihm3/yk59085aWFjmXqg8uKytz81Dd6cyZMzPNdeDAATnXzp073bympsbNQ3XkqoYyVPfa19fn5hs3bpRjkBv1NzUzO/vss91cnVP/9m//lnn/559/vtz2zDPPZNp/6LWoCuPGxkY3f+655+Rcqo587ty5bl5eXi7nUtavX59p32b6vjVr1iw5Zs+ePdkODEFTp051866uLjkmVKPtCdWXV1RUuPmhQ4fkGHVt1NXVuXnoHOzv7880pra2Vs6lfmfqazEGBgbkXGo/qg49VOGv3jeE6qvVfPPnz3dzdf1jdDv33HPlNvW1FF/5ylfcPHRvVveMH/zgB27+9a9/Xc71y1/+0s3VveSUU06Rcz3++ONuTh05AAAAAICFEwAAAADEsHACAAAAgAgWTgAAAAAQwcIJAAAAACIKqlUv1I4Tas9TrrvuOjdX7VyhxqS9e/dmymfPni3nUs1dqhnltNNOk3Nt3brVzVtbW9188uTJci7VWqRyM93ypBqIkDvVUGWmW61Ue9zhw4cz73/OnDly24svvujmubRhqnPn3nvvdXN1PZvpdiR13YbmUp599lk3P/XUU+WYffv2ubn6e5nRqpcrdc9TzY6qQdXMrLS01M1VE117e3vmudQ9NbRNtdSFnqmq8W/SpEmZ9hHaj8pLSkoyH5f6HatryUy3VIbaDtU965xzznHz73znO3IunBi5vD/86U9/Krf92Z/9mZt/8IMfdPPVq1fLub71rW+5+fXXX+/mg4ODcq7//t//u5urZ2PoXqJa9QqpPU/hEycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgIhx06qnmj6uuuoqOaa+vt7Ne3t73TzUqDVz5kw3379/v5tXVlbKuXbu3Onmqm2vrKxMzrVkyRI3P3DggJuHWvVUa1KogUjNp5qZQs1woTYrmDU1NcltdXV1bq7+Pp2dnZn339fXJ7epv3d/f3/muVTj3Zve9CY3f/jhh+VcqtVM3RvU7zFENVued955coxqCFMtYMidaoM8dOiQm4faVdV9XTUrTpig/92met4dP35cjgnN5wm1jalrVt0z1HPTTD8j1H0m9KxX+1fP2lDrq/rb5/J3WbVqlRyDsecTn/iE3NbT0+PmX/nKV9z8ggsukHOp95U33nijm3/uc5+Tc918881ufvDgQTdfvHixnEuhVQ8AAAAAwMIJAAAAAGJYOAEAAABABAsnAAAAAIhg4QQAAAAAESycAAAAACBixOvIVRWnqu8M1YoePXo0075DNazK008/LbepKta2tjY3D1U0qxrt0tJSN586daqcS1UxqxrcUB35nj173HxwcNDNa2pq5Fzqb6xq0s10daUaE6pb3rhxo9wGs4qKCrlteHjYzdU59fzzz2fef6jCV9Xfqwrjs88+W841e/ZsN7/jjjvcPPQ1AqoSfMOGDW4euj5UFbW6b4Rq/EtKStw8VNOO3MyYMcPN1b079LUI6nmn6sinTZsm51L3TnUtm+lnqqrRD82larzVsyP0VRLq2a2ewaH3Bmqb+uqN0GtUioqK5DY1X0NDQ+b9YPS6+OKL5baWlhY3v+GGG9xcfSWFmX5ufuELX3Dz0FcIqK8kUc+m1tZWOdd4xidOAAAAABDBwgkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARwVa9UAuWkrUdZyTNmTNHbvv0pz/t5qHGuerqajdX7Tx79+6Vc23atMnNL7zwQjdvb2+Xc6l2ItXONWXKFDnXtm3b3Hzy5MluHmogmj59upuHGpBUe55qc1N/E8Spv6mZ/rv29/e7eehcP/30091cNTiamS1cuNDNf/azn7l5qL3ul7/8pZuvXbvWzUNtjPv373dz1VCoft7M7KyzznJz1cCk2jtDY07EfXa8WbFihZurhrxc/gbq3n3JJZfIMapxUjUuhnR0dLh5qIlT3btVq17oOaB+Z+r5HHpuq9eimgMff/xxOZcSarxU58XMmTMz7wf5p9oz1fVnpt/v1dbWurlqgjUzu/zyy938s5/9rJuHro3Nmze7+Tve8Q43V8+Z8Y5PnAAAAAAggoUTAAAAAESwcAIAAACACBZOAAAAABDBwgkAAAAAIoKteqohLxezZs1y81DTjGoaUWMuuuiizMelGlPMzA4dOuTmqmls7ty5cq4zzjgj0z527twp51KNYur3oprzzMxaW1vdfMaMGW6umonMdJtQqAlPNdOouebPny/nevTRR+U26N+pmVlPT0+mPNREd+aZZ7q5ahQy001cb3jDG9w8dG9SrULqOgg1h6lWIXWtV1ZWyrnUfh577DE3D7UjqblCzWXIjWp8VELtlervo66N0DNFXZuhc1A17qVp6uahe4ZqllP7CP1e1PWsns/qGWymX0tjY6ObqwbXkNCYI0eOuLn6vYSeqaF2XZwYqq05dD6rMSrv7u6Wc33xi1908/PPP9/Nh4aG5FzqPqOev6G2P9W6PZLrhtGKT5wAAAAAIIKFEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABARLCOPBef/vSn3byqqsrNQ9WJqu5RVYGqWl8zs4aGBjcP1fcuWLDAzVVFbFdXl5xr165dbq4qXZctWybn2rx5s5sXFRW5eag6WlWFq7pjVUFppqsuVT2rmT5m9bdfvHixnAthoWtNVdwvWrTIzZubm+VcU6dOdfM9e/bIMR0dHW6urtsNGzbIuZYsWeLm6lo7ePCgnGtgYMDNVY1/X1+fnEvVWv/kJz9x89C5rq5pVcWM3K1YscLN1bNj0qRJci5VIZ5LtbDavzrPQ9Q9OvRa1LmmjjlU4a3mUtXGx44dk3OpqnL1HuSkk07KfFzl5eVyjHrWT5s2zc1D1/njjz8ut+HEWLNmjZuHvspGnevqWfPDH/5QzqXO9enTp7u5emaaZX8+hL4OQW176aWXMu1jLOITJwAAAACIYOEEAAAAABEsnAAAAAAggoUTAAAAAESwcAIAAACAiGD9jmqB+fjHPy7HqBYc1TgXag0qKyvLlKvjNdPNJKEWrGeffdbNH3zwwUz7CLn44ovdPNReN2XKFDdXbT6htr9Zs2a5uWq7U/s20014KjfTv3/VPqMakxC3dOlSuU39vbu7u908SRI5l2qJmjdvnhyj7hvquFauXCnnUo1GDz/8sJtfeumlcq6HHnrIzVXbYEjoOvQ89dRTcptqTgs1PSE3jY2Nbh5qZFVUG5u6r4YaSVVDVugeqVry1DWjrkuz7O19oWeaus7Vawk9U0pKStxcNWSGWsjU6w/97bOeF7Nnz5bbaNUbvVS7sZnZtm3b3Fw9N0Lvqc844ww3/5M/+ZNMuZk+N2+77TY3/8d//Ec515w5c9ycVj0AAAAAAAsnAAAAAIhh4QQAAAAAESycAAAAACCChRMAAAAARARrca6++mo3DzXaVFZWurlq1Ors7JRzZW2nCbX2qEad0GuZP3++m6vmqlCjVW1trZurY66qqpJzqaYl1VB34YUXyrnq6urcvLW11c1VK5SZ2d69e9081LKijlmdF6E2t8suu0xug9nzzz8vty1btszN1d8h1Lal2i1DbV+qKVMJ7f/AgQNuftppp7l5qO1ONRGqRjHVTmaWvfFOtaaZ6Xa0wcHBTPtA3IwZM9x8eHjYzUP3bnWuqVa5XP6eobY79UxVryX0fFTPIXVthhp0a2pq3Fw11ba1tcm51GtUv5fQcam/V+hvrJ6R6v531llnybnuueceuQ0nxutf//rMY7Zs2eLm6jn3rW99S86lWh+bmprc/C1veYuc6wc/+IGbq+a+97znPXIu1Ub761//Wo4pFHziBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACKCdeSqhvX73/++HPPCCy+4+R133OHm9fX1ci5Vd6pqfUtKSuRcqr43VG+tKsxVPWSoqlvVFKvKYVUHbmb23HPPufnjjz/u5ocOHZJz7d69281VTfjhw4flXL29vW6+aNEiOUZVVyuzZ8+W20K10tCV42b6/FTV3iGrVq1y81Aduro+1TUYqupWla+q2jj0NQYVFRWZ8lDleuj37+np6ZHbVIVyqKYduVE11uoeGaoDV88odT6rc9ZMn7eq2txMV3Wr4wrNlfUrPtQ1Hjou9fpD1f7qGlCV66F7ibrOQmOyfl1I6PmI/Dv11FPdPPRsPP/88928sbHRzUPX2YIFC9x85cqVbv7www/LuVasWOHm6tn01re+Vc61f/9+N//iF78oxxQKPnECAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIgItuq99NJLbn7DDTfIMa9//evd/I1vfKObhxqtli9f7uaqiS/UaKXa21avXi3HqDYT1Q7U0tIi5zp48KCb//znP3fzdevWyblU009lZaWbq5YfM7Pq6mo3r6qqcnPVtGim25RC7WBbtmxxc3XMGzZskHOFGv9gtnfvXrlt8eLFbh5qilRe+9rXurlqtTLTjVPq/lBTUyPnUtvU9Tl16lQ5l7oOlM7OTrkt1Prp2bdvn9w2ODjo5urvaGb2wAMPZNr/eBJqwlPnU3t7u5uHznN1X1NNcKH2NkW13YX2n0vrrDo29VpUc56ZbqlU53mohUxtU68l9LdXf8vQGPUcVHlTU5OcCyfG/Pnz5TZ1T1ftrWb6HHzwwQfd/KqrrpJzdXR0uPmTTz7p5qH7j2q3vummm9xcvdc00+/dxgM+cQIAAACACBZOAAAAABDBwgkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARwTryO++8081DldSPPfaYm99zzz1u/uMf/1jO9cILLwSObmT89Kc/fdX3MdLq6urcvLS01M0bGxvlXKqGVlXNhupxVd1sqIb52LFjbq6qo0PnXqgeFGbTp0+X21Tt+DPPPJN5P6qmORfq/Ghra5NjQts8vb29mX7+RAlVi2/dutXNR+trGe1ClfSqFl7d70J1wKqmWN27Q/dbVS0equpWNdq51H6r2nNVLa6uZTOz7u5uN1e/41Dluqr9VjXpoePK5Ss21POuq6vLzUPPZ5wYs2fPltvUdabODTN9796/f7+bh772YvPmzW6+cuVKN7/++uvlXOq5oa6N0L1Mnefqtat9j0V84gQAAAAAESycAAAAACCChRMAAAAARLBwAgAAAIAIFk4AAAAAEBFs1VP+4R/+QW6744473PyWW25x8+uuu07OpVrAdu/e7eah1g7VZtLa2irHKKoBKGT+/Plu/oY3vMHNly1bJufasWOHmz/88MNuHmpGUy1LqjGmr69PztXf3y+3Zd3/Rz/6UTdXjYJmZh//+Mcz7388mTBB/3sS1V4VatXKup9QQ1hoW1ZJkmTah/p5s+yvJfQ61Fyq1Wv79u1yrvr6ejfftm2bHAPt6quvltuamprcXDXRhdq2tmzZ4uaqLTTUhLl37143Vw19ZvpcV9d/6Hyuqalxc9XQmct1pvJcGlRVQ9i0adPkmM7OTjdXzYFmuiFtaGjIzXN5P4GR9drXvlZumzVrlpv/7ne/k2PUc/PCCy90c/X+1Mzs6aefdvPXvOY1bh5qo1bX80svveTmq1evlnOpttEVK1a4Oa16AAAAADCOsHACAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABARLBVT7XghNq5Ojo63PxDH/pQhsN62dy5c91ctfmcffbZcq41a9a4eahVb9GiRW7+4osvurlqEzEz+/3vf+/m999/v5s/8MADcq4jR464+YIFC9xcNfeZ6VY71f7U1tYm51K/4z179sgximp/oTkvd+q8HWnHjx8/IftRsjb0hX5eNd7lIutclZWVcptq4sqlbQxm69atk9tUw2dtba2br127Vs71xje+0c1Vq1VIcXFxptwse7Okatsz0+enapwLNXSG3lNkNTAw4Oaq9VW9Zwk55ZRT5DbVwtje3u7mzz33XOb9Y2SdeeaZctvmzZvdfObMmXKMetbu3LnTzT/wgQ/IuVpaWtx8yZIlbq7eH5uZXXnllW6umiVDLcrq/qfetxcSPnECAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIhg4QQAAAAAEUmoijdJkmy9vsAolKap37U7inCtIYuqqio3VzXlJ8pov9a4zlAIuM7y7yMf+YjcdujQITdXX+dy3nnnybk2btzo5uvXr3fzZcuWybnUc0N9hYD6eTOz5uZmN3/++efdfPv27XKu0UpdZ3ziBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgAgWTgAAAAAQEWzVAwAAAADwiRMAAAAARLFwAgAAAIAIFk4AAAAAEMHCCQAAAAAiWDgBAAAAQAQLJwAAAACIYOEEAAAAABEsnAAAAAAggoUTAAAAAESwcAIAAACACBZOAAAAABDBwgkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABAunPEmS5KEkSQaTJOl95Z8t+T4moJAkSTI5SZJvJEmyO0mSniRJnk2S5HX5Pi6gUCVJsuiV59pd+T4WoBAlSXJXkiQHkyTpTpJka5Ik78v3MY03LJzy68Npmla88s+SfB8MUGAmmtleM7vQzKrN7FNmdk+SJHPzeVBAAfuKmT2Z74MACtitZjY3TdMqM7vGzG5JkuT0PB/TuMLCCUBBStO0L03TG9M03ZWm6fE0TdeZ2U4z4yEDjLAkSd5uZp1m9qs8HwpQsNI03Zim6dB//L+v/LMgj4c07rBwyq9bkyRpTZLkkSRJ1uT7YIBCliRJo5ktNrON+T4WoJAkSVJlZjeZ2UfzfSxAoUuS5J+TJOk3s81mdtDMfp7nQxpXWDjlz8fNbL6ZzTSzO8zsviRJ+LcGwKsgSZJiM7vbzL6dpunmfB8PUGBuNrNvpGm6L98HAhS6NE0/aGaVZna+mf3IzIbCIzCSWDjlSZqmT6Rp2pOm6VCapt82s0fM7PX5Pi6g0CRJMsHM7jSzYTP7cJ4PBygoSZKcYmaXmNkX8nwowLiRpumxNE3Xm1mTmf1Vvo9nPJmY7wPAf0rNLMn3QQCFJEmSxMy+YWaNZvb6NE2P5PmQgEKzxszmmtmely83qzCzoiRJlqdpeloejwsYDyYa/43TCcUnTnmQJElNkiSXJ0lSkiTJxCRJ3mlmF5jZ/fk+NqDAfNXMlpnZ1WmaDuT7YIACdIe9/MbtlFf+ud3MfmZml+fvkIDCkyRJQ5Ikb0+SpCJJkqIkSS43s3cYhSwnFJ845Uexmd1iZkvN7Ji9/B/4vSFN0615PSqggCRJMsfM/tJe/t9/N7/yb8PNzP4yTdO783ZgQAFJ07TfzPr/4/9PkqTXzAbTND2cv6MCClJqL//P8m63lz/42G1m16dpem9ej2qcSdI0zfcxAAAAAMCoxv9UDwAAAAAiWDgBAAAAQAQLJwAAAACIYOEEAAAAABHBVr0kSWiOwJiXpumo/36s8XCtlZSUyG0//OEP3Xzfvn1u3tfXJ+dqampy80ceecTNa2pq5FzV1dVu3tPT4+azZs2Sc91www1u3tbWJseMNaP9WhsP1xkKH9dZ/v3VX+nvnF28eLGbb9iwwc1Dz8bjx4+7eXd3t5tXVFTIuWprazONWbJkiZzrxRdfdPPPfOYzcsxYo64zPnECAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABARLAcopAkycj9t5Rpmv2/e/zABz7g5uo//CsuLpZzlZeXu3lZWZmbz5w5U85VWVmZaa7Q73Hy5MluPmnSJDmmo6PDzXt7e9386aeflnPddtttchvy75prrpHbTj31VDdX18H06dPlXOrcPemkk9xcnbdm+ty9//773XzVqlVyrtNOO83NH3zwQTkGADD6vO51r5Pb+vv73VyVQITeIx06dMjNVTmDKqYwM5swwf+sZHh42M0PHDgg51q4cKHcVuj4xAkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEjJs6clUhHqrXVtWNx44dy7z/G2+80c0PHjzo5qqm3EzXi6vjGhgYkHOpMapOU+VmulKzrq5OjpkyZYqbFxUVufn8+fPlXNSRj26qDtxM14vv3bvXzVUVq1n2WvxQHbmqxVdfCXD48GE5V3V1tdwGABh9LrjgAjdfs2aNHPPoo4+6+TnnnOPmbW1tcq6JE/236VdccYWbq/dOZmZHjx51c/UerbOzU87V2Njo5n/5l3/p5l/72tfkXGMNnzgBAAAAQAQLJwAAAACIYOEEAAAAABEsnAAAAAAggoUTAAAAAESMm1Y9RbXtmeXWnqfcd999br5w4UI3Hx4ezryPvr6+zGNKSkrcXLX6hdr+1DGHmsbU7181oK1bt07OhdGtrKxMbvv1r3/t5qoRMtRQV1lZ6eaqwTLUaFRcXJwpD90zli1bJrcBAEYf1YT37LPPyjHqfZ16bqmW1lyE3tMqqm1v7ty5csxvf/tbNz/33HPdnFY9AAAAABhHWDgBAAAAQAQLJwAAAACIYOEEAAAAABEsnAAAAAAgYty36p0oqh1s4kT/TxBqrxsaGnJz1fSlmvNy2f+ECXqtPTg46OZ1dXVyTHd3t5urVr1f/OIXci6MbqtXr5bbVBudamRUzXlm+tyZM2eOm6vz1syst7fXzTdt2uTmoUYjdQ8AAIxOqvFOPWfMzKqqqtxcPc/U+7BchN47Jkni5qoRWbXtmZlNmzbNzUMttYWCT5wAAAAAIIKFEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABHXkJ8gzzzzj5qtWrXLzUA2kqm5W9ZihCvGioiK5Lcs+QnOpCszQfKoi+oUXXggcHUazhoYGue3QoUNuripPQ+fUkSNHMu1j5cqVcq4XX3zRzadMmeLm6qsCzMK15wCA0Ue9R6murpZj+vv73Vy9Fwu9R1PPOvV+K/TeUVWVq7lCX6HR1NTk5uPhPRqfOAEAAABABAsnAAAAAIhg4QQAAAAAESycAAAAACCChRMAAAAARNCqlwPVgKIaS8zMHn30UTd/97vfnXkuRY1RLXxmZhMn+qdA1rY9M/17Ce2/sbHRzbdu3ermocYYjG6h86C9vd3N29ra3LyqqkrOpbb19fW5eUtLi5yrp6fHzQ8ePOjmoXYkNRcAYHSaOnWqm1dUVMgx6lmj3leF3u9lbeILPYNCz2BPqCW2tLTUzevr6zPtYyziEycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgAha9XKQSzNKc3Ozm8+ZM8fN9+zZI+dS+1ENeWmayrlUA4saE2plUXOFmvC6u7szj8HoliSJm4f+pocPH3Zzdb6pfZiZdXV1uXlDQ4Obq+sGADC+zZs3z837+/vlmNB7rqw/r56bofY8Rb13VPmkSZPkXIODg24+ZcqUzMc11vCJEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIigh/cEKS0tdXNVq3zkyBE51+TJkzPNFaqUVGNUHqrAzFp1aWY2MDDg5jt27JBjMLotWLDAzcvLy+UYdR5kvW7MzFavXu3m69atc/OTTz5ZzlVVVeXm8+fPd/OdO3fKuULXAQBg9FHveULPIDVGPQNCc6kxqqY8l6/XyFqfHhoT+sqaQsEnTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIhg4QQAAAAAEbTq5SCXBpLly5e7+d69e928paVFzjV79mw3V00uoSa83t7eTGPKysrkXKoJMNQmphr/Dh06JMdgdFuxYoWbh9p21Pmmzo+amho5V21trZtff/31bv6LX/xCznXJJZe4+cMPP+zmbW1tcq6+vj65DQAw+gwODrp5cXFx5jFFRUVuHno2qvebubwPVY3Mw8PDmY+rpKTEzUON0IWCT5wAAAAAIIKFEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABHXkJ0jWGspQ7beq9z569KibJ0kyYnOFKpVV1WWoDj3r/jH6NTQ0uHnoPFDVql1dXW6+cuVKOdeDDz4YOLo/tG/fPrmtu7vbzVXteOhaKy0tzXRcAID8eumll9x89erVckx/f7+bT5zov+UOVYur56aqQw9ViKsx6rhC1eKqjry5uVmOKRR84gQAAAAAESycAAAAACCChRMAAAAARLBwAgAAAIAIFk4AAAAAEEGrXg5yaXzr7Ox0c9VmEqKaTgYHB9081Gam9q/a7lQe2pZLY8zJJ58sx2B0q6mpcfNQ24+6ptT5WVdXJ+e67rrr9ME5fvKTn8htV199daa5hoeH5baBgYFMcwEhixcvdvPQOahaItUzpaenJ/uBCaHGydAzAsinbdu2uXl5ebkco551oWtAmTRpkpur95SNjY1yrqGhITdX78NyaYndunWrHFMo+MQJAAAAACJYOAEAAABABAsnAAAAAIhg4QQAAAAAESycAAAAACBi3LfqFRUVyW2hFrCsli5d6uaqASnUtqfaTIqLi9081AI4efLkTHOp9iUzs/7+fjcvKyuTY1Rr07nnnuvm6njNdGMMTqzKysrMY9S5c8opp7j5U089JedqaWnJtO/nnntOblPnZ0VFhZurBiQzswMHDmQ6Low81RKV71a3z33uc27+pje9SY6pqqpy8+eff16OefHFF91c3e9DrVr33HOPmz/wwANunu/fMZALdd8OvRdRVPNw6DpT70P/7//9v27+gQ98QM7V3NwcOLr/+r7N9PvQHTt2ZNrHWMQnTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIhg4QQAAAAAESycAAAAACBi3NSRq7pHVQ8ZGpNLreqqVavcfGBgwM1LSkrkXKoGUlWrh6ouBwcH5TZPX1+f3Kb2r6puzcw6OzvdfOfOnW5+yy23yLluuOEGuQ0nzp49e9w8dN2o872xsdHN161bl/3AhNA5ra4dVctfXl4u5+ru7s52YBhx6hwMfS2Fun9lvXeamd1xxx1u/o53vMPNb7/9djnXnDlz3Pycc86RY9S2gwcPuvnhw4flXCeddJKbf/7zn3fzj3/843KukbyeJ0zw/32wykNCz04l6/uD0FeP8BUb+bd58+bMY7K+3wy9R1Ln7b//+7+7+V//9V/LudRX06hzNnT+q3vm008/LccUCj5xAgAAAIAIFk4AAAAAEMHCCQAAAAAiWDgBAAAAQAQLJwAAAACIGDetekqoAUe1magxJ598spxr0aJFbj558mQ3r6yslHONZNtf1gaisrIyOZd6LaHjUq9TjXnDG94g56JVb3RQDV3Hjh2TY6qqqtxcNUju2rUr83Ep6rw1021HuTRI7tu3L9uB4YQJnZuhbZ7Qc6ClpcXNQ/f7E+HP//zP3Xzt2rVyTH19vZvv37/fza+77jo514UXXujmudzTVXNZqEE3n1TTGUaHDRs2uPnw8LAco94/qXMw1Kyo3u89+eSTcoyinlvqHAy1jarX/+KLL2Y+rrGGT5wAAAAAIIKFEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACLGTaueamlTjSVm2Vt4/uIv/kJuO3LkiJtXVFS4eajpS7WZqGaWUGuP2o+aK9Qw1d7e7uaqYcZMt7aov0uo5eXqq6+W23DilJSUuHnoWps0aZKb19TUuLlqJ8tFc3Oz3Nbf3+/m6rpVP29mVl1dne3AMOJOO+00N1+5cqUcs2nTJjdX7XHXXnutnEs1dKnzafbs2XIuda4NDAzIMYcOHXLzb3/725lyM7OTTjrJzb/0pS+5+erVq+Vcl1xyiZufccYZbv7lL39ZzqV+l+qeEXqmDQ0Nufng4KAck1VjY6Pc9sQTT4zYfjCyQu+rQu95PKH3e319fW6uruVQi7F6NufSqjdaWypPBD5xAgAAAIAIFk4AAAAAEMHCCQAAAAAiWDgBAAAAQAQLJwAAAACIYOEEAAAAABF5ryMPVRSHahVHSi77eMc73uHm06ZNk2NUhbjKQ/WUVVVVmeYKVUqqutXe3l43D1Xd9vT0uHmotlLVnqvazLa2NjnXmjVr5DacOJs3b3bzUO2vOkcPHjzo5h0dHdkPLAeqJj3rNWhmtmjRIjf/xS9+kf3AkJO3vvWtbv7mN79ZjlG14+oeHaqkX7VqlZvfdNNNbp7L8zFUhazOZ3X9qa/RMNP3+3379rn5iy++KOfq7Ox0c/V1BP/8z/8s51JjVOVyaWmpnOvAgQNurl67mf6dqb+Lqk83M/vkJz8ptyG/1HsnM/2+Rr0XCl2zWavvVX25mb7+ldBxhe4NhY5PnAAAAAAggoUTAAAAAESwcAIAAACACBZOAAAAABDBwgkAAAAAInJq1ct3E96JsnTpUje/9NJL3TzUHjd16tRMY0LtXIpqGgs19KnGFtWyFGrVU+1AqiHPzKy4uDjTcYXOvVA7EU6cjRs3unno3KmurnZz9fduaGjIfFzqnA61/T3wwANufvnll7v57373OznX7NmzA0eHE+Hmm29281B7lGppq6ysdPPQ/VY1uL3wwgtyzEhSz5Xu7m43D10boVYxT6gdTN27n3nmGTf/13/9VzmXajRT701C16X624eaatU2dS8rKyuTc/3yl7+U25Bfofdo6hxQzY6he0bW66y1tVVua2xszHRcofuiumeMB3ziBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgAgWTgAAAAAQkVOr3kg254XmCjV6eEKtdrn4yEc+4uaqJa6urk7OpdqJ+vr63Fy1nJiZ9ff3u7lqbMraymKm2+7UPsxya7WbNGmSm6vf18yZM+Vcd999d+b948Rpb2+X21SzlLo/XHbZZXKudevWuXku94eXXnrJzdV5O3/+fDnXpk2bMu8fI0vdbz/2sY+d4CMBMJap92Fm+vmg3tepJkiz7O11nZ2dcltTU5Obq2fjSB5XIeETJwAAAACIYOEEAAAAABEsnAAAAAAggoUTAAAAAESwcAIAAACACBZOAAAAABCRUx15UVGR3KYqxFUNY6iOfCTrxevr6938E5/4hBwzY8YMN1dV2aEK8azV6qry3Ez//quqqtw89HtUx6zqocvLy+Vcw8PDbn7kyBE5Rm1Teahq8xvf+Iabf/7zn5djcOIcOHBAbjvttNPcfHBw0M1DdeRKLl+j0NbW5ubqeq6urpZzheprAQBjR6iOu7Gx0c3Ve0f19S9m+isUlK6uLrkt9N7dE6oj37dvX6a5CgmfOAEAAABABAsnAAAAAIhg4QQAAAAAESycAAAAACCChRMAAAAAROTUqqeaQWLbRsqsWbPc/KqrrpJj1q5d6+aTJ0+WYzo6Oty8tLTUzUPtcUmSuLlqqVP7CM2l9q+ayczMamtr3Vy1qbS2tsq5VGtZqBVm0qRJbq4a+kKvpbe3V25D/v3whz+U21772te6eXNzs5uH/tZTp05189C5q6jzUAm1ENXU1GTePwBg9Ak1/KpWPfUeKfTc2Lp1a6bjCr1Ham9vd3P1vj3UBn3w4MFMx1VI+MQJAAAAACJYOAEAAABABAsnAAAAAIhg4QQAAAAAESycAAAAACAip1a9adOmyW0XX3yxm1dUVLj5woUL5VxLlixxc9WEF2omUQ0ooWaUuro6N1dNeKH9q4a+oqIiN+/p6ZFzFRcXZ9r/RRddJOf6yU9+kmn/s2fPlnO1tbW5uTpeM90QqMaE/l7Hjx+X25B/999/v9ymWn0qKyvdXLUxmpm97nWvc/M777wzcHS+5557zs3VuRY6B0P3BwDA2NHV1SW3qfc1qlVP/byZ2ZYtWzIdV39/f6afDwkdV6gtudDxiRMAAAAARLBwAgAAAIAIFk4AAAAAEMHCCQAAAAAiWDgBAAAAQAQLJwAAAACICPbj1tfXu/n//J//U46pra11c1U3HKoVHhgYcPP29vZM+w7tJ7T/oaEhN1evJVS7HTo2z6FDh+S2qqoqN1+1apWb/+mf/qmc67vf/a6b33DDDW6+Zs0aOZeqI1dV9Ga6jl3Vdqq/CcY29RUDR48ezTzXokWL/tjD+U8vvPCCmzc2Nrp5qKJVXR8AgLElVEc+YcLIfSbR3Nyc6ee7u7vltqxfiaHen5mZHThwINNchYRPnAAAAAAggoUTAAAAAESwcAIAAACACBZOAAAAABDBwgkAAAAAIoIVGx/84AfdfPbs2XKMahopKytzc9WeFlJSUuLmR44ckWNyaedSDSTqtYQa+vr7+918eHjYzefOnSvnUu1cqpksF/Pnz3fzzs5OOUa9/tDvXm0rLS11c/X7wtj2ne98x83f8573uPng4KCca/r06SNxSEEdHR1uniSJHKOa+AAAY0tra6vcptrocmnb6+3tzfTzoWfjSLb97dq1a8TmGmv4xAkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEBOvIVYV2bW2tHKMqd48dO+bmoXrpoaEhNx8YGHDzUFW22k+onnHq1Klurmq31Ws0MysvL3fzhoYGN7/nnnvkXJ/5zGfktpGiasIPHz4sx6hq+e7ubjmmuLjYzVWt8/79++VcGB3UNXX8+HE55mc/+5mbv/vd73bz0FcPrF69OnB0I0N9JYH6qgCzka2CBQDkT+h9jaojV+9rmpub5Vw9PT2Zjiv0njr0dRlZ7d69e8TmGmt4kgMAAABABAsnAAAAAIhg4QQAAAAAESycAAAAACCChRMAAAAARARb9T772c+6+be+9S055i1veYubX3jhhW6+bNkyOdeMGTPcvKKiws0nTtQvRzWNdHV1yTGqGUU1u5188slyru3bt7v52rVr3XzLli1yrhNBNZOVlJTIMao5cObMmXLM3r17M+0n1JyIsevxxx938z179rj5lClT5FyqOWj69OlufvDgwcjR/aGNGze6eX19vRzT29ubeT8AgNEn1CpXWlrq5qqNVeVm2ZvwQj+v3tNOnjw50z7Mwg2yhY5PnAAAAAAggoUTAAAAAESwcAIAAACACBZOAAAAABDBwgkAAAAAIoKtekpra6vc9tWvfjVTHqKaRhYvXuzm8+bNk3MtXbrUzUPtXMeOHXNz1ZD35JNPyrmeffZZuW00+uY3v+nm06ZNk2PUeTFp0iQ5ZmhoyM0bGhrc/De/+Y2cC6PD8ePHR2yul156yc3nz58vx/T19bn5FVdc4eahllBlxYoVbq7aO83M5syZk3k/AIDR5+c//7nc9uKLL7r54OCgm4ea8J5++ulMx7Vt2za57fe//72bt7S0uPmCBQvkXDt27Mh0XIWET5wAAAAAIIKFEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABARJKmqd6YJHojMEakaaq7PkcJrjWfqqW/9dZb5Zg9e/a4+W233ebmXV1dmY/rrLPOcvOFCxfKMd/73vfc/OjRo5n3P1qN9muN6wyFgOtsdHvnO9/p5kuWLHFz9cwyM/uXf/mXTPsuLS2V2/7kT/7EzYuLi9089NVD69aty3RcY5G6zvjECQAAAAAiWDgBAAAAQAQLJwAAAACIYOEEAAAAABEsnAAAAAAgItiqBwAAAADgEycAAAAAiGLhBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIhg4QQAAAAAESycAAAAACCChRMAAAAARLBwAgAAAIAIFk4AAAAAEMHCCQAAAAAiWDgBAAAAQAQLJwAAAACIYOEEAAAAABEsnAAAAAAggoUTAAAAAESwcMqDJEk+nCTJU0mSDCVJ8q/5Ph6gUHGtAa++JEkmJ0nyjSRJdidJ0pMkybNJkrwu38cFFKokSRYlSTKYJMld+T6W8WZivg9gnDpgZreY2eVmVprnYwEKGdca8OqbaGZ7zexCM9tjZq83s3uSJFmZpumufB4YUKC+YmZP5vsgxiMWTnmQpumPzMySJFltZk15PhygYHGtAa++NE37zOzG/0+0LkmSnWZ2upntyscxAYUqSZK3m1mnmT1qZgvzezTjD/9TPQAAMGKSJGk0s8VmtjHfxwIUkiRJqszsJjP7aL6PZbxi4QQAAEZEkiTFZna3mX07TdPN+T4eoMDcbGbfSNN0X74PZLzif6oHAAD+aEmSTDCzO81s2Mw+nOfDAQpKkiSnmNklZnZqng9lXGPhBAAA/ihJkiRm9g0zazSz16dpeiTPhwQUmjVmNtfM9rx8uVmFmRUlSbI8TdPT8nhc4woLpzxIkmSivfy7L7KXT/oSMzuapunR/B4ZUFi41oAT5qtmtszMLknTdCDfBwMUoDvM7N/+P///39rLC6m/ysvRjFP8N0758SkzGzCz/8fM3vXK//2pvB4RUJi41oBXWZIkc8zsL83sFDNrTpKk95V/3pnfIwMKR5qm/WmaNv/HP2bWa2aDaZoezvexjSdJmqb5PgYAAAAAGNX4xAkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAICL4PU5JkozKyr1XvvjrD+TSELhixQq57UMf+pCbz5o1y82//vWvy7l+9atfufnQ0JCb19bWyrlmz57t5up46+vr5Vxf/vKX3fyBBx6QY7KaMEGvz48fPz5i+1HSNPVPmFFktF5r+XbxxRe7+Zo1a+SYZ555xs0vuOCCTD9vZnbeeee5+Wc/+1k337Fjh5xrPBjt19p4v86uuuoqN//85z/v5k888YScq6yszM0PHDjg5p2dnXKupUuXunlvb6+bz58/X871tre9zc2bm5vlmLGG6wx49anrjE+cAAAAACCChRMAAAAARLBwAgAAAIAIFk4AAAAAEBEshxitampq3PxP//RP5Zi3v/3tbt7Y2CjHtLW1ufnAwICb/8u//Iucq66uLtM+Ghoa5Fxq/+o/yt25c6ec64477nDzwcFBN7/77rvlXLfddpubd3d3yzFAiCpPWbZsmRyzcOFCN1f3gK997Wtyrurqajfv6uqSY4DR6vWvf72bq+eNKkcx0wVGqqSpvb1dzqWew6pQoqmpSc512WWXufl3vvMdOQYA/qv4xAkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEjOo68muvvdbN3/3ud7t5cXGxnEvVa2/ZskWOOXbsmJv39PS4+f79++VcS5YscfOjR4+6+d69e+VcBw8edHNVbV5aWirnevTRR91c1cNeddVVcq5LL73UzTdt2iTHvP/975fbgG3btrl5qOJenW+qjnjNmjVyLlVH3traKscAo9WcOXPcXF1PoetseHg4076PHDkit7300ktu3t/f7+bq6z3MzKZPn57puAAgCz5xAgAAAIAIFk4AAAAAEMHCCQAAAAAiWDgBAAAAQAQLJwAAAACIGNWtek8++aSbv/Wtb3XzQ4cOyblKSkrcfNKkSXJMV1eXmx8/ftzNQ61+SllZmZtPnjxZjikqKso0l2oHDM2l2pT6+vrkXOp3OTQ0JMcAIb29vW7e3t4uxzQ3N7v54sWL3VxdA2a6OWzCBP/fOal7AzAaLFu2LNPPq+emWfZrQP18iLo2Q8+hFStWZN4PAPxX8YkTAAAAAESwcAIAAACACBZOAAAAABDBwgkAAAAAIlg4AQAAAEDEqG7V27Bhg5urpp9Qo5VqdlOtWWZmAwMDbq7agULtdW1tbW6+fPlyN1fNYKHjUvsPtRmpMarNaHBwUM61cOFCN3/3u98txwAhpaWlbt7S0pJ5LnWth+ZSTZHV1dVu3tHRkfm4gBOloqLCzUMtdUqSJG4+cWL2txVZm2r7+/vlXA0NDZn3DxSK008/XW57+umnR2w/6vpXeZqmmfeRy5gTgU+cAAAAACCChRMAAAAARLBwAgAAAIAIFk4AAAAAEMHCCQAAAAAiWDgBAAAAQMSoriNX7r33Xjd/61vfKsfs2bPHzUMV4qrGW1WnhqoTVU2xGhOqSVfV6qHXklVnZ6ebV1ZWyjGHDh1y81yqowEzXYt/+PBhOUZdO3v37nXz8vJyOZeqI1e1ztSRYzRT53pPT4+bq2rh0Db13Ax9LYa6ztUzLfTVI6FjBkaj0LWhzvW3ve1tbv6+971PzrVz5043V++p161bJ+dS711Hso58JIV+x5nnGrGZAAAAAKBAsXACAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABAxJhs1fvqV7/q5ldeeaUco5pJVJuQmW7hyKW1Z3Bw0M1V41yoVe/IkSNurhrAVG6m24zU7yXUQPaDH/xAbgNyoc5P1SxpZtba2urm6joINeGp/YeuKWC0Us9BlYeaqCZO9N8+VFVVZT4u1ZI5efLkTLmZftYCo1WoJVK56KKL3PzUU0+VY9Sz8fLLL3fzbdu2ybm2bNni5rm8lqwN1rkYybn4xAkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAIGJMtur19/e7eXd3txyjmn66urrkGNWopVr1Qg1ER48edfO2tjY3Lysrk3Op16+EGvrUflRjkmr0MzP7/ve/n+m4gJhjx465uTo/zXTjXU1NjZsfOnRIzjUwMJApB0Yz1Sylnmlpmsq5qqur3Xz79u1uHnoOrVy50s3379/v5qFWvdAzChhrFixY4OYvvfSSm997771yLvV+T13Ln/jEJ+RcO3fudPNvfvObbr537145Vy6tnn/+53/u5qr5+fbbb5dzLVy4UG5zjyvTTwMAAADAOMTCCQAAAAAiWDgBAAAAQAQLJwAAAACIYOEEAAAAABEsnAAAAAAgYlTXkasqQlVdeP/998u53vve97p5S0uLHKPqyFVFsvp5M12R3NnZ6eaDg4NyLlXFrI4rRFW4V1ZWZtq3mVlzc3Pm/QMh6ppS15OZrgpX1cb19fWZ5wpd68BoFaoX94S++kLV+//85z93802bNsm5vvvd77q5eg6WlpbKuagjR75lrfdXdeBmZu9///vdfNeuXW5+zz33yLmuueYaN7/44osz7cNM136rOvLHHntMzvWzn/3MzRctWiTHXHHFFW6uKtdD70/37dsnt3n4xAkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAIGJUt+plbQC6/fbb5TbVAHTBBRfIMW1tbW6eS6OWagFTrUG1tbVyrpKSkkz7Vs1gZmazZs1y8+eff97NP/axj2XaN/DHaG9vd/Ph4WE5RjVuqdbJUEPX4cOH3by3t1eOAUYr1TinnrWh9krloYcecvNQq15WxcXFcltfX9+I7QfIhWqEVs+gULNrR0dHpn2/9rWvlduee+45N9+8ebObX3TRRXKuGTNmuLl6Nr75zW+Wc6mGvFDrdVbbt2+X25599tlMc/GJEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIgYk3XkSZJk+nkzs7//+793c1WDaKZrFYeGhuQYRR2zqlXt7++Xc6lKS1WTHvq9VFdXu3kuNZC5/F2AEHWud3d3yzHqqwdUtbnah5nZli1b3DyXryQA8i1U4+85fvx45n2sX7/ezVUVekh5ebmbh66/0LMTOBFCzxRP6D3SlVde6eaq9l99hYaZ2erVq91cXTOPPfaYnKuxsdHNQ9XqyuTJk91c1bqb6a/ZqaysdPPQV/xkxSdOAAAAABDBwgkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARo7pVbySVlJS4uWrzMDM7evSom6tGH9UqZxZuB8k6V1YTJ+o/86FDh9x86tSpI7Z/IFeqoSd0PfX09Li5ajoKtRCpVjHVRtna2irnAvJNNdupZ51qfc1lH7nI5VmbtTkQJ07o75b1PU+oiS5rk28u792yNueFXHvttXKbetZMmTLFzc855xw519133+3mDQ0Nbv6Od7xDzvX888+7eVdXl5sPDg7KuVQTrnqNZrrdWt2z1BogF3ziBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgAgWTgAAAAAQMSZb9VQDSqhJRTV6DAwMjNh+Qk1fai7VGqTy0Fy5/LxqhpkxY0amfZjp30to/1nbbzC+qOugr69Pjpk0aZKbL1u2zM2feeYZOZdq6GlsbHTzHTt2yLmAfMvaBBZqnd25c+cfezj/qbm52c3VtRx6pnR2do7EIeFVkEsTXi4Nw+q9mDqfQo1vI9med/3117v53Llz5Zif/vSnbr5+/Xo3v/XWW+Vcb3nLW9y8rq7OzXt7e+VctbW1bq7uGd3d3XIu1YQbupbV81w9s5999lk5V1Z84gQAAAAAESycAAAAACCChRMAAAAARLBwAgAAAIAIFk4AAAAAEMHCCQAAAAAiRnUduaqhVFWTx48fz7yPo0ePym1qP8PDw24eqhBXjhw54uaqUjF0XEpoLqWsrCzzGOBE6e/vl9va29vdXF0HoSpaNWYkK2qBEyXrsyNUR/7oo4/+sYfznw4ePOjm06dPd/PQ9Tc0NDQix4SRF3qPpM5N9R4pRFWbh+71WYWujauvvtrNzz77bDefNm2anKupqcnNS0pK3Pxzn/ucnOsjH/mIm6vrae/evXIu9ZUc6v1xfX29nEs9s2tqauQYVS+uvl7kPe95j5wrVOHu4RMnAAAAAIhg4QQAAAAAESycAAAAACCChRMAAAAARLBwAgAAAICIUd2qp5pRcmnPUyZNmjRic4WOK2vjXi6tXWofquXETB9zeXl55v0rqh3RTP+NATOzqqoqN584Ud+6BgYG3Lyvr8/NQ9eaapfs6uqSY4DRSl03qtEs1Bz229/+dkSOycxsx44dbj5r1iw3b2trG7F948QJ3WuzvucJNf+qJr6ZM2e6+ZVXXinnWrt2rZuHGpkVdd5u375djtm0aZObv/DCC26ujtfM7L777nNzdZ2vWrVKzvWDH/zAzfft2+fmqoXPTLcKqme5mdkjjzzi5rfddpubhxoVadUDAAAAgBHGwgkAAAAAIlg4AQAAAEAECycAAAAAiGDhBAAAAAARo7pVT8mliU21CYUa39S2rA15ZvqYVZtRf3+/nCtrM1Iux1tSUuLmuTTk0ZyHkVZRUSG3dXZ2urlq0AxdH+qaAsai0tJSN1eNU6F79+bNm0fkmMzMDh8+7ObqWRdqYAs9o5BfoSa8888/383PO+88Nw81/z7++OOZ9t/a2irn+tKXvuTmoZY4pbe3N1NuZnb66ae7+SWXXOLm3d3dcq4FCxa4uWq1C7VXTp8+PVPe0tIi51INgUNDQ3LM3/7t37q5agjcuXOnnCsr3hUAAAAAQAQLJwAAAACIYOEEAAAAABEsnAAAAAAggoUTAAAAAESwcAIAAACAiDFZR67qRkPVqTU1NW5eWVkpxxw4cMDNc6n3zur48eNyW9aKZFXDbKZ/Z6q2VlU9mulKWyBXR44ccfPQNagqZ1VNeXFxcea5gLEo61dZHD16VM61a9eukTgkMzNrbm7O9POhZ/2JeD4jTL2veu973yvHnHrqqW6u3u91dXXJuZYvX+7m6v1L6D1Ve3u7m6sKfTOznp4eN1dV3ddcc42cq7a21s1VHXro/Z56/ep6mj9/vpxL1aGrudSz3Exf/+p+Zabr6Pft2+fmTU1Ncq4lS5bIbR4+cQIAAACACBZOAAAAABDBwgkAAAAAIlg4AQAAAEAECycAAAAAiBiTrXqqASXURNfQ0ODmoTYf1SgUavpQ1DGrBqBQy0vWBqTQ8aoGlNbWVjefO3eunGvz5s2Z9gG8Gurr6928ra3NzRcuXCjnUu1Q/f392Q8MyLOsz6GhoSE517Zt20bkmMzM9u7dm+nnQ88U1QiLE2fFihVufvLJJ8sx6j3HjBkz3Lyurk7OpdrrVKtcqImuoqLCzdVzJkQ1wYWoNjr1PBsYGJBzqetZNcuG3oceOnTIzdX78NDveMqUKZnmMtOtimo/ofeuocY9D584AQAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEjOpWvSRJRmyu2bNnu7lqEzLTbXSqaSSX41X7H8nXHnqNqolPtc8sXrxYzqVa9ULNLKHWFEC1/YQaelRzkToPQ+1I6tqhVQ9jUdbnyuDgoNx27NixP/Zw/pNqt82lkTWX5jKMLNW41tfXJ8eolrja2lo3DzWhlZWVublqnAu1R6q2P/UazfT7KnXNdHZ2yrmmTp3q5ieddFLmuVTjpHr9jz32mJxLvUZ1jwm9D1XHpV67mVlJSYmbq/cMu3btknOF7nMePnECAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIhg4QQAAAAAEaO6jnwkTZs2zc1D9ayqblHVIOYil7pVNUbVp4f2oWoo1ZilS5fKue69997M+wdCZs6c6ea5VA6rCvNQrXJdXZ2bt7e3Z94/kG87d+508+rqajdX9c0jTV1PuTw7Ql9VgBPjwIEDbn7qqafKMYsWLXLzw4cPu/m2bdvkXHv37nVz9d4tVJWtKtRz+SqVyspKNw/Vbu/fv9/NVU176Ctj1O9SVXirr6Ux069FVYur99Nm+n1oS0uLHKNq148cOeLm6iuJzMweeeQRuc3DJ04AAAAAEMHCCQAAAAAiWDgBAAAAQAQLJwAAAACIYOEEAAAAABGjulVPNeqE2jkU1VqSS2vPhAn+ejPUsqLGqP2H2v6y7iM0l2ogGh4edvNQq55Cqx5GmmrJNNMNPSrv7u6Wc82dO9fNZ8yYoQ8OGKVU86p6RqhrZqS1tbWN2FzqOYgTZ3Bw0M0vu+wyOebv/u7v3PyMM85w86amJjnXySef7ObqPVpPT4+cK5f3Yqr1VV1PBw8elHOp97uPPvqom4eeZ6pZTrVahq4ldc2q35dq7jPTTXhlZWVyjGoPVO8Nzj33XDnXjTfeKLd5uMMAAAAAQAQLJwAAAACIYOEEAAAAABEsnAAAAAAggoUTAAAAAESM6la9kTR9+nQ3DzWmqAaioqKizHMpakwuzUAj2cSn1NfXZ94HkKv+/n43nzVrVua5VNOTahQyM2ttbXXzioqKzPsH8i3rs0tdMyMt635Cz7pQexfyK/R3/uQnP5lproULF8pt73//+91cNfTNnDlTzlVTU+PmoRZl1VasGvIWLFgg51LPwGXLlrn5XXfdJef6zne+4+aqJfbmm2+Wcx04cMDNVSOzuveY6fehofenar6WlhY3//SnPy3n2rVrl9zmHlemnwYAAACAcYiFEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABAxKiuI1eVo2maZp5r6tSpbq7qIUNUDWWoOjFUXflq7z9UA6l+l2ofdXV1ci61/5F87RhfysrK3FxVnpqZlZaWuvlJJ53k5ocPH858XCeqphkYSeorNlSFd6imeSQdOXLEzdWzgzrywpP1/d727dvlXB/72Mcy7Vs9Z8zMLrzwQjefNm2aHKMqzNV5HjpnN2zY4OabN2928/3798u5svrFL34htzU1Nbn5WWed5eaqJtzMrLy8PPOYQ4cOufnGjRvdvKurS86VFZ84AQAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEjOpWvZEUaoNTQm10nlDTj6Ka6EJzZR0Tmku9xmPHjrl5W1ubnKu+vt7NQ80oQMiUKVPcvLq6Wo7p7e11c9W2t2TJEjnXnj173DyX+wmQb+pZoFq9hoaGXs3D+U+qPU81qoWeabm07iL/cvlbZ51L6e/vl9tCzXJjTdb3e7t27ZJzqW3r16/PelhjDp84AQAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgIhxU0euKopDtcZZ68hzofaRS91qLrWdWceoSmczs1mzZrk5deTIlaopVvWpZmYDAwOZxhw+fFjO9fzzz7t5qMIcGGsmTvTfCgwODp6Q/avrXOXqKzlQeKiXHzmh5yb+67j7AAAAAEAECycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEjOpWPdX4plpWysrK5FyqPS+XlpFcWl5UC9CRI0fcvKSkRM6lmoaOHj2a6efNsjcHqvYlM7OamppMcwExqsUxdN329fW5eUVFhZtPmjRJztXU1OTmJ6JxExhpWZ93O3bseJWO5P/X8PCwm6vjLS4uzjwXAIwEPnECAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIgY1a16Wdvr+vv75TbVuKea+8x0S5xqr+vt7c18bKrxLtTapRr31FyTJ0+Wc1VWVrp5Z2enmy9btkzOtWnTJrkNyMWTTz7p5u9+97szzzV16lQ3V217ZmazZs1y846Ojsz7B/JNPQerqqrcfNWqVZn3oZ5doUY/1daqjjfUoFteXh44OgD44/CJEwAAAABEsHACAAAAgAgWTgAAAAAQwcIJAAAAACJYOAEAAABABAsnAAAAAIgoqDrykDVr1mTKzcxmz57t5qrudOHChXIuVWusKloHBwflXGpbd3e3m4eqzQ8fPuzm27Ztc/Nf/vKXmecKVb6P5N8YhWfjxo1u/sEPflCOufzyy918xowZbv6pT31KznXLLbe4+QsvvCDHAKPVY4895uaqkv9rX/ta5n2EascVVe9/3333uXmoJv2JJ57IvH8A+K/iEycAAAAAiGDhBAAAAAARLJwAAAAAIIKFEwAAAABEsHACAAAAgIiEVjMAAAAACOMTJwAAAACIYOEEAAAAABEsnAAAAAAggoUTAAAAAESwcAIAAACACBZOAAAAABDx/wJIhipA/6YMkAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 1080x1080 with 16 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, axes = plt.subplots(4, 4, figsize = (15,15))\n",
+    "for row in axes:\n",
+    "    for axe in row:\n",
+    "        index = np.random.randint(60000)\n",
+    "        img = f1.drop('target', axis=1).values[index].reshape(28,28)\n",
+    "        cloths = f1['target'][index]\n",
+    "        axe.imshow(img, cmap='gray')\n",
+    "        axe.set_title(clothing2[cloths])\n",
+    "        axe.set_axis_off()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "manufactured-frank",
+   "metadata": {
+    "papermill": {
+     "duration": 0.032035,
+     "end_time": "2021-04-26T05:19:48.234310",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:48.202275",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5.3 Data Preprocessing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "quarterly-senate",
+   "metadata": {
+    "papermill": {
+     "duration": 0.032694,
+     "end_time": "2021-04-26T05:19:48.299380",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:48.266686",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.3.1 Setting Random Seeds for Reproducibilty :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "promising-institution",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:48.369750Z",
+     "iopub.status.busy": "2021-04-26T05:19:48.368568Z",
+     "iopub.status.idle": "2021-04-26T05:19:48.371466Z",
+     "shell.execute_reply": "2021-04-26T05:19:48.371061Z"
+    },
+    "papermill": {
+     "duration": 0.039222,
+     "end_time": "2021-04-26T05:19:48.371571",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:48.332349",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "seed = 66\n",
+    "np.random.seed(seed)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cordless-flower",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0323,
+     "end_time": "2021-04-26T05:19:48.436502",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:48.404202",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.3.2 Splitting Data into Train and Validation Set :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "medium-distribution",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:48.510185Z",
+     "iopub.status.busy": "2021-04-26T05:19:48.509416Z",
+     "iopub.status.idle": "2021-04-26T05:19:48.877930Z",
+     "shell.execute_reply": "2021-04-26T05:19:48.877447Z"
+    },
+    "papermill": {
+     "duration": 0.409164,
+     "end_time": "2021-04-26T05:19:48.878059",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:48.468895",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "X = f1.iloc[:, :-1]\n",
+    "Y = f1.iloc[:,784]\n",
+    "x_train1, x_valtest, y_train, y_valtest = train_test_split(X, Y, test_size=0.2, random_state=seed)\n",
+    "x_val1,x_test1,y_val,y_test = train_test_split(x_valtest, y_valtest, test_size=0.5, random_state=seed)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "federal-bunny",
+   "metadata": {
+    "papermill": {
+     "duration": 0.03241,
+     "end_time": "2021-04-26T05:19:48.943523",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:48.911113",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.3.3 Reshaping Image :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "complicated-paste",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:49.015342Z",
+     "iopub.status.busy": "2021-04-26T05:19:49.014572Z",
+     "iopub.status.idle": "2021-04-26T05:19:49.017374Z",
+     "shell.execute_reply": "2021-04-26T05:19:49.016963Z"
+    },
+    "papermill": {
+     "duration": 0.040473,
+     "end_time": "2021-04-26T05:19:49.017484",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:48.977011",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "x_train = x_train1.values.reshape((-1, 28, 28, 1))\n",
+    "x_val = x_val1.values.reshape((-1, 28, 28, 1))\n",
+    "x_test = x_test1.values.reshape((-1, 28, 28, 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "looking-foundation",
+   "metadata": {
+    "papermill": {
+     "duration": 0.032641,
+     "end_time": "2021-04-26T05:19:49.082798",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:49.050157",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.3.4 One Hot Encoding :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "superb-local",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:49.153870Z",
+     "iopub.status.busy": "2021-04-26T05:19:49.152720Z",
+     "iopub.status.idle": "2021-04-26T05:19:49.161279Z",
+     "shell.execute_reply": "2021-04-26T05:19:49.161995Z"
+    },
+    "papermill": {
+     "duration": 0.046633,
+     "end_time": "2021-04-26T05:19:49.162194",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:49.115561",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "y_train = to_categorical(y_train, num_classes=5)\n",
+    "y_val = to_categorical(y_val, num_classes=5)\n",
+    "y_test = to_categorical(y_test, num_classes=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fitting-theology",
+   "metadata": {
+    "papermill": {
+     "duration": 0.05469,
+     "end_time": "2021-04-26T05:19:49.273568",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:49.218878",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5.4 Convolutional Neural Network :\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "flush-playing",
+   "metadata": {
+    "papermill": {
+     "duration": 0.051586,
+     "end_time": "2021-04-26T05:19:49.376155",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:49.324569",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.4.1 The design of Convolution neural networks definition :\n",
+    "\n",
+    "1) Firstly we used **Sequential Keras API** which is just a linear stack of layers.\n",
+    "\n",
+    "2) Then we include **Convolutional Layers**, this operation performs below operations :\n",
+    "\n",
+    "    1. Apply filters to extract features.\n",
+    "\n",
+    "    2. Apply activation function( in our case 'relu' ) on every every input value of feature maps.\n",
+    "\n",
+    "    3. Filters are composed of small kernels learned.\n",
+    "\n",
+    "3) Next we apply **Batch Normalization** to achieve zero mean and zero variance on image pixels after each convolution.\n",
+    "\n",
+    "4) Then we add **Max Pooling Layers**, which are used for Dimensionality Reduction or DownSampling the Input. These are used where we have lot of Input Features. It reduces the amount of Parameters and Computational power required drastically, thus reducing Overfitting. These along with Convolutional layers are able to learn more Complex features of the Image.\n",
+    "\n",
+    "5) We add **Dropout Layers** to avoid Overfitting. DropOut is a Regularization Technique, which Penalizes the Parameters. We DropOutRate to 0.25. Usually in general we can set this rate between 0.2-0.5.\n",
+    "\n",
+    "6) Then we include **Flatten layer** to map the input to a 1D vector. We then add Fully connected Layers after some convolutional/pooling layers.\n",
+    "\n",
+    "7) Lastly, we add the **Dense (Output) Layer**. It has units equal to the number of classes to be identified.Here, we use 'softmax' function since it is Multi-Class Classification. For binary classification we can use 'sigmoid' function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "fleet-peter",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:49.488546Z",
+     "iopub.status.busy": "2021-04-26T05:19:49.487736Z",
+     "iopub.status.idle": "2021-04-26T05:19:52.525384Z",
+     "shell.execute_reply": "2021-04-26T05:19:52.524450Z"
+    },
+    "papermill": {
+     "duration": 3.096586,
+     "end_time": "2021-04-26T05:19:52.525520",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:49.428934",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model = Sequential()\n",
+    "model.add(Conv2D(filters=32, kernel_size=(3, 3), activation='relu', strides=1, padding='same', \n",
+    "                 data_format='channels_last', input_shape=(28,28,1)))\n",
+    "model.add(BatchNormalization())\n",
+    "\n",
+    "model.add(Conv2D(filters=32, kernel_size=(3, 3), activation='relu', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model.add(BatchNormalization())\n",
+    "model.add(Dropout(0.25))\n",
+    "\n",
+    "model.add(Conv2D(filters=64, kernel_size=(3, 3), activation='relu', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model.add(MaxPooling2D(pool_size=(2, 2)))\n",
+    "model.add(Dropout(0.25))\n",
+    "    \n",
+    "    \n",
+    "model.add(Conv2D(filters=128, kernel_size=(3, 3), activation='relu', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model.add(BatchNormalization())\n",
+    "model.add(Dropout(0.25))\n",
+    "\n",
+    "model.add(Flatten())\n",
+    "model.add(Dense(512, activation='relu'))\n",
+    "model.add(BatchNormalization())\n",
+    "model.add(Dropout(0.5))\n",
+    "model.add(Dense(128, activation='relu'))\n",
+    "model.add(BatchNormalization())\n",
+    "model.add(Dropout(0.5))\n",
+    "model.add(Dense(5, activation='softmax'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "chief-senate",
+   "metadata": {
+    "papermill": {
+     "duration": 0.032832,
+     "end_time": "2021-04-26T05:19:52.591635",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:52.558803",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.4.2 Optimizer of the model :\n",
+    "\n",
+    "- Before model compilation we need to set optimizer used by the model. We have multiple options for optimizer e.g ADAM, SGD, ADAGRAD, ADADELTA, RMSPROP.\n",
+    "\n",
+    "**Parameters for Adam optimizer:**\n",
+    "\n",
+    "- learning rate : the learning rate is a configurable hyperparameter used in the training of neural networks. The learning rate controls how quickly the model is adapted to the problem.\n",
+    "\n",
+    "- beta1 : The exponential decay rate for the first moment estimates (e.g. 0.9).\n",
+    "\n",
+    "- beta2 : The exponential decay rate for the second-moment estimates (e.g. 0.999).\n",
+    "\n",
+    "![](http://www.linkpicture.com/q/1_osB82GKHBOT8k1idLqiqA-99.png)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "single-longitude",
+   "metadata": {
+    "papermill": {
+     "duration": 0.033106,
+     "end_time": "2021-04-26T05:19:52.658005",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:52.624899",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Learning rate adjustment :**\n",
+    "\n",
+    "- The learning rate controls how quickly the model is adapted to the problem.\n",
+    "- Smaller learning rates require more training epochs given the smaller changes made to the weights each update.\n",
+    "- Larger learning rates result in rapid changes and require fewer training epochs.\n",
+    "\n",
+    "**Problem with too large or small learning rate value :**\n",
+    "\n",
+    "- A learning rate that is too large can cause the model to converge too quickly to a suboptimal solution.\n",
+    "- A learning rate that is too small can cause the process to get stuck.\n",
+    "\n",
+    "**Note :**\n",
+    "\n",
+    "The learning rate is perhaps the most important hyperparameter for each optimizer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "average-match",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:52.733893Z",
+     "iopub.status.busy": "2021-04-26T05:19:52.732087Z",
+     "iopub.status.idle": "2021-04-26T05:19:52.734446Z",
+     "shell.execute_reply": "2021-04-26T05:19:52.734873Z"
+    },
+    "papermill": {
+     "duration": 0.043388,
+     "end_time": "2021-04-26T05:19:52.735005",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:52.691617",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "optimizer = tf.keras.optimizers.Adam(learning_rate=0.01, beta_1=0.9, beta_2=0.999)\n",
+    "\n",
+    "# SGD \n",
+    "optimizer_sgd = tf.keras.optimizers.SGD(learning_rate=0.01)\n",
+    "\n",
+    "# RMSProp\n",
+    "from keras.optimizers import RMSprop\n",
+    "optimizer_rmsprop = tf.keras.optimizers.RMSprop(learning_rate=0.01)\n",
+    "\n",
+    "# Adagrad\n",
+    "from keras.optimizers import Adagrad\n",
+    "optimizer_adagrad = tf.keras.optimizers.Adagrad(learning_rate=0.01)\n",
+    "\n",
+    "# Adadelta\n",
+    "from keras.optimizers import Adagrad\n",
+    "optimizer_adadelta = tf.keras.optimizers.Adadelta(learning_rate=0.01)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "intimate-massachusetts",
+   "metadata": {
+    "papermill": {
+     "duration": 0.032943,
+     "end_time": "2021-04-26T05:19:52.801169",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:52.768226",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.4.3 Model compilation :\n",
+    "\n",
+    "- During model compile we need to specify the loss function for the neural network which we want to minimize. For Multi-class Classification we use \"categorical_crossentropy\" and for Binary Classification we use \"binary_crossentropy\".\n",
+    "\n",
+    "- We need to specify the metric to evaluate our models performance. Here we used accuracy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "beautiful-welding",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:52.873176Z",
+     "iopub.status.busy": "2021-04-26T05:19:52.872434Z",
+     "iopub.status.idle": "2021-04-26T05:19:52.884396Z",
+     "shell.execute_reply": "2021-04-26T05:19:52.883954Z"
+    },
+    "papermill": {
+     "duration": 0.050398,
+     "end_time": "2021-04-26T05:19:52.884504",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:52.834106",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model.compile(optimizer=optimizer, loss=\"categorical_crossentropy\", metrics=[\"accuracy\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "limiting-switzerland",
+   "metadata": {
+    "papermill": {
+     "duration": 0.032739,
+     "end_time": "2021-04-26T05:19:52.950252",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:52.917513",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.4.4 Model Summary :\n",
+    "\n",
+    "Summary shows below things of our model :\n",
+    "\n",
+    "* The layers and their order in the model.\n",
+    "* The output shape of each layer.\n",
+    "* The number of parameters (weights) in each layer.\n",
+    "* The total number of parameters (weights) in the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "parallel-scholarship",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:53.025482Z",
+     "iopub.status.busy": "2021-04-26T05:19:53.024624Z",
+     "iopub.status.idle": "2021-04-26T05:19:53.036798Z",
+     "shell.execute_reply": "2021-04-26T05:19:53.036400Z"
+    },
+    "papermill": {
+     "duration": 0.053239,
+     "end_time": "2021-04-26T05:19:53.036935",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:52.983696",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: \"sequential\"\n",
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "conv2d (Conv2D)              (None, 28, 28, 32)        320       \n",
+      "_________________________________________________________________\n",
+      "batch_normalization (BatchNo (None, 28, 28, 32)        128       \n",
+      "_________________________________________________________________\n",
+      "conv2d_1 (Conv2D)            (None, 28, 28, 32)        9248      \n",
+      "_________________________________________________________________\n",
+      "batch_normalization_1 (Batch (None, 28, 28, 32)        128       \n",
+      "_________________________________________________________________\n",
+      "dropout (Dropout)            (None, 28, 28, 32)        0         \n",
+      "_________________________________________________________________\n",
+      "conv2d_2 (Conv2D)            (None, 28, 28, 64)        18496     \n",
+      "_________________________________________________________________\n",
+      "max_pooling2d (MaxPooling2D) (None, 14, 14, 64)        0         \n",
+      "_________________________________________________________________\n",
+      "dropout_1 (Dropout)          (None, 14, 14, 64)        0         \n",
+      "_________________________________________________________________\n",
+      "conv2d_3 (Conv2D)            (None, 14, 14, 128)       73856     \n",
+      "_________________________________________________________________\n",
+      "batch_normalization_2 (Batch (None, 14, 14, 128)       512       \n",
+      "_________________________________________________________________\n",
+      "dropout_2 (Dropout)          (None, 14, 14, 128)       0         \n",
+      "_________________________________________________________________\n",
+      "flatten (Flatten)            (None, 25088)             0         \n",
+      "_________________________________________________________________\n",
+      "dense (Dense)                (None, 512)               12845568  \n",
+      "_________________________________________________________________\n",
+      "batch_normalization_3 (Batch (None, 512)               2048      \n",
+      "_________________________________________________________________\n",
+      "dropout_3 (Dropout)          (None, 512)               0         \n",
+      "_________________________________________________________________\n",
+      "dense_1 (Dense)              (None, 128)               65664     \n",
+      "_________________________________________________________________\n",
+      "batch_normalization_4 (Batch (None, 128)               512       \n",
+      "_________________________________________________________________\n",
+      "dropout_4 (Dropout)          (None, 128)               0         \n",
+      "_________________________________________________________________\n",
+      "dense_2 (Dense)              (None, 5)                 645       \n",
+      "=================================================================\n",
+      "Total params: 13,017,125\n",
+      "Trainable params: 13,015,461\n",
+      "Non-trainable params: 1,664\n",
+      "_________________________________________________________________\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "flexible-generator",
+   "metadata": {
+    "papermill": {
+     "duration": 0.033437,
+     "end_time": "2021-04-26T05:19:53.104297",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:53.070860",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.4.5 Learning Rate Decay :\n",
+    "\n",
+    "- We should tuned our learning so that it is not too high to take very large steps, neither it should be too small which not change weights and bias of the model.\n",
+    "- We use LearningRateScheduler here, which takes the step decay function as argument and return the updated learning rates for use in optimzer at every epoch stage.\n",
+    "- So at every epoch learning rate will be change by LearningRateScheduler.\n",
+    "- LearningRateScheduler callback that allows you to specify a function that is called each epoch in order to adjust the learning rate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "massive-speech",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:53.177826Z",
+     "iopub.status.busy": "2021-04-26T05:19:53.176360Z",
+     "iopub.status.idle": "2021-04-26T05:19:53.178829Z",
+     "shell.execute_reply": "2021-04-26T05:19:53.179236Z"
+    },
+    "papermill": {
+     "duration": 0.041488,
+     "end_time": "2021-04-26T05:19:53.179366",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:53.137878",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "reduce_lr = LearningRateScheduler(lambda x: 1e-3 * 0.9 ** x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "verified-abuse",
+   "metadata": {
+    "papermill": {
+     "duration": 0.033321,
+     "end_time": "2021-04-26T05:19:53.246618",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:53.213297",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "- As an alternate solution of LearningRateScheduler we can also use **ReduceLROnPlateau**.\n",
+    "- The ReduceLROnPlateau that will adjust the learning rate when a plateau in model performance is detected.\n",
+    "- This callback is designed to reduce the learning rate after the model stops improving with the hope of fine-tuning model weights.\n",
+    "- ReduceLROnPlateau works like EarlyStopping, with three parameters: monitor, patience and mode"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "unlikely-intervention",
+   "metadata": {
+    "papermill": {
+     "duration": 0.033509,
+     "end_time": "2021-04-26T05:19:53.313492",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:53.279983",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Parameters of ReduceLROnPlateau :**\n",
+    "\n",
+    "1) min_lr : The lowest value for the learning rate in model.\n",
+    "\n",
+    "2) patience : number of epochs with no improvement after which learning rate will be reduced.\n",
+    "\n",
+    "3) monitor: quantity to be monitored. (i.e val_loss, val_accuracy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "structured-sixth",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:53.385482Z",
+     "iopub.status.busy": "2021-04-26T05:19:53.384956Z",
+     "iopub.status.idle": "2021-04-26T05:19:53.388649Z",
+     "shell.execute_reply": "2021-04-26T05:19:53.388143Z"
+    },
+    "papermill": {
+     "duration": 0.041239,
+     "end_time": "2021-04-26T05:19:53.388752",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:53.347513",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#Learning Rate Annealer\n",
+    "lrr= ReduceLROnPlateau(monitor='val_accuracy', factor=.01,  patience=3, min_lr=1e-5) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cosmetic-today",
+   "metadata": {
+    "papermill": {
+     "duration": 0.033489,
+     "end_time": "2021-04-26T05:19:53.456106",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:53.422617",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.4.6 Data Augmentation :\n",
+    "\n",
+    "- Data Augmentation is like adding a data and/or noise to a dataset, so that model can perform well in various patterns.\n",
+    "- For example, what if our images will have object at some angle ? In that case mostly our model will fail to predict right label.\n",
+    "- So using data augmentation our model will build with different variations so that model performance on variety of input will remain same.\n",
+    "- Image data augmentation is supported in the Keras deep learning library via the ImageDataGenerator class.\n",
+    "\n",
+    "**Parameters we used in  ImageDataGenerator :**\n",
+    "\n",
+    "1) **rotation_range :** (Integer) Degree range for random rotations.\n",
+    "\n",
+    "2) **zoom_range :** (Float or [lower, upper]) Range for random zoom.\n",
+    "\n",
+    "3) **shear_range :** (Float) Shear Intensity (Shear angle in counter-clockwise direction in degrees).\n",
+    "\n",
+    "4) **width_shift_range :** (Float, 1-D array-like or int - float) fraction of total width, if < 1, or pixels if >= 1. - 1-D array-like: random elements from the array. - int: integer number of pixels from interval.\n",
+    "\n",
+    "5) **height_shift_range :** (Float, 1-D array-like or int - float) fraction of total height, if < 1, or pixels if >= 1. - 1-D array-like: random elements from the array. - int: integer number of pixels from interval.\n",
+    "\n",
+    "6) **vertical_flip :** (Boolean) Randomly flip inputs vertically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "organizational-albert",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:53.529693Z",
+     "iopub.status.busy": "2021-04-26T05:19:53.527975Z",
+     "iopub.status.idle": "2021-04-26T05:19:53.530334Z",
+     "shell.execute_reply": "2021-04-26T05:19:53.530757Z"
+    },
+    "papermill": {
+     "duration": 0.041126,
+     "end_time": "2021-04-26T05:19:53.530895",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:53.489769",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "datagen = ImageDataGenerator(\n",
+    "        rotation_range = 8,  # randomly rotate images in the range (degrees, 0 to 180)\n",
+    "        zoom_range = 0.1, # Randomly zoom image \n",
+    "        shear_range = 0.3,# shear angle in counter-clockwise direction in degrees  \n",
+    "        width_shift_range=0.08,  # randomly shift images horizontally (fraction of total width)\n",
+    "        height_shift_range=0.08,  # randomly shift images vertically (fraction of total height)\n",
+    "        vertical_flip=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "amateur-bahrain",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:53.603308Z",
+     "iopub.status.busy": "2021-04-26T05:19:53.602268Z",
+     "iopub.status.idle": "2021-04-26T05:19:53.715583Z",
+     "shell.execute_reply": "2021-04-26T05:19:53.715125Z"
+    },
+    "papermill": {
+     "duration": 0.150631,
+     "end_time": "2021-04-26T05:19:53.715711",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:53.565080",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "datagen.fit(x_train)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "laden-farming",
+   "metadata": {
+    "papermill": {
+     "duration": 0.034275,
+     "end_time": "2021-04-26T05:19:53.784763",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:53.750488",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.4.7 Model fitting :\n",
+    "\n",
+    "- **batch size :** The batch size is a hyperparameter that defines the number of samples to work through before updating the internal model parameters.\n",
+    "- **epochs :** The number of epochs is a hyperparameter that defines the number times that the learning algorithm will work through the entire training dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "deadly-rhythm",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:53.857875Z",
+     "iopub.status.busy": "2021-04-26T05:19:53.857072Z",
+     "iopub.status.idle": "2021-04-26T05:19:53.859386Z",
+     "shell.execute_reply": "2021-04-26T05:19:53.859899Z"
+    },
+    "papermill": {
+     "duration": 0.041245,
+     "end_time": "2021-04-26T05:19:53.860029",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:53.818784",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "batch_size = 128\n",
+    "epochs = 25"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "indonesian-guyana",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:19:53.934608Z",
+     "iopub.status.busy": "2021-04-26T05:19:53.933612Z",
+     "iopub.status.idle": "2021-04-26T05:26:34.592531Z",
+     "shell.execute_reply": "2021-04-26T05:26:34.591935Z"
+    },
+    "papermill": {
+     "duration": 400.698393,
+     "end_time": "2021-04-26T05:26:34.592696",
+     "exception": false,
+     "start_time": "2021-04-26T05:19:53.894303",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/25\n",
+      "375/375 - 20s - loss: 0.8106 - accuracy: 0.6799 - val_loss: 2.1567 - val_accuracy: 0.3357\n",
+      "Epoch 2/25\n",
+      "375/375 - 15s - loss: 0.5759 - accuracy: 0.7659 - val_loss: 0.5030 - val_accuracy: 0.7878\n",
+      "Epoch 3/25\n",
+      "375/375 - 15s - loss: 0.5204 - accuracy: 0.7875 - val_loss: 0.4177 - val_accuracy: 0.8318\n",
+      "Epoch 4/25\n",
+      "375/375 - 17s - loss: 0.4909 - accuracy: 0.8031 - val_loss: 0.5545 - val_accuracy: 0.7827\n",
+      "Epoch 5/25\n",
+      "375/375 - 16s - loss: 0.4641 - accuracy: 0.8135 - val_loss: 0.3826 - val_accuracy: 0.8477\n",
+      "Epoch 6/25\n",
+      "375/375 - 16s - loss: 0.4483 - accuracy: 0.8198 - val_loss: 0.4014 - val_accuracy: 0.8283\n",
+      "Epoch 7/25\n",
+      "375/375 - 15s - loss: 0.4383 - accuracy: 0.8236 - val_loss: 0.3356 - val_accuracy: 0.8635\n",
+      "Epoch 8/25\n",
+      "375/375 - 16s - loss: 0.4191 - accuracy: 0.8316 - val_loss: 0.4851 - val_accuracy: 0.8005\n",
+      "Epoch 9/25\n",
+      "375/375 - 15s - loss: 0.4138 - accuracy: 0.8355 - val_loss: 0.3199 - val_accuracy: 0.8703\n",
+      "Epoch 10/25\n",
+      "375/375 - 16s - loss: 0.3981 - accuracy: 0.8423 - val_loss: 0.3404 - val_accuracy: 0.8545\n",
+      "Epoch 11/25\n",
+      "375/375 - 15s - loss: 0.3982 - accuracy: 0.8407 - val_loss: 0.3041 - val_accuracy: 0.8720\n",
+      "Epoch 12/25\n",
+      "375/375 - 16s - loss: 0.3867 - accuracy: 0.8440 - val_loss: 0.3602 - val_accuracy: 0.8447\n",
+      "Epoch 13/25\n",
+      "375/375 - 16s - loss: 0.3781 - accuracy: 0.8508 - val_loss: 0.3642 - val_accuracy: 0.8445\n",
+      "Epoch 14/25\n",
+      "375/375 - 16s - loss: 0.3705 - accuracy: 0.8541 - val_loss: 0.3734 - val_accuracy: 0.8415\n",
+      "Epoch 15/25\n",
+      "375/375 - 16s - loss: 0.3718 - accuracy: 0.8503 - val_loss: 0.5279 - val_accuracy: 0.7862\n",
+      "Epoch 16/25\n",
+      "375/375 - 16s - loss: 0.3653 - accuracy: 0.8557 - val_loss: 0.3531 - val_accuracy: 0.8472\n",
+      "Epoch 17/25\n",
+      "375/375 - 16s - loss: 0.3582 - accuracy: 0.8581 - val_loss: 0.3650 - val_accuracy: 0.8433\n",
+      "Epoch 18/25\n",
+      "375/375 - 16s - loss: 0.3541 - accuracy: 0.8604 - val_loss: 0.2928 - val_accuracy: 0.8770\n",
+      "Epoch 19/25\n",
+      "375/375 - 16s - loss: 0.3511 - accuracy: 0.8603 - val_loss: 0.3113 - val_accuracy: 0.8698\n",
+      "Epoch 20/25\n",
+      "375/375 - 16s - loss: 0.3501 - accuracy: 0.8617 - val_loss: 0.3845 - val_accuracy: 0.8360\n",
+      "Epoch 21/25\n",
+      "375/375 - 15s - loss: 0.3431 - accuracy: 0.8654 - val_loss: 0.3851 - val_accuracy: 0.8360\n",
+      "Epoch 22/25\n",
+      "375/375 - 16s - loss: 0.3412 - accuracy: 0.8671 - val_loss: 0.4382 - val_accuracy: 0.8218\n",
+      "Epoch 23/25\n",
+      "375/375 - 17s - loss: 0.3426 - accuracy: 0.8632 - val_loss: 0.4460 - val_accuracy: 0.8177\n",
+      "Epoch 24/25\n",
+      "375/375 - 16s - loss: 0.3358 - accuracy: 0.8670 - val_loss: 0.3110 - val_accuracy: 0.8688\n",
+      "Epoch 25/25\n",
+      "375/375 - 16s - loss: 0.3341 - accuracy: 0.8681 - val_loss: 0.4659 - val_accuracy: 0.8095\n",
+      "--- 400.65404772758484 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "history = model.fit(datagen.flow(x_train, y_train, batch_size = batch_size), epochs = epochs, \n",
+    "                              validation_data = (x_val, y_val), verbose=2, \n",
+    "                              steps_per_epoch=x_train.shape[0] // batch_size,\n",
+    "                              callbacks = [reduce_lr])\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "technological-ethiopia",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:26:34.697087Z",
+     "iopub.status.busy": "2021-04-26T05:26:34.696142Z",
+     "iopub.status.idle": "2021-04-26T05:26:35.301653Z",
+     "shell.execute_reply": "2021-04-26T05:26:35.301014Z"
+    },
+    "papermill": {
+     "duration": 0.659485,
+     "end_time": "2021-04-26T05:26:35.301837",
+     "exception": false,
+     "start_time": "2021-04-26T05:26:34.642352",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "188/188 [==============================] - 1s 3ms/step - loss: 0.4659 - accuracy: 0.8095\n",
+      "Loss: 0.4659\n",
+      "Accuracy: 0.8095\n",
+      "--- 0.6016826629638672 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "score = model.evaluate(x_val, y_val)\n",
+    "\n",
+    "print('Loss: {:.4f}'.format(score[0]))\n",
+    "print('Accuracy: {:.4f}'.format(score[1]))\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "minus-billion",
+   "metadata": {
+    "papermill": {
+     "duration": 0.051568,
+     "end_time": "2021-04-26T05:26:35.406689",
+     "exception": false,
+     "start_time": "2021-04-26T05:26:35.355121",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.4.7 Optimization and result with model :\n",
+    "\n",
+    "\n",
+    "1. **AdamGrad ( Learning rate : 0.01 ) :**\n",
+    "- Epoch 5/5\n",
+    "375/375 - 246s - loss: 0.9002 - accuracy: 0.6537 - val_loss: 0.5834 - val_accuracy: 0.7535\n",
+    "\n",
+    "- Adaptive Gradient Algorithm (Adagrad) is an algorithm for gradient-based optimization. ... It performs smaller updates As a result, it is well-suited when dealing with sparse data (NLP or image recognition).\n",
+    "\n",
+    "\n",
+    "2. **Adam ( Learning rate : 0.01 ) :**\n",
+    "\n",
+    "- Epoch 5/5\n",
+    "375/375 - 256s - loss: 0.4789 - accuracy: 0.8052 - val_loss: 0.4912 - val_accuracy: 0.7988\n",
+    "\n",
+    "- Adam combines the best properties of the AdaGrad and RMSProp algorithms to provide an optimization algorithm that can handle sparse gradients on noisy problems.\n",
+    "\n",
+    "\n",
+    "3. **SGD ( Learning rate : 0.01 ) :**\n",
+    "- Epoch 5/5\n",
+    "375/375 - 227s - loss: 1.0482 - accuracy: 0.6044 - val_loss: 0.6966 - val_accuracy: 0.7113\n",
+    "\n",
+    "- The SGD class that implements the stochastic gradient descent optimizer with a learning rate and momentum.\n",
+    "\n",
+    "4. **RMSProp ( Learning rate : 0.01 ) :**\n",
+    "\n",
+    "- Epoch 5/5\n",
+    "375/375 - 271s - loss: 0.4527 - accuracy: 0.8188 - val_loss: 0.5517 - val_accuracy: 0.7843\n",
+    "\n",
+    "- RmsProp optimizer is an optimizer that utilizes the magnitude of recent gradients to normalize the gradients.\n",
+    "\n",
+    "\n",
+    "\n",
+    "5. **Adadelta ( Learning rate : 0.01 ) :**\n",
+    "\n",
+    "- Epoch 5/5\n",
+    "375/375 - 255s - loss: 1.6791 - accuracy: 0.4668 - val_loss: 1.0540 - val_accuracy: 0.6050\n",
+    "\n",
+    "\n",
+    "**Note :**\n",
+    "- Result of every epoch are included in CM6.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wrong-hopkins",
+   "metadata": {
+    "papermill": {
+     "duration": 0.050871,
+     "end_time": "2021-04-26T05:26:35.509808",
+     "exception": false,
+     "start_time": "2021-04-26T05:26:35.458937",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5.5 Resnet ( Model 2 )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bizarre-covering",
+   "metadata": {
+    "papermill": {
+     "duration": 0.052033,
+     "end_time": "2021-04-26T05:26:35.614159",
+     "exception": false,
+     "start_time": "2021-04-26T05:26:35.562126",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "- In Resnet model we have to create residuals mappings. Residual mapping is the difference between the input and output of the residual block under question.\n",
+    "- In other words, residual mapping is the value that will be added to the input to approximate the final function of the block.\n",
+    "- We can consider the residual mapping is the amount of error which can be added to input so as to reach the final destination i.e. to approximate the final function.\n",
+    "\n",
+    "![](https://cdn-5f733ed3c1ac190fbc56ef88.closte.com/wp-content/uploads/2019/07/visualize_identity_mapping.png)\n",
+    "\n",
+    "- From above figure the Residual Mapping is acting as a bridge between the input and the output of the block.\n",
+    "\n",
+    "**Note :**\n",
+    "- The weight layers and activation function are not shown in the diagram but they are actually present in the network.\n",
+    "\n",
+    "- The function which should be learned as a final result of the block is represented as H(x). The input to the block is x and the residual mapping.\n",
+    "\n",
+    "\n",
+    "A RESIDUAL FUNCTION i.e. **F(x) = H(x) – x**.\n",
+    "\n",
+    "**Residual function in Resnet model :**\n",
+    "\n",
+    "1. During training the deep residual network, the main focus is to learn the residual function i.e. F(x). So, if the network will somehow learn the difference (F(x)) between the input and output, then the overall accuracy can be increased. \n",
+    "\n",
+    "2. In other words, the residual value should be learned in a way such that it approaches zero, therefore making the identity mapping optimal.\n",
+    "\n",
+    "3. In this way, all the layers in the network will always produce the optimal feature maps i.e. the best case feature map after the convolution, pooling and activation operations.\n",
+    "\n",
+    "\n",
+    "**Other parameters we used in Resnet in Conv2D :**\n",
+    "1. **kernel_initializer:** Initializer for the kernel weights matrix.\n",
+    "2. **kernel_regularizer:** Regularizer function applied to the kernel weights matrix.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "environmental-gathering",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:26:35.733615Z",
+     "iopub.status.busy": "2021-04-26T05:26:35.732718Z",
+     "iopub.status.idle": "2021-04-26T05:26:36.069087Z",
+     "shell.execute_reply": "2021-04-26T05:26:36.068066Z"
+    },
+    "papermill": {
+     "duration": 0.403701,
+     "end_time": "2021-04-26T05:26:36.069221",
+     "exception": false,
+     "start_time": "2021-04-26T05:26:35.665520",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "input_size = (28, 28,1)\n",
+    "num_filters = 64\n",
+    "use_max_pool = False\n",
+    "num_blocks = 4\n",
+    "num_sub_blocks = 2\n",
+    "num_classes = 5\n",
+    "inputs = Input(shape=input_size)\n",
+    "con_x = Conv2D(num_filters, padding='same', \n",
+    "           kernel_initializer='he_normal', \n",
+    "           kernel_size=7, strides=2,\n",
+    "           kernel_regularizer=l2(1e-4))(inputs)\n",
+    "con_x = BatchNormalization()(con_x)\n",
+    "con_x = Activation('relu')(con_x)\n",
+    "\n",
+    "#Check by applying max pooling later (setting it false as size of image is small i.e. 28x28)\n",
+    "if use_max_pool:\n",
+    "    con_x = MaxPooling2D(pool_size=3,padding='same', strides=2)(con_x)\n",
+    "    num_blocks =3\n",
+    "#Creating Conv base stack \n",
+    "\n",
+    "# Instantiate convolutional base (stack of blocks).\n",
+    "for i in range(num_blocks):\n",
+    "    for j in range(num_sub_blocks):\n",
+    "        strides = 1\n",
+    "        is_first_layer_but_not_first_block = j == 0 and i > 0\n",
+    "        if is_first_layer_but_not_first_block:\n",
+    "            strides = 2\n",
+    "        #Creating residual mapping using y\n",
+    "        con_y = Conv2D(num_filters,\n",
+    "                   kernel_size=3,\n",
+    "                   padding='same',\n",
+    "                   strides=strides,\n",
+    "                   kernel_initializer='he_normal',\n",
+    "                   kernel_regularizer=l2(1e-4))(con_x)\n",
+    "        con_y = BatchNormalization()(con_y)\n",
+    "        con_y = Activation('relu')(con_y)\n",
+    "        con_y = Conv2D(num_filters,\n",
+    "                   kernel_size=3,\n",
+    "                   padding='same',\n",
+    "                   kernel_initializer='he_normal',\n",
+    "                   kernel_regularizer=l2(1e-4))(con_y)\n",
+    "        con_y = BatchNormalization()(con_y)\n",
+    "        if is_first_layer_but_not_first_block:\n",
+    "            con_x = Conv2D(num_filters,\n",
+    "                       kernel_size=1,\n",
+    "                       padding='same',\n",
+    "                       strides=2,\n",
+    "                       kernel_initializer='he_normal',\n",
+    "                       kernel_regularizer=l2(1e-4))(con_x)\n",
+    "        #Adding back residual mapping\n",
+    "        con_x = keras.layers.add([con_x, con_y])\n",
+    "        con_x = Activation('relu')(con_x)\n",
+    "\n",
+    "    num_filters = 2 * num_filters\n",
+    "\n",
+    "# Add classifier on top.\n",
+    "con_x = AveragePooling2D()(con_x)\n",
+    "con_y = Flatten()(con_x)\n",
+    "outputs = Dense(num_classes,\n",
+    "                activation='softmax',\n",
+    "                kernel_initializer='he_normal')(con_y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "pressed-license",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:26:36.186184Z",
+     "iopub.status.busy": "2021-04-26T05:26:36.182150Z",
+     "iopub.status.idle": "2021-04-26T05:26:36.215260Z",
+     "shell.execute_reply": "2021-04-26T05:26:36.215641Z"
+    },
+    "papermill": {
+     "duration": 0.092865,
+     "end_time": "2021-04-26T05:26:36.215788",
+     "exception": false,
+     "start_time": "2021-04-26T05:26:36.122923",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: \"model\"\n",
+      "__________________________________________________________________________________________________\n",
+      "Layer (type)                    Output Shape         Param #     Connected to                     \n",
+      "==================================================================================================\n",
+      "input_1 (InputLayer)            [(None, 28, 28, 1)]  0                                            \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_4 (Conv2D)               (None, 14, 14, 64)   3200        input_1[0][0]                    \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_5 (BatchNor (None, 14, 14, 64)   256         conv2d_4[0][0]                   \n",
+      "__________________________________________________________________________________________________\n",
+      "activation (Activation)         (None, 14, 14, 64)   0           batch_normalization_5[0][0]      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_5 (Conv2D)               (None, 14, 14, 64)   36928       activation[0][0]                 \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_6 (BatchNor (None, 14, 14, 64)   256         conv2d_5[0][0]                   \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_1 (Activation)       (None, 14, 14, 64)   0           batch_normalization_6[0][0]      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_6 (Conv2D)               (None, 14, 14, 64)   36928       activation_1[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_7 (BatchNor (None, 14, 14, 64)   256         conv2d_6[0][0]                   \n",
+      "__________________________________________________________________________________________________\n",
+      "add (Add)                       (None, 14, 14, 64)   0           activation[0][0]                 \n",
+      "                                                                 batch_normalization_7[0][0]      \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_2 (Activation)       (None, 14, 14, 64)   0           add[0][0]                        \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_7 (Conv2D)               (None, 14, 14, 64)   36928       activation_2[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_8 (BatchNor (None, 14, 14, 64)   256         conv2d_7[0][0]                   \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_3 (Activation)       (None, 14, 14, 64)   0           batch_normalization_8[0][0]      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_8 (Conv2D)               (None, 14, 14, 64)   36928       activation_3[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_9 (BatchNor (None, 14, 14, 64)   256         conv2d_8[0][0]                   \n",
+      "__________________________________________________________________________________________________\n",
+      "add_1 (Add)                     (None, 14, 14, 64)   0           activation_2[0][0]               \n",
+      "                                                                 batch_normalization_9[0][0]      \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_4 (Activation)       (None, 14, 14, 64)   0           add_1[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_9 (Conv2D)               (None, 7, 7, 128)    73856       activation_4[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_10 (BatchNo (None, 7, 7, 128)    512         conv2d_9[0][0]                   \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_5 (Activation)       (None, 7, 7, 128)    0           batch_normalization_10[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_10 (Conv2D)              (None, 7, 7, 128)    147584      activation_5[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_11 (Conv2D)              (None, 7, 7, 128)    8320        activation_4[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_11 (BatchNo (None, 7, 7, 128)    512         conv2d_10[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_2 (Add)                     (None, 7, 7, 128)    0           conv2d_11[0][0]                  \n",
+      "                                                                 batch_normalization_11[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_6 (Activation)       (None, 7, 7, 128)    0           add_2[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_12 (Conv2D)              (None, 7, 7, 128)    147584      activation_6[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_12 (BatchNo (None, 7, 7, 128)    512         conv2d_12[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_7 (Activation)       (None, 7, 7, 128)    0           batch_normalization_12[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_13 (Conv2D)              (None, 7, 7, 128)    147584      activation_7[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_13 (BatchNo (None, 7, 7, 128)    512         conv2d_13[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_3 (Add)                     (None, 7, 7, 128)    0           activation_6[0][0]               \n",
+      "                                                                 batch_normalization_13[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_8 (Activation)       (None, 7, 7, 128)    0           add_3[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_14 (Conv2D)              (None, 4, 4, 256)    295168      activation_8[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_14 (BatchNo (None, 4, 4, 256)    1024        conv2d_14[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_9 (Activation)       (None, 4, 4, 256)    0           batch_normalization_14[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_15 (Conv2D)              (None, 4, 4, 256)    590080      activation_9[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_16 (Conv2D)              (None, 4, 4, 256)    33024       activation_8[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_15 (BatchNo (None, 4, 4, 256)    1024        conv2d_15[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_4 (Add)                     (None, 4, 4, 256)    0           conv2d_16[0][0]                  \n",
+      "                                                                 batch_normalization_15[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_10 (Activation)      (None, 4, 4, 256)    0           add_4[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_17 (Conv2D)              (None, 4, 4, 256)    590080      activation_10[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_16 (BatchNo (None, 4, 4, 256)    1024        conv2d_17[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_11 (Activation)      (None, 4, 4, 256)    0           batch_normalization_16[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_18 (Conv2D)              (None, 4, 4, 256)    590080      activation_11[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_17 (BatchNo (None, 4, 4, 256)    1024        conv2d_18[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_5 (Add)                     (None, 4, 4, 256)    0           activation_10[0][0]              \n",
+      "                                                                 batch_normalization_17[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_12 (Activation)      (None, 4, 4, 256)    0           add_5[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_19 (Conv2D)              (None, 2, 2, 512)    1180160     activation_12[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_18 (BatchNo (None, 2, 2, 512)    2048        conv2d_19[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_13 (Activation)      (None, 2, 2, 512)    0           batch_normalization_18[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_20 (Conv2D)              (None, 2, 2, 512)    2359808     activation_13[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_21 (Conv2D)              (None, 2, 2, 512)    131584      activation_12[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_19 (BatchNo (None, 2, 2, 512)    2048        conv2d_20[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_6 (Add)                     (None, 2, 2, 512)    0           conv2d_21[0][0]                  \n",
+      "                                                                 batch_normalization_19[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_14 (Activation)      (None, 2, 2, 512)    0           add_6[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_22 (Conv2D)              (None, 2, 2, 512)    2359808     activation_14[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_20 (BatchNo (None, 2, 2, 512)    2048        conv2d_22[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_15 (Activation)      (None, 2, 2, 512)    0           batch_normalization_20[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_23 (Conv2D)              (None, 2, 2, 512)    2359808     activation_15[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_21 (BatchNo (None, 2, 2, 512)    2048        conv2d_23[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_7 (Add)                     (None, 2, 2, 512)    0           activation_14[0][0]              \n",
+      "                                                                 batch_normalization_21[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_16 (Activation)      (None, 2, 2, 512)    0           add_7[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "average_pooling2d (AveragePooli (None, 1, 1, 512)    0           activation_16[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "flatten_1 (Flatten)             (None, 512)          0           average_pooling2d[0][0]          \n",
+      "__________________________________________________________________________________________________\n",
+      "dense_3 (Dense)                 (None, 5)            2565        flatten_1[0][0]                  \n",
+      "==================================================================================================\n",
+      "Total params: 11,183,621\n",
+      "Trainable params: 11,175,813\n",
+      "Non-trainable params: 7,808\n",
+      "__________________________________________________________________________________________________\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Instantiate and compile model.\n",
+    "resmodel = Model(inputs=inputs, outputs=outputs)\n",
+    "resmodel.compile(loss='categorical_crossentropy',\n",
+    "              optimizer='adam',\n",
+    "              metrics=['accuracy'])\n",
+    "resmodel.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "attempted-campus",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:26:36.338327Z",
+     "iopub.status.busy": "2021-04-26T05:26:36.334907Z",
+     "iopub.status.idle": "2021-04-26T05:26:36.341315Z",
+     "shell.execute_reply": "2021-04-26T05:26:36.341702Z"
+    },
+    "papermill": {
+     "duration": 0.062674,
+     "end_time": "2021-04-26T05:26:36.341845",
+     "exception": false,
+     "start_time": "2021-04-26T05:26:36.279171",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/kaggle/working/saved_model/fmnist_resnet_model.h5\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "save_dir = os.path.join(os.getcwd(), 'saved_model')\n",
+    "model_name = 'fmnist_resnet_model.h5'\n",
+    "if not os.path.isdir(save_dir):\n",
+    "    os.makedirs(save_dir)\n",
+    "filepath = os.path.join(save_dir,model_name)\n",
+    "print(filepath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "adult-median",
+   "metadata": {
+    "papermill": {
+     "duration": 0.052072,
+     "end_time": "2021-04-26T05:26:36.445881",
+     "exception": false,
+     "start_time": "2021-04-26T05:26:36.393809",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**ModelCheckpoint :**\n",
+    "\n",
+    "- ModelCheckpoint save the best version of your model after a single training.\n",
+    "- During saving we can select save_best_only and save_weights_only: The first will save the complete model with better training performance; The other will save only the weight values for this model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "dental-amber",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:26:36.557930Z",
+     "iopub.status.busy": "2021-04-26T05:26:36.556097Z",
+     "iopub.status.idle": "2021-04-26T05:26:36.558483Z",
+     "shell.execute_reply": "2021-04-26T05:26:36.558882Z"
+    },
+    "papermill": {
+     "duration": 0.060385,
+     "end_time": "2021-04-26T05:26:36.559010",
+     "exception": false,
+     "start_time": "2021-04-26T05:26:36.498625",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from keras.callbacks import ModelCheckpoint, ReduceLROnPlateau\n",
+    "checkpoint = ModelCheckpoint(filepath=filepath,\n",
+    "                             verbose=1,\n",
+    "                             save_best_only=True)\n",
+    "lr_reducer = ReduceLROnPlateau(factor=np.sqrt(0.1),\n",
+    "                               cooldown=0,\n",
+    "                               patience=5,\n",
+    "                               min_lr=0.5e-6)\n",
+    "callbacks = [checkpoint, lr_reducer]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "racial-pacific",
+   "metadata": {
+    "papermill": {
+     "duration": 0.051903,
+     "end_time": "2021-04-26T05:26:36.663287",
+     "exception": false,
+     "start_time": "2021-04-26T05:26:36.611384",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Comparision of LearningRateScheduler and ReduceLROnPlateau are included in CM6."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "varying-empty",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:26:36.789961Z",
+     "iopub.status.busy": "2021-04-26T05:26:36.789140Z",
+     "iopub.status.idle": "2021-04-26T05:31:28.283701Z",
+     "shell.execute_reply": "2021-04-26T05:31:28.284281Z"
+    },
+    "papermill": {
+     "duration": 291.56875,
+     "end_time": "2021-04-26T05:31:28.284497",
+     "exception": false,
+     "start_time": "2021-04-26T05:26:36.715747",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/25\n",
+      "375/375 [==============================] - 15s 32ms/step - loss: 1.6841 - accuracy: 0.7555 - val_loss: 1.1087 - val_accuracy: 0.8332\n",
+      "\n",
+      "Epoch 00001: val_loss improved from inf to 1.10869, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 2/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.9823 - accuracy: 0.8681 - val_loss: 0.8282 - val_accuracy: 0.8767\n",
+      "\n",
+      "Epoch 00002: val_loss improved from 1.10869 to 0.82815, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 3/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.7506 - accuracy: 0.8941 - val_loss: 0.7199 - val_accuracy: 0.8740\n",
+      "\n",
+      "Epoch 00003: val_loss improved from 0.82815 to 0.71990, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 4/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.6387 - accuracy: 0.8999 - val_loss: 0.6921 - val_accuracy: 0.8643\n",
+      "\n",
+      "Epoch 00004: val_loss improved from 0.71990 to 0.69214, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 5/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.5522 - accuracy: 0.9104 - val_loss: 0.6032 - val_accuracy: 0.8812\n",
+      "\n",
+      "Epoch 00005: val_loss improved from 0.69214 to 0.60323, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 6/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.5021 - accuracy: 0.9155 - val_loss: 0.9253 - val_accuracy: 0.7907\n",
+      "\n",
+      "Epoch 00006: val_loss did not improve from 0.60323\n",
+      "Epoch 7/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.4579 - accuracy: 0.9219 - val_loss: 0.5643 - val_accuracy: 0.8748\n",
+      "\n",
+      "Epoch 00007: val_loss improved from 0.60323 to 0.56433, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 8/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.4205 - accuracy: 0.9291 - val_loss: 0.5172 - val_accuracy: 0.8932\n",
+      "\n",
+      "Epoch 00008: val_loss improved from 0.56433 to 0.51716, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 9/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.4025 - accuracy: 0.9301 - val_loss: 0.6454 - val_accuracy: 0.8533\n",
+      "\n",
+      "Epoch 00009: val_loss did not improve from 0.51716\n",
+      "Epoch 10/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.3829 - accuracy: 0.9334 - val_loss: 0.5331 - val_accuracy: 0.8867\n",
+      "\n",
+      "Epoch 00010: val_loss did not improve from 0.51716\n",
+      "Epoch 11/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.3689 - accuracy: 0.9380 - val_loss: 0.6069 - val_accuracy: 0.8627\n",
+      "\n",
+      "Epoch 00011: val_loss did not improve from 0.51716\n",
+      "Epoch 12/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.3559 - accuracy: 0.9398 - val_loss: 0.5403 - val_accuracy: 0.8740\n",
+      "\n",
+      "Epoch 00012: val_loss did not improve from 0.51716\n",
+      "Epoch 13/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.3346 - accuracy: 0.9462 - val_loss: 0.5604 - val_accuracy: 0.8695\n",
+      "\n",
+      "Epoch 00013: val_loss did not improve from 0.51716\n",
+      "Epoch 14/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.2793 - accuracy: 0.9656 - val_loss: 0.5032 - val_accuracy: 0.9002\n",
+      "\n",
+      "Epoch 00014: val_loss improved from 0.51716 to 0.50325, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 15/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.2293 - accuracy: 0.9798 - val_loss: 0.5364 - val_accuracy: 0.9003\n",
+      "\n",
+      "Epoch 00015: val_loss did not improve from 0.50325\n",
+      "Epoch 16/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.2120 - accuracy: 0.9817 - val_loss: 0.5712 - val_accuracy: 0.8937\n",
+      "\n",
+      "Epoch 00016: val_loss did not improve from 0.50325\n",
+      "Epoch 17/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.2072 - accuracy: 0.9817 - val_loss: 0.5480 - val_accuracy: 0.9012\n",
+      "\n",
+      "Epoch 00017: val_loss did not improve from 0.50325\n",
+      "Epoch 18/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.1944 - accuracy: 0.9842 - val_loss: 0.5718 - val_accuracy: 0.8958\n",
+      "\n",
+      "Epoch 00018: val_loss did not improve from 0.50325\n",
+      "Epoch 19/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.1874 - accuracy: 0.9848 - val_loss: 0.6879 - val_accuracy: 0.8830\n",
+      "\n",
+      "Epoch 00019: val_loss did not improve from 0.50325\n",
+      "Epoch 20/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.1634 - accuracy: 0.9930 - val_loss: 0.5765 - val_accuracy: 0.9072\n",
+      "\n",
+      "Epoch 00020: val_loss did not improve from 0.50325\n",
+      "Epoch 21/25\n",
+      "375/375 [==============================] - 11s 31ms/step - loss: 0.1496 - accuracy: 0.9965 - val_loss: 0.5778 - val_accuracy: 0.9118\n",
+      "\n",
+      "Epoch 00021: val_loss did not improve from 0.50325\n",
+      "Epoch 22/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.1447 - accuracy: 0.9972 - val_loss: 0.6340 - val_accuracy: 0.9060\n",
+      "\n",
+      "Epoch 00022: val_loss did not improve from 0.50325\n",
+      "Epoch 23/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.1396 - accuracy: 0.9974 - val_loss: 0.6178 - val_accuracy: 0.9033\n",
+      "\n",
+      "Epoch 00023: val_loss did not improve from 0.50325\n",
+      "Epoch 24/25\n",
+      "375/375 [==============================] - 12s 31ms/step - loss: 0.1367 - accuracy: 0.9976 - val_loss: 0.6877 - val_accuracy: 0.8993\n",
+      "\n",
+      "Epoch 00024: val_loss did not improve from 0.50325\n",
+      "Epoch 25/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.1348 - accuracy: 0.9979 - val_loss: 0.6234 - val_accuracy: 0.9110\n",
+      "\n",
+      "Epoch 00025: val_loss did not improve from 0.50325\n",
+      "--- 291.4898257255554 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "resmodel.fit(x_train, y_train, batch_size=batch_size,\n",
+    "              epochs=epochs,\n",
+    "              validation_data=(x_val, y_val),\n",
+    "              shuffle=True,\n",
+    "              callbacks=callbacks)\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "interior-symposium",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:31:30.868960Z",
+     "iopub.status.busy": "2021-04-26T05:31:30.868028Z",
+     "iopub.status.idle": "2021-04-26T05:31:32.300096Z",
+     "shell.execute_reply": "2021-04-26T05:31:32.300683Z"
+    },
+    "papermill": {
+     "duration": 2.728859,
+     "end_time": "2021-04-26T05:31:32.300897",
+     "exception": false,
+     "start_time": "2021-04-26T05:31:29.572038",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "188/188 [==============================] - 1s 7ms/step - loss: 0.6234 - accuracy: 0.9110\n",
+      "Loss: 0.6234\n",
+      "Accuracy: 0.9110\n",
+      "--- 1.429495096206665 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "score = resmodel.evaluate(x_val, y_val)\n",
+    "\n",
+    "print('Loss: {:.4f}'.format(score[0]))\n",
+    "print('Accuracy: {:.4f}'.format(score[1]))\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "placed-grant",
+   "metadata": {
+    "papermill": {
+     "duration": 1.557559,
+     "end_time": "2021-04-26T05:31:35.184848",
+     "exception": false,
+     "start_time": "2021-04-26T05:31:33.627289",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Advantages of Resnet :**\n",
+    "- ResNet uses Batch Normalization at its core. The Batch Normalization adjusts the input layer to increase the performance of the network.\n",
+    "- ResNet makes use of the Identity Connection, which helps to protect the network from vanishing gradient problem.\n",
+    "- Deep Residual Network uses bottleneck residual block design to increase the performance of the network.\n",
+    "\n",
+    "**Limitations of Resnet :**\n",
+    "- Increased complexity of architecture.\n",
+    "- Deeper network usually requires weeks for training, making it practically infeasible in real-world applications.\n",
+    "- Implementation of Batch normalization layers since ResNet heavily depends on it.\n",
+    "- The dimensionality between the different layers which can become a headache while adding skip connections in model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "documentary-findings",
+   "metadata": {
+    "papermill": {
+     "duration": 1.30157,
+     "end_time": "2021-04-26T05:31:37.788847",
+     "exception": false,
+     "start_time": "2021-04-26T05:31:36.487277",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5.6 ML model ( Random Forest with Gridsearch ) :\n",
+    "\n",
+    "**Parameters :**\n",
+    "\n",
+    "- **n_estimators :** number of trees in the forest.\n",
+    "- **max_depth :** max number of levels in each decision tree.\n",
+    "- **bootstrap :** method for sampling data points (with or without replacement).\n",
+    "\n",
+    "Other parameters can use :\n",
+    "\n",
+    "- **max_features :** max number of features considered for splitting a node.\n",
+    "- **min_samples_split :** min number of data points placed in a node before the node is split.\n",
+    "- **min_samples_leaf :** min number of data points allowed in a leaf node.\n",
+    "\n",
+    "**GridSearchCV :**\n",
+    "\n",
+    "- GridSearchCV exhaustively generates candidates from a grid of parameter values specified with the param_grid parameter.\n",
+    "\n",
+    "\n",
+    "**Note :**\n",
+    "\n",
+    "- Instead of GridSearchCV we can also use RandomizedSearchCV, which implements a randomized search over parameters, where each setting is sampled from a distribution over possible parameter values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "attempted-semiconductor",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:31:40.410558Z",
+     "iopub.status.busy": "2021-04-26T05:31:40.409616Z",
+     "iopub.status.idle": "2021-04-26T05:31:40.411348Z",
+     "shell.execute_reply": "2021-04-26T05:31:40.412128Z"
+    },
+    "papermill": {
+     "duration": 1.299357,
+     "end_time": "2021-04-26T05:31:40.412278",
+     "exception": false,
+     "start_time": "2021-04-26T05:31:39.112921",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "param_grid = {\n",
+    "    'bootstrap': [True],\n",
+    "    'max_depth': [3,5,10, None],\n",
+    "    'n_estimators': [5,10,50, 150, 200]\n",
+    "}\n",
+    "# Create a based model\n",
+    "rfc = RandomForestClassifier()\n",
+    "# Instantiate the grid search model\n",
+    "grid_search = GridSearchCV(estimator = rfc, param_grid = param_grid, \n",
+    "                          cv = 3, n_jobs = -1, verbose = 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "promotional-junction",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:31:43.003260Z",
+     "iopub.status.busy": "2021-04-26T05:31:43.002394Z",
+     "iopub.status.idle": "2021-04-26T05:50:44.614803Z",
+     "shell.execute_reply": "2021-04-26T05:50:44.615336Z"
+    },
+    "papermill": {
+     "duration": 1142.910024,
+     "end_time": "2021-04-26T05:50:44.615494",
+     "exception": false,
+     "start_time": "2021-04-26T05:31:41.705470",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 3 folds for each of 20 candidates, totalling 60 fits\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'bootstrap': True, 'max_depth': None, 'n_estimators': 200}"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grid_search.fit(x_train1,y_train)\n",
+    "grid_search.best_params_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "subtle-kazakhstan",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:50:47.187760Z",
+     "iopub.status.busy": "2021-04-26T05:50:47.186686Z",
+     "iopub.status.idle": "2021-04-26T05:50:47.825176Z",
+     "shell.execute_reply": "2021-04-26T05:50:47.824618Z"
+    },
+    "papermill": {
+     "duration": 1.94203,
+     "end_time": "2021-04-26T05:50:47.825321",
+     "exception": false,
+     "start_time": "2021-04-26T05:50:45.883291",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "y_pred_rf = grid_search.predict(x_val1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "joined-seminar",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:50:50.703971Z",
+     "iopub.status.busy": "2021-04-26T05:50:50.703219Z",
+     "iopub.status.idle": "2021-04-26T05:50:50.712467Z",
+     "shell.execute_reply": "2021-04-26T05:50:50.711801Z"
+    },
+    "papermill": {
+     "duration": 1.301518,
+     "end_time": "2021-04-26T05:50:50.712617",
+     "exception": false,
+     "start_time": "2021-04-26T05:50:49.411099",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy : 0.8116666666666666\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Accuracy :',metrics.accuracy_score(y_val,y_pred_rf))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aerial-biography",
+   "metadata": {
+    "papermill": {
+     "duration": 1.262632,
+     "end_time": "2021-04-26T05:50:53.278744",
+     "exception": false,
+     "start_time": "2021-04-26T05:50:52.016112",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5.7 Simple Neural Networks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "desperate-disposition",
+   "metadata": {
+    "papermill": {
+     "duration": 1.271601,
+     "end_time": "2021-04-26T05:50:55.840239",
+     "exception": false,
+     "start_time": "2021-04-26T05:50:54.568638",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "- In this model we havn't use any convolution or max polling layer in model. We simply use Flatter and Dense in model and trained it with learning rate.\n",
+    "\n",
+    "- We try to create a model on paper below is an overview on a model :\n",
+    "\n",
+    "![](http://www.linkpicture.com/q/0001_33.jpg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "neutral-spine",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:50:58.464759Z",
+     "iopub.status.busy": "2021-04-26T05:50:58.463774Z",
+     "iopub.status.idle": "2021-04-26T05:50:58.489717Z",
+     "shell.execute_reply": "2021-04-26T05:50:58.489219Z"
+    },
+    "papermill": {
+     "duration": 1.355131,
+     "end_time": "2021-04-26T05:50:58.489864",
+     "exception": false,
+     "start_time": "2021-04-26T05:50:57.134733",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model3 = keras.Sequential([\n",
+    "    keras.layers.Flatten(input_shape=(28, 28)),\n",
+    "    keras.layers.Dense(128, activation='relu'),\n",
+    "    keras.layers.Dense(5, activation='softmax')\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "trained-tiger",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:51:01.433549Z",
+     "iopub.status.busy": "2021-04-26T05:51:01.432633Z",
+     "iopub.status.idle": "2021-04-26T05:51:01.437975Z",
+     "shell.execute_reply": "2021-04-26T05:51:01.438673Z"
+    },
+    "papermill": {
+     "duration": 1.580513,
+     "end_time": "2021-04-26T05:51:01.438863",
+     "exception": false,
+     "start_time": "2021-04-26T05:50:59.858350",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: \"sequential_1\"\n",
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "flatten_2 (Flatten)          (None, 784)               0         \n",
+      "_________________________________________________________________\n",
+      "dense_4 (Dense)              (None, 128)               100480    \n",
+      "_________________________________________________________________\n",
+      "dense_5 (Dense)              (None, 5)                 645       \n",
+      "=================================================================\n",
+      "Total params: 101,125\n",
+      "Trainable params: 101,125\n",
+      "Non-trainable params: 0\n",
+      "_________________________________________________________________\n"
+     ]
+    }
+   ],
+   "source": [
+    "model3.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "described-matthew",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:51:04.016096Z",
+     "iopub.status.busy": "2021-04-26T05:51:04.015183Z",
+     "iopub.status.idle": "2021-04-26T05:51:04.020376Z",
+     "shell.execute_reply": "2021-04-26T05:51:04.019858Z"
+    },
+    "papermill": {
+     "duration": 1.28832,
+     "end_time": "2021-04-26T05:51:04.020487",
+     "exception": false,
+     "start_time": "2021-04-26T05:51:02.732167",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model3.compile(optimizer='adam', loss=\"categorical_crossentropy\", metrics=[\"accuracy\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "utility-alberta",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:51:07.050808Z",
+     "iopub.status.busy": "2021-04-26T05:51:07.049324Z",
+     "iopub.status.idle": "2021-04-26T05:57:35.337334Z",
+     "shell.execute_reply": "2021-04-26T05:57:35.337737Z"
+    },
+    "papermill": {
+     "duration": 389.575032,
+     "end_time": "2021-04-26T05:57:35.337940",
+     "exception": false,
+     "start_time": "2021-04-26T05:51:05.762908",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/25\n",
+      "375/375 - 15s - loss: 0.9691 - accuracy: 0.5913 - val_loss: 0.8071 - val_accuracy: 0.6923\n",
+      "Epoch 2/25\n",
+      "375/375 - 14s - loss: 0.7936 - accuracy: 0.6748 - val_loss: 0.6961 - val_accuracy: 0.7185\n",
+      "Epoch 3/25\n",
+      "375/375 - 14s - loss: 0.7313 - accuracy: 0.7015 - val_loss: 0.6656 - val_accuracy: 0.7337\n",
+      "Epoch 4/25\n",
+      "375/375 - 15s - loss: 0.6941 - accuracy: 0.7187 - val_loss: 0.6353 - val_accuracy: 0.7482\n",
+      "Epoch 5/25\n",
+      "375/375 - 15s - loss: 0.6693 - accuracy: 0.7317 - val_loss: 0.6087 - val_accuracy: 0.7493\n",
+      "Epoch 6/25\n",
+      "375/375 - 14s - loss: 0.6530 - accuracy: 0.7361 - val_loss: 0.5939 - val_accuracy: 0.7665\n",
+      "Epoch 7/25\n",
+      "375/375 - 16s - loss: 0.6419 - accuracy: 0.7423 - val_loss: 0.5875 - val_accuracy: 0.7712\n",
+      "Epoch 8/25\n",
+      "375/375 - 14s - loss: 0.6286 - accuracy: 0.7491 - val_loss: 0.5946 - val_accuracy: 0.7533\n",
+      "Epoch 9/25\n",
+      "375/375 - 15s - loss: 0.6226 - accuracy: 0.7502 - val_loss: 0.5776 - val_accuracy: 0.7630\n",
+      "Epoch 10/25\n",
+      "375/375 - 15s - loss: 0.6153 - accuracy: 0.7529 - val_loss: 0.5784 - val_accuracy: 0.7775\n",
+      "Epoch 11/25\n",
+      "375/375 - 39s - loss: 0.6099 - accuracy: 0.7563 - val_loss: 0.5543 - val_accuracy: 0.7717\n",
+      "Epoch 12/25\n",
+      "375/375 - 16s - loss: 0.6030 - accuracy: 0.7586 - val_loss: 0.5602 - val_accuracy: 0.7798\n",
+      "Epoch 13/25\n",
+      "375/375 - 14s - loss: 0.5973 - accuracy: 0.7636 - val_loss: 0.5616 - val_accuracy: 0.7782\n",
+      "Epoch 14/25\n",
+      "375/375 - 14s - loss: 0.5940 - accuracy: 0.7634 - val_loss: 0.5448 - val_accuracy: 0.7855\n",
+      "Epoch 15/25\n",
+      "375/375 - 15s - loss: 0.5893 - accuracy: 0.7668 - val_loss: 0.5427 - val_accuracy: 0.7870\n",
+      "Epoch 16/25\n",
+      "375/375 - 14s - loss: 0.5867 - accuracy: 0.7663 - val_loss: 0.5423 - val_accuracy: 0.7952\n",
+      "Epoch 17/25\n",
+      "375/375 - 14s - loss: 0.5859 - accuracy: 0.7670 - val_loss: 0.5363 - val_accuracy: 0.7940\n",
+      "Epoch 18/25\n",
+      "375/375 - 15s - loss: 0.5780 - accuracy: 0.7712 - val_loss: 0.5339 - val_accuracy: 0.7985\n",
+      "Epoch 19/25\n",
+      "375/375 - 15s - loss: 0.5775 - accuracy: 0.7720 - val_loss: 0.5283 - val_accuracy: 0.7935\n",
+      "Epoch 20/25\n",
+      "375/375 - 14s - loss: 0.5726 - accuracy: 0.7736 - val_loss: 0.5255 - val_accuracy: 0.7937\n",
+      "Epoch 21/25\n",
+      "375/375 - 15s - loss: 0.5734 - accuracy: 0.7716 - val_loss: 0.5227 - val_accuracy: 0.7960\n",
+      "Epoch 22/25\n",
+      "375/375 - 14s - loss: 0.5695 - accuracy: 0.7749 - val_loss: 0.5186 - val_accuracy: 0.7912\n",
+      "Epoch 23/25\n",
+      "375/375 - 14s - loss: 0.5698 - accuracy: 0.7759 - val_loss: 0.5159 - val_accuracy: 0.8007\n",
+      "Epoch 24/25\n",
+      "375/375 - 15s - loss: 0.5666 - accuracy: 0.7764 - val_loss: 0.5207 - val_accuracy: 0.7982\n",
+      "Epoch 25/25\n",
+      "375/375 - 14s - loss: 0.5651 - accuracy: 0.7780 - val_loss: 0.5196 - val_accuracy: 0.7983\n",
+      "--- 388.28542041778564 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time()\n",
+    "history3 = model3.fit(datagen.flow(x_train, y_train, batch_size = batch_size), epochs = epochs, \n",
+    "                              validation_data = (x_val, y_val), verbose=2, \n",
+    "                              steps_per_epoch=x_train.shape[0] // batch_size,\n",
+    "                              callbacks = [reduce_lr])\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "seasonal-collector",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-26T05:57:38.189896Z",
+     "iopub.status.busy": "2021-04-26T05:57:38.188958Z",
+     "iopub.status.idle": "2021-04-26T05:57:38.568037Z",
+     "shell.execute_reply": "2021-04-26T05:57:38.568453Z"
+    },
+    "papermill": {
+     "duration": 1.714059,
+     "end_time": "2021-04-26T05:57:38.568611",
+     "exception": false,
+     "start_time": "2021-04-26T05:57:36.854552",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "188/188 [==============================] - 0s 2ms/step - loss: 0.5196 - accuracy: 0.7983\n",
+      "Loss: 0.5196\n",
+      "Accuracy: 0.7983\n",
+      "--- 0.3760824203491211 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "score = model3.evaluate(x_val, y_val)\n",
+    "\n",
+    "print('Loss: {:.4f}'.format(score[0]))\n",
+    "print('Accuracy: {:.4f}'.format(score[1]))\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "engaged-honduras",
+   "metadata": {
+    "papermill": {
+     "duration": 1.776878,
+     "end_time": "2021-04-26T05:57:41.615465",
+     "exception": false,
+     "start_time": "2021-04-26T05:57:39.838587",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Note :**\n",
+    "- Each model evaluation, performance and comparision performed in CM6."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 2297.950887,
+   "end_time": "2021-04-26T05:57:46.197251",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "__notebook__.ipynb",
+   "output_path": "__notebook__.ipynb",
+   "parameters": {},
+   "start_time": "2021-04-26T05:19:28.246364",
+   "version": "2.3.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/CM6.ipynb
+++ b/CM6.ipynb
@@ -1,0 +1,4256 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "united-estate",
+   "metadata": {
+    "papermill": {
+     "duration": 0.056983,
+     "end_time": "2021-04-25T14:14:11.459593",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:11.402610",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# <div align=\"center\">CM6</div>\n",
+    "\n",
+    "## 6.1 Importing libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "smooth-cosmetic",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:11.582072Z",
+     "iopub.status.busy": "2021-04-25T14:14:11.581505Z",
+     "iopub.status.idle": "2021-04-25T14:14:19.189915Z",
+     "shell.execute_reply": "2021-04-25T14:14:19.189340Z"
+    },
+    "papermill": {
+     "duration": 7.676071,
+     "end_time": "2021-04-25T14:14:19.190115",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:11.514044",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/kaggle/input/mnist-train/fashion_mnist_dataset_train.npy\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Handle table-like data and matrices :\n",
+    "import numpy as np \n",
+    "import pandas as pd \n",
+    "\n",
+    "\n",
+    "import os\n",
+    "for dirname, _, filenames in os.walk('/kaggle/input'):\n",
+    "    for filename in filenames:\n",
+    "        print(os.path.join(dirname, filename))\n",
+    "\n",
+    "        \n",
+    "# Modelling Helpers Libraries\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import confusion_matrix, classification_report\n",
+    "from sklearn.model_selection import GridSearchCV , KFold , cross_val_score\n",
+    "\n",
+    "# Deep Learning Libraries\n",
+    "import tensorflow as tf\n",
+    "from keras.utils import to_categorical\n",
+    "from keras.models import Sequential, load_model\n",
+    "from keras.layers import Dense, Dropout, Flatten\n",
+    "from keras.layers import Conv2D, MaxPooling2D, BatchNormalization\n",
+    "from keras.optimizers import Adam,SGD,Adagrad,Adadelta,RMSprop\n",
+    "from keras.preprocessing.image import ImageDataGenerator\n",
+    "from keras.callbacks import ReduceLROnPlateau, LearningRateScheduler\n",
+    "\n",
+    "# Resnet \n",
+    "import keras\n",
+    "from keras.layers import AveragePooling2D, Input, Flatten\n",
+    "from keras.layers import Dense, Conv2D, BatchNormalization, Activation\n",
+    "from keras.regularizers import l2\n",
+    "from keras.models import Model\n",
+    "import os\n",
+    "from keras.callbacks import ModelCheckpoint, ReduceLROnPlateau\n",
+    "\n",
+    "# Machine Learning Model\n",
+    "from sklearn.model_selection import GridSearchCV\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn import metrics\n",
+    "\n",
+    "# Visualisation\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Time library\n",
+    "import time \n",
+    "\n",
+    "\n",
+    "# Classification\n",
+    "from sklearn.metrics import accuracy_score,precision_score,recall_score,f1_score,confusion_matrix,classification_report\n",
+    "import itertools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "insured-blind",
+   "metadata": {
+    "papermill": {
+     "duration": 0.056277,
+     "end_time": "2021-04-25T14:14:19.303470",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:19.247193",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6.2 Dataset Extract"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bridal-somalia",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:19.420292Z",
+     "iopub.status.busy": "2021-04-25T14:14:19.419703Z",
+     "iopub.status.idle": "2021-04-25T14:14:24.254693Z",
+     "shell.execute_reply": "2021-04-25T14:14:24.253626Z"
+    },
+    "papermill": {
+     "duration": 4.895628,
+     "end_time": "2021-04-25T14:14:24.254844",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:19.359216",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "data = np.load('../input/mnist-train/fashion_mnist_dataset_train.npy', allow_pickle=True).item()\n",
+    "data = np.array(data)\n",
+    "my_dict = data[()]\n",
+    "features = my_dict.get('features')\n",
+    "target = my_dict.get('target')\n",
+    "farray = features.reshape(features.shape[0], (features.shape[1]*features.shape[2]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fundamental-privilege",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:24.377480Z",
+     "iopub.status.busy": "2021-04-25T14:14:24.376732Z",
+     "iopub.status.idle": "2021-04-25T14:14:24.381001Z",
+     "shell.execute_reply": "2021-04-25T14:14:24.380355Z"
+    },
+    "papermill": {
+     "duration": 0.067664,
+     "end_time": "2021-04-25T14:14:24.381323",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:24.313659",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "column_names = []\n",
+    "[column_names.append(\"pixel\"+str(x)) for x in range(0, 784)]\n",
+    "f1 = pd.DataFrame(farray , columns = column_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "separated-prior",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:24.501479Z",
+     "iopub.status.busy": "2021-04-25T14:14:24.499527Z",
+     "iopub.status.idle": "2021-04-25T14:14:24.502256Z",
+     "shell.execute_reply": "2021-04-25T14:14:24.502712Z"
+    },
+    "papermill": {
+     "duration": 0.063841,
+     "end_time": "2021-04-25T14:14:24.502851",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:24.439010",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "column_names = ['target']\n",
+    "t1  = pd.DataFrame(target , columns = column_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "prostate-voluntary",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:24.624702Z",
+     "iopub.status.busy": "2021-04-25T14:14:24.623974Z",
+     "iopub.status.idle": "2021-04-25T14:14:24.645330Z",
+     "shell.execute_reply": "2021-04-25T14:14:24.644330Z"
+    },
+    "papermill": {
+     "duration": 0.088341,
+     "end_time": "2021-04-25T14:14:24.645463",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:24.557122",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "f1['target'] = t1['target'] - 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "daily-england",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:24.767000Z",
+     "iopub.status.busy": "2021-04-25T14:14:24.766089Z",
+     "iopub.status.idle": "2021-04-25T14:14:24.777654Z",
+     "shell.execute_reply": "2021-04-25T14:14:24.778120Z"
+    },
+    "papermill": {
+     "duration": 0.073707,
+     "end_time": "2021-04-25T14:14:24.778271",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:24.704564",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.0    12019\n",
+       "2.0    12011\n",
+       "3.0    11992\n",
+       "0.0    11989\n",
+       "4.0    11989\n",
+       "Name: target, dtype: int64"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f1['target'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "separate-acting",
+   "metadata": {
+    "papermill": {
+     "duration": 0.055685,
+     "end_time": "2021-04-25T14:14:24.893086",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:24.837401",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6.3 Data Preprocessing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ahead-revelation",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:25.009637Z",
+     "iopub.status.busy": "2021-04-25T14:14:25.008848Z",
+     "iopub.status.idle": "2021-04-25T14:14:25.012824Z",
+     "shell.execute_reply": "2021-04-25T14:14:25.012392Z"
+    },
+    "papermill": {
+     "duration": 0.064688,
+     "end_time": "2021-04-25T14:14:25.012933",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:24.948245",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "seed = 66\n",
+    "np.random.seed(seed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "exempt-entrepreneur",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:25.168753Z",
+     "iopub.status.busy": "2021-04-25T14:14:25.167843Z",
+     "iopub.status.idle": "2021-04-25T14:14:25.549179Z",
+     "shell.execute_reply": "2021-04-25T14:14:25.550251Z"
+    },
+    "papermill": {
+     "duration": 0.479998,
+     "end_time": "2021-04-25T14:14:25.550456",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:25.070458",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "X = f1.iloc[:, :-1]\n",
+    "Y = f1.iloc[:,784]\n",
+    "x_train1, x_valtest, y_train, y_valtest = train_test_split(X, Y, test_size=0.2, random_state=seed)\n",
+    "x_val1,x_test1,y_val,y_test = train_test_split(x_valtest, y_valtest, test_size=0.5, random_state=seed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "historical-observer",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:25.747410Z",
+     "iopub.status.busy": "2021-04-25T14:14:25.746397Z",
+     "iopub.status.idle": "2021-04-25T14:14:25.749150Z",
+     "shell.execute_reply": "2021-04-25T14:14:25.748281Z"
+    },
+    "papermill": {
+     "duration": 0.104425,
+     "end_time": "2021-04-25T14:14:25.749345",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:25.644920",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "x_train = x_train1.values.reshape((-1, 28, 28, 1))\n",
+    "x_val = x_val1.values.reshape((-1, 28, 28, 1))\n",
+    "x_test = x_test1.values.reshape((-1, 28, 28, 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "suited-lunch",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:25.979480Z",
+     "iopub.status.busy": "2021-04-25T14:14:25.978560Z",
+     "iopub.status.idle": "2021-04-25T14:14:25.983041Z",
+     "shell.execute_reply": "2021-04-25T14:14:25.984388Z"
+    },
+    "papermill": {
+     "duration": 0.097852,
+     "end_time": "2021-04-25T14:14:25.984595",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:25.886743",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from keras.utils.np_utils import to_categorical\n",
+    "\n",
+    "y_train = to_categorical(y_train, num_classes=5)\n",
+    "y_val = to_categorical(y_val, num_classes=5)\n",
+    "y_test = to_categorical(y_test, num_classes=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "directed-healthcare",
+   "metadata": {
+    "papermill": {
+     "duration": 0.059418,
+     "end_time": "2021-04-25T14:14:26.253241",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:26.193823",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6.4 Model 1 ( CNN ) :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "choice-nomination",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:26.432120Z",
+     "iopub.status.busy": "2021-04-25T14:14:26.431319Z",
+     "iopub.status.idle": "2021-04-25T14:14:30.614875Z",
+     "shell.execute_reply": "2021-04-25T14:14:30.614353Z"
+    },
+    "papermill": {
+     "duration": 4.279868,
+     "end_time": "2021-04-25T14:14:30.615025",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:26.335157",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model = Sequential()\n",
+    "model.add(Conv2D(filters=32, kernel_size=(3, 3), activation='relu', strides=1, padding='same', \n",
+    "                 data_format='channels_last', input_shape=(28,28,1)))\n",
+    "model.add(BatchNormalization())\n",
+    "\n",
+    "model.add(Conv2D(filters=32, kernel_size=(3, 3), activation='relu', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model.add(BatchNormalization())\n",
+    "model.add(Dropout(0.25))\n",
+    "\n",
+    "model.add(Conv2D(filters=64, kernel_size=(3, 3), activation='relu', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model.add(MaxPooling2D(pool_size=(2, 2)))\n",
+    "model.add(Dropout(0.25))\n",
+    "    \n",
+    "    \n",
+    "model.add(Conv2D(filters=128, kernel_size=(3, 3), activation='relu', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model.add(BatchNormalization())\n",
+    "model.add(Dropout(0.25))\n",
+    "\n",
+    "model.add(Flatten())\n",
+    "model.add(Dense(512, activation='relu'))\n",
+    "model.add(BatchNormalization())\n",
+    "model.add(Dropout(0.5))\n",
+    "model.add(Dense(128, activation='relu'))\n",
+    "model.add(BatchNormalization())\n",
+    "model.add(Dropout(0.5))\n",
+    "model.add(Dense(5, activation='softmax'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "funny-creature",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:30.737518Z",
+     "iopub.status.busy": "2021-04-25T14:14:30.735656Z",
+     "iopub.status.idle": "2021-04-25T14:14:30.738148Z",
+     "shell.execute_reply": "2021-04-25T14:14:30.738596Z"
+    },
+    "papermill": {
+     "duration": 0.067155,
+     "end_time": "2021-04-25T14:14:30.738747",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:30.671592",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#Adam\n",
+    "optimizer = tf.keras.optimizers.Adam(learning_rate=0.01, beta_1=0.9, beta_2=0.999)\n",
+    "\n",
+    "# SGD \n",
+    "optimizer_sgd = tf.keras.optimizers.SGD(learning_rate=0.01)\n",
+    "\n",
+    "# RMSProp\n",
+    "optimizer_rmsprop = tf.keras.optimizers.RMSprop(learning_rate=0.01)\n",
+    "\n",
+    "# Adagrad\n",
+    "optimizer_adagrad = tf.keras.optimizers.Adagrad(learning_rate=0.01)\n",
+    "\n",
+    "# Adadelta\n",
+    "optimizer_adadelta = tf.keras.optimizers.Adadelta(learning_rate=0.01)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dried-literature",
+   "metadata": {
+    "papermill": {
+     "duration": 0.057064,
+     "end_time": "2021-04-25T14:14:30.853420",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:30.796356",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Comparision of different optimizer on Train data in model1:\n",
+    "\n",
+    "\n",
+    "\n",
+    "1. **AdamGrad ( Learning rate : 0.01 ) :**\n",
+    "\n",
+    "- Epoch 1/5\n",
+    "375/375 - 254s - loss: 1.3776 - accuracy: 0.5393 - val_loss: 2.1717 - val_accuracy: 0.3278\n",
+    "- Epoch 2/5\n",
+    "375/375 - 249s - loss: 1.0766 - accuracy: 0.6093 - val_loss: 0.6624 - val_accuracy: 0.7432\n",
+    "- Epoch 3/5\n",
+    "375/375 - 247s - loss: 0.9727 - accuracy: 0.6331 - val_loss: 0.6141 - val_accuracy: 0.7528\n",
+    "- Epoch 4/5\n",
+    "375/375 - 246s - loss: 0.9331 - accuracy: 0.6477 - val_loss: 0.5946 - val_accuracy: 0.7560\n",
+    "- Epoch 5/5\n",
+    "375/375 - 246s - loss: 0.9002 - accuracy: 0.6537 - val_loss: 0.5834 - val_accuracy: 0.7535\n",
+    "\n",
+    "- 188/188 [==============================] - 8s 41ms/step - loss: 0.5530 - accuracy: 0.7613\n",
+    "Loss: 0.5530\n",
+    "Accuracy: 0.7613\n",
+    "\n",
+    "\n",
+    "\n",
+    "2. **Adam ( Learning rate : 0.01 ) :**\n",
+    "\n",
+    "- Epoch 1/5\n",
+    "375/375 - 259s - loss: 0.8156 - accuracy: 0.6819 - val_loss: 1.8547 - val_accuracy: 0.4477\n",
+    "- Epoch 2/5\n",
+    "375/375 - 256s - loss: 0.5948 - accuracy: 0.7591 - val_loss: 0.5780 - val_accuracy: 0.7612\n",
+    "- Epoch 3/5\n",
+    "375/375 - 256s - loss: 0.5337 - accuracy: 0.7834 - val_loss: 0.6188 - val_accuracy: 0.7583\n",
+    "- Epoch 4/5\n",
+    "375/375 - 256s - loss: 0.4951 - accuracy: 0.7986 - val_loss: 0.3815 - val_accuracy: 0.8415\n",
+    "- Epoch 5/5\n",
+    "375/375 - 256s - loss: 0.4789 - accuracy: 0.8052 - val_loss: 0.4912 - val_accuracy: 0.7988\n",
+    "\n",
+    "\n",
+    "- 188/188 [==============================] - 8s 43ms/step - loss: 0.4644 - accuracy: 0.8085\n",
+    "Loss: 0.4644\n",
+    "Accuracy: 0.8085\n",
+    "\n",
+    "======================================\n",
+    "\n",
+    "3. **SGD ( Learning rate : 0.01 ) :**\n",
+    "\n",
+    "- Epoch 1/5\n",
+    "375/375 - 232s - loss: 1.6960 - accuracy: 0.4583 - val_loss: 3.2621 - val_accuracy: 0.2008\n",
+    "- Epoch 2/5\n",
+    "375/375 - 232s - loss: 1.3080 - accuracy: 0.5543 - val_loss: 0.8120 - val_accuracy: 0.6838\n",
+    "- Epoch 3/5\n",
+    "375/375 - 234s - loss: 1.1773 - accuracy: 0.5765 - val_loss: 0.7603 - val_accuracy: 0.6918\n",
+    "- Epoch 4/5\n",
+    "375/375 - 227s - loss: 1.0984 - accuracy: 0.5939 - val_loss: 0.7157 - val_accuracy: 0.7072\n",
+    "- Epoch 5/5\n",
+    "375/375 - 227s - loss: 1.0482 - accuracy: 0.6044 - val_loss: 0.6966 - val_accuracy: 0.7113\n",
+    "\n",
+    "- 188/188 [==============================] - 7s 37ms/step - loss: 0.6966 - accuracy: 0.7113\n",
+    "Loss: 0.6966\n",
+    "Accuracy: 0.7113\n",
+    "\n",
+    "\n",
+    "4. **RMSProp ( Learning rate : 0.01 ) :**\n",
+    "\n",
+    "- Epoch 1/5\n",
+    "375/375 - 278s - loss: 0.8272 - accuracy: 0.6795 - val_loss: 1.2462 - val_accuracy: 0.4917\n",
+    "- Epoch 2/5\n",
+    "375/375 - 268s - loss: 0.5720 - accuracy: 0.7679 - val_loss: 0.4691 - val_accuracy: 0.8070\n",
+    "- Epoch 3/5\n",
+    "375/375 - 266s - loss: 0.5047 - accuracy: 0.7982 - val_loss: 0.4190 - val_accuracy: 0.8362\n",
+    "- Epoch 4/5\n",
+    "375/375 - 269s - loss: 0.4752 - accuracy: 0.8092 - val_loss: 0.4911 - val_accuracy: 0.8118\n",
+    "- Epoch 5/5\n",
+    "375/375 - 271s - loss: 0.4527 - accuracy: 0.8188 - val_loss: 0.5517 - val_accuracy: 0.7843\n",
+    "\n",
+    "- 188/188 [==============================] - 8s 44ms/step - loss: 0.5517 - accuracy: 0.7843\n",
+    "Loss: 0.5517\n",
+    "Accuracy: 0.7843\n",
+    "\n",
+    "\n",
+    "5. **Adadelta ( Learning rate : 0.01 ) :**\n",
+    "\n",
+    "- Epoch 1/5\n",
+    "375/375 - 265s - loss: 2.2840 - accuracy: 0.2971 - val_loss: 2.6322 - val_accuracy: 0.2008\n",
+    "- Epoch 2/5\n",
+    "375/375 - 261s - loss: 1.9450 - accuracy: 0.3816 - val_loss: 1.2628 - val_accuracy: 0.5022\n",
+    "- Epoch 3/5\n",
+    "375/375 - 261s - loss: 1.7921 - accuracy: 0.4280 - val_loss: 1.0999 - val_accuracy: 0.5840\n",
+    "- Epoch 4/5\n",
+    "375/375 - 260s - loss: 1.7350 - accuracy: 0.4508 - val_loss: 1.0728 - val_accuracy: 0.5983\n",
+    "- Epoch 5/5\n",
+    "375/375 - 255s - loss: 1.6791 - accuracy: 0.4668 - val_loss: 1.0540 - val_accuracy: 0.6050\n",
+    "\n",
+    "- 188/188 [==============================] - 8s 43ms/step - loss: 1.0540 - accuracy: 0.6050\n",
+    "Loss: 1.0540\n",
+    "Accuracy: 0.6050\n",
+    "\n",
+    "**Note:** \n",
+    "We restart session on each optimizer testing so that model not learn again on last session."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "closing-number",
+   "metadata": {
+    "papermill": {
+     "duration": 0.060534,
+     "end_time": "2021-04-25T14:14:30.973260",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:30.912726",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    " ### Analysis of optimizers :\n",
+    "\n",
+    "- From above result we can see that 'adam' optimizer achieve highest accuracy so for each CNN in this data we are going to use adam optimizer.\n",
+    "\n",
+    "**Parameters for Adam optimizer:**\n",
+    "\n",
+    "- learning rate : the learning rate is a configurable hyperparameter used in the training of neural networks. The learning rate controls how quickly the model is adapted to the problem.\n",
+    "- beta1 : The exponential decay rate for the first moment estimates (e.g. 0.9).\n",
+    "- beta2 : The exponential decay rate for the second-moment estimates (e.g. 0.999).\n",
+    "\n",
+    "![](http://miro.medium.com/max/660/1*_osB82GKHBOT8k1idLqiqA.gif)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "enabling-hepatitis",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:31.101424Z",
+     "iopub.status.busy": "2021-04-25T14:14:31.100454Z",
+     "iopub.status.idle": "2021-04-25T14:14:31.107327Z",
+     "shell.execute_reply": "2021-04-25T14:14:31.106876Z"
+    },
+    "papermill": {
+     "duration": 0.075624,
+     "end_time": "2021-04-25T14:14:31.107448",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:31.031824",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model.compile(optimizer=optimizer, loss=\"categorical_crossentropy\", metrics=[\"accuracy\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "jewish-college",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:31.237822Z",
+     "iopub.status.busy": "2021-04-25T14:14:31.234827Z",
+     "iopub.status.idle": "2021-04-25T14:14:31.245076Z",
+     "shell.execute_reply": "2021-04-25T14:14:31.244449Z"
+    },
+    "papermill": {
+     "duration": 0.076523,
+     "end_time": "2021-04-25T14:14:31.245227",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:31.168704",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: \"sequential\"\n",
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "conv2d (Conv2D)              (None, 28, 28, 32)        320       \n",
+      "_________________________________________________________________\n",
+      "batch_normalization (BatchNo (None, 28, 28, 32)        128       \n",
+      "_________________________________________________________________\n",
+      "conv2d_1 (Conv2D)            (None, 28, 28, 32)        9248      \n",
+      "_________________________________________________________________\n",
+      "batch_normalization_1 (Batch (None, 28, 28, 32)        128       \n",
+      "_________________________________________________________________\n",
+      "dropout (Dropout)            (None, 28, 28, 32)        0         \n",
+      "_________________________________________________________________\n",
+      "conv2d_2 (Conv2D)            (None, 28, 28, 64)        18496     \n",
+      "_________________________________________________________________\n",
+      "max_pooling2d (MaxPooling2D) (None, 14, 14, 64)        0         \n",
+      "_________________________________________________________________\n",
+      "dropout_1 (Dropout)          (None, 14, 14, 64)        0         \n",
+      "_________________________________________________________________\n",
+      "conv2d_3 (Conv2D)            (None, 14, 14, 128)       73856     \n",
+      "_________________________________________________________________\n",
+      "batch_normalization_2 (Batch (None, 14, 14, 128)       512       \n",
+      "_________________________________________________________________\n",
+      "dropout_2 (Dropout)          (None, 14, 14, 128)       0         \n",
+      "_________________________________________________________________\n",
+      "flatten (Flatten)            (None, 25088)             0         \n",
+      "_________________________________________________________________\n",
+      "dense (Dense)                (None, 512)               12845568  \n",
+      "_________________________________________________________________\n",
+      "batch_normalization_3 (Batch (None, 512)               2048      \n",
+      "_________________________________________________________________\n",
+      "dropout_3 (Dropout)          (None, 512)               0         \n",
+      "_________________________________________________________________\n",
+      "dense_1 (Dense)              (None, 128)               65664     \n",
+      "_________________________________________________________________\n",
+      "batch_normalization_4 (Batch (None, 128)               512       \n",
+      "_________________________________________________________________\n",
+      "dropout_4 (Dropout)          (None, 128)               0         \n",
+      "_________________________________________________________________\n",
+      "dense_2 (Dense)              (None, 5)                 645       \n",
+      "=================================================================\n",
+      "Total params: 13,017,125\n",
+      "Trainable params: 13,015,461\n",
+      "Non-trainable params: 1,664\n",
+      "_________________________________________________________________\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "impressive-jacob",
+   "metadata": {
+    "papermill": {
+     "duration": 0.056908,
+     "end_time": "2021-04-25T14:14:31.360209",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:31.303301",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Comparision of LearningRateScheduler and ReduceLROnPlateau :\n",
+    "\n",
+    "**LearningRateScheduler :**\n",
+    "- We should tuned our learning so that it is not too high to take very large steps, neither it should be too small which not change weights and bias of the model.\n",
+    "- We use LearningRateScheduler here, which takes the step decay function as argument and return the updated learning rates for use in optimzer at every epoch stage.So at every epoch learning rate will be change by LearningRateScheduler.\n",
+    "- LearningRateScheduler callback that allows us to specify a function that is called each epoch in order to adjust the learning rate.\n",
+    "\n",
+    "**ReduceLROnPlateau :**\n",
+    "- As an alternate solution of LearningRateScheduler we can also use ReduceLROnPlateau.\n",
+    "- The ReduceLROnPlateau that will adjust the learning rate when a plateau in model performance is detected.\n",
+    "- This callback is designed to reduce the learning rate after the model stops improving with the hope of fine-tuning model weights.\n",
+    "- ReduceLROnPlateau works like EarlyStopping, with three parameters: monitor, patience and mode.\n",
+    "\n",
+    "**We test both approach on model1 using train data, below is result :**\n",
+    "\n",
+    "#### LearningRateScheduler result :\n",
+    "\n",
+    "Epoch 1/10\n",
+    "375/375 - 22s - loss: 0.8385 - accuracy: 0.6747 - val_loss: 2.2334 - val_accuracy: 0.3228\n",
+    "\n",
+    "Epoch 2/10\n",
+    "375/375 - 16s - loss: 0.5952 - accuracy: 0.7586 - val_loss: 0.4966 - val_accuracy: 0.7923\n",
+    "\n",
+    "Epoch 3/10\n",
+    "375/375 - 17s - loss: 0.5389 - accuracy: 0.7831 - val_loss: 0.3984 - val_accuracy: 0.8392\n",
+    "\n",
+    "Epoch 4/10\n",
+    "375/375 - 16s - loss: 0.5076 - accuracy: 0.7933 - val_loss: 0.3561 - val_accuracy: 0.8537\n",
+    "\n",
+    "Epoch 5/10\n",
+    "375/375 - 17s - loss: 0.4805 - accuracy: 0.8073 - val_loss: 0.4016 - val_accuracy: 0.8385\n",
+    "\n",
+    "Epoch 6/10\n",
+    "375/375 - 16s - loss: 0.4586 - accuracy: 0.8132 - val_loss: 0.3974 - val_accuracy: 0.8353\n",
+    "\n",
+    "Epoch 7/10\n",
+    "375/375 - 17s - loss: 0.4435 - accuracy: 0.8237 - val_loss: 0.3501 - val_accuracy: 0.8588\n",
+    "\n",
+    "Epoch 8/10\n",
+    "375/375 - 16s - loss: 0.4259 - accuracy: 0.8298 - val_loss: 0.3469 - val_accuracy: 0.8550\n",
+    "\n",
+    "Epoch 9/10\n",
+    "375/375 - 17s - loss: 0.4135 - accuracy: 0.8346 - val_loss: 0.5395 - val_accuracy: 0.7760\n",
+    "\n",
+    "Epoch 10/10\n",
+    "375/375 - 16s - loss: 0.4111 - accuracy: 0.8370 - val_loss: 0.3105 - val_accuracy: **0.8717**\n",
+    "\n",
+    "#### ReduceLROnPlateau result :\n",
+    "\n",
+    "Epoch 1/10\n",
+    "375/375 - 19s - loss: 0.7770 - accuracy: 0.6837 - val_loss: 1.3474 - val_accuracy: 0.5248\n",
+    "\n",
+    "Epoch 2/10\n",
+    "375/375 - 14s - loss: 0.6540 - accuracy: 0.7333 - val_loss: 0.6390 - val_accuracy: 0.7378\n",
+    "\n",
+    "Epoch 3/10\n",
+    "375/375 - 14s - loss: 0.5939 - accuracy: 0.7584 - val_loss: 2.8995 - val_accuracy: 0.5407\n",
+    "\n",
+    "Epoch 4/10\n",
+    "375/375 - 14s - loss: 0.5605 - accuracy: 0.7715 - val_loss: 0.3914 - val_accuracy: 0.8387\n",
+    "\n",
+    "Epoch 5/10\n",
+    "375/375 - 14s - loss: 0.5332 - accuracy: 0.7827 - val_loss: 4.3203 - val_accuracy: 0.3747\n",
+    "\n",
+    "Epoch 6/10\n",
+    "375/375 - 14s - loss: 0.5202 - accuracy: 0.7917 - val_loss: 0.5354 - val_accuracy: 0.8003\n",
+    "\n",
+    "Epoch 7/10\n",
+    "375/375 - 13s - loss: 0.4950 - accuracy: 0.7994 - val_loss: 0.5384 - val_accuracy: 0.7745\n",
+    "\n",
+    "Epoch 8/10\n",
+    "375/375 - 15s - loss: 0.4846 - accuracy: 0.8050 - val_loss: 0.6269 - val_accuracy: 0.7897\n",
+    "\n",
+    "Epoch 9/10\n",
+    "375/375 - 14s - loss: 0.4729 - accuracy: 0.8099 - val_loss: 0.4836 - val_accuracy: 0.8022\n",
+    "\n",
+    "Epoch 10/10\n",
+    "375/375 - 14s - loss: 0.4363 - accuracy: 0.8248 - val_loss: 0.3205 - val_accuracy: **0.8705**\n",
+    "\n",
+    "\n",
+    "**Note :**\n",
+    "We restart a session on each testing for Learning rate decay."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "failing-bridal",
+   "metadata": {
+    "papermill": {
+     "duration": 0.061123,
+     "end_time": "2021-04-25T14:14:31.480704",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:31.419581",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Analysis of LearningRateSchedular and ReduceLROnPlateau :\n",
+    "\n",
+    "- From above result it can be seen that both works pretty same in terms of accuracy and loss but in ReduceLROnPlateau accuracy fluctuate more so we are going to use LearningRateSchedular on this model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "excited-registrar",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:31.610243Z",
+     "iopub.status.busy": "2021-04-25T14:14:31.609441Z",
+     "iopub.status.idle": "2021-04-25T14:14:31.612267Z",
+     "shell.execute_reply": "2021-04-25T14:14:31.612693Z"
+    },
+    "papermill": {
+     "duration": 0.069735,
+     "end_time": "2021-04-25T14:14:31.612841",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:31.543106",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "reduce_lr = LearningRateScheduler(lambda x: 1e-3 * 0.9 ** x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "corrected-front",
+   "metadata": {
+    "papermill": {
+     "duration": 0.061208,
+     "end_time": "2021-04-25T14:14:31.734459",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:31.673251",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "approximate-count",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:31.861010Z",
+     "iopub.status.busy": "2021-04-25T14:14:31.860099Z",
+     "iopub.status.idle": "2021-04-25T14:14:31.863784Z",
+     "shell.execute_reply": "2021-04-25T14:14:31.864417Z"
+    },
+    "papermill": {
+     "duration": 0.069613,
+     "end_time": "2021-04-25T14:14:31.864581",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:31.794968",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#Learning Rate Annealer\n",
+    "lrr= ReduceLROnPlateau(monitor='val_accuracy', factor=.01,  patience=3, min_lr=1e-5) \n",
+    "\n",
+    "\n",
+    "lr_reducer = ReduceLROnPlateau(factor=np.sqrt(0.1),\n",
+    "                               cooldown=0,\n",
+    "                               patience=5,\n",
+    "                               min_lr=0.5e-6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "intended-account",
+   "metadata": {
+    "papermill": {
+     "duration": 0.061458,
+     "end_time": "2021-04-25T14:14:31.988551",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:31.927093",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Data Augmentation :\n",
+    "\n",
+    "- Data Augmentation is like adding a data and/or noise to a dataset, so that model can perform well in various patterns.\n",
+    "- For example, what if our images will have object at some angle ? In that case mostly our model will fail to predict right label.\n",
+    "- So using data augmentation our model will build with different variations so that model performance on variety of input will remain same."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "republican-playlist",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:32.125903Z",
+     "iopub.status.busy": "2021-04-25T14:14:32.124995Z",
+     "iopub.status.idle": "2021-04-25T14:14:32.128143Z",
+     "shell.execute_reply": "2021-04-25T14:14:32.127653Z"
+    },
+    "papermill": {
+     "duration": 0.079573,
+     "end_time": "2021-04-25T14:14:32.128260",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:32.048687",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "datagen = ImageDataGenerator(\n",
+    "        rotation_range = 8,  # randomly rotate images in the range (degrees, 0 to 180)\n",
+    "        zoom_range = 0.1, # Randomly zoom image \n",
+    "        shear_range = 0.3,# shear angle in counter-clockwise direction in degrees  \n",
+    "        width_shift_range=0.08,  # randomly shift images horizontally (fraction of total width)\n",
+    "        height_shift_range=0.08,  # randomly shift images vertically (fraction of total height)\n",
+    "        vertical_flip=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "chinese-reception",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:32.254135Z",
+     "iopub.status.busy": "2021-04-25T14:14:32.253037Z",
+     "iopub.status.idle": "2021-04-25T14:14:32.372396Z",
+     "shell.execute_reply": "2021-04-25T14:14:32.371854Z"
+    },
+    "papermill": {
+     "duration": 0.182989,
+     "end_time": "2021-04-25T14:14:32.372541",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:32.189552",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "datagen.fit(x_train)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "worse-challenge",
+   "metadata": {
+    "papermill": {
+     "duration": 0.060357,
+     "end_time": "2021-04-25T14:14:32.493849",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:32.433492",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Model fitting :\n",
+    "- batch size : The batch size is a hyperparameter that defines the number of samples to work through before updating the internal model parameters.\n",
+    "- epochs : The number of epochs is a hyperparameter that defines the number times that the learning algorithm will work through the entire training dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "former-thesis",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:32.618556Z",
+     "iopub.status.busy": "2021-04-25T14:14:32.616814Z",
+     "iopub.status.idle": "2021-04-25T14:14:32.619223Z",
+     "shell.execute_reply": "2021-04-25T14:14:32.619690Z"
+    },
+    "papermill": {
+     "duration": 0.065797,
+     "end_time": "2021-04-25T14:14:32.619835",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:32.554038",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "batch_size = 128\n",
+    "epochs = 25"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "intelligent-transportation",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:14:32.749740Z",
+     "iopub.status.busy": "2021-04-25T14:14:32.748660Z",
+     "iopub.status.idle": "2021-04-25T14:21:16.069406Z",
+     "shell.execute_reply": "2021-04-25T14:21:16.068690Z"
+    },
+    "papermill": {
+     "duration": 403.387267,
+     "end_time": "2021-04-25T14:21:16.069575",
+     "exception": false,
+     "start_time": "2021-04-25T14:14:32.682308",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/25\n",
+      "375/375 - 21s - loss: 0.8174 - accuracy: 0.6812 - val_loss: 1.4310 - val_accuracy: 0.3890\n",
+      "Epoch 2/25\n",
+      "375/375 - 17s - loss: 0.5886 - accuracy: 0.7617 - val_loss: 0.4809 - val_accuracy: 0.7988\n",
+      "Epoch 3/25\n",
+      "375/375 - 16s - loss: 0.5306 - accuracy: 0.7863 - val_loss: 0.5203 - val_accuracy: 0.7840\n",
+      "Epoch 4/25\n",
+      "375/375 - 17s - loss: 0.5002 - accuracy: 0.7967 - val_loss: 0.6418 - val_accuracy: 0.7638\n",
+      "Epoch 5/25\n",
+      "375/375 - 16s - loss: 0.4767 - accuracy: 0.8065 - val_loss: 0.3829 - val_accuracy: 0.8400\n",
+      "Epoch 6/25\n",
+      "375/375 - 16s - loss: 0.4544 - accuracy: 0.8167 - val_loss: 0.3477 - val_accuracy: 0.8613\n",
+      "Epoch 7/25\n",
+      "375/375 - 15s - loss: 0.4434 - accuracy: 0.8235 - val_loss: 0.3579 - val_accuracy: 0.8470\n",
+      "Epoch 8/25\n",
+      "375/375 - 16s - loss: 0.4309 - accuracy: 0.8288 - val_loss: 0.3356 - val_accuracy: 0.8640\n",
+      "Epoch 9/25\n",
+      "375/375 - 16s - loss: 0.4189 - accuracy: 0.8325 - val_loss: 0.3361 - val_accuracy: 0.8632\n",
+      "Epoch 10/25\n",
+      "375/375 - 16s - loss: 0.4081 - accuracy: 0.8375 - val_loss: 0.3611 - val_accuracy: 0.8492\n",
+      "Epoch 11/25\n",
+      "375/375 - 16s - loss: 0.4022 - accuracy: 0.8412 - val_loss: 0.5019 - val_accuracy: 0.7995\n",
+      "Epoch 12/25\n",
+      "375/375 - 16s - loss: 0.3919 - accuracy: 0.8443 - val_loss: 0.3263 - val_accuracy: 0.8632\n",
+      "Epoch 13/25\n",
+      "375/375 - 16s - loss: 0.3874 - accuracy: 0.8459 - val_loss: 0.3056 - val_accuracy: 0.8722\n",
+      "Epoch 14/25\n",
+      "375/375 - 17s - loss: 0.3812 - accuracy: 0.8479 - val_loss: 0.3062 - val_accuracy: 0.8727\n",
+      "Epoch 15/25\n",
+      "375/375 - 16s - loss: 0.3767 - accuracy: 0.8518 - val_loss: 0.3809 - val_accuracy: 0.8375\n",
+      "Epoch 16/25\n",
+      "375/375 - 16s - loss: 0.3707 - accuracy: 0.8504 - val_loss: 0.3551 - val_accuracy: 0.8477\n",
+      "Epoch 17/25\n",
+      "375/375 - 15s - loss: 0.3648 - accuracy: 0.8555 - val_loss: 0.3370 - val_accuracy: 0.8567\n",
+      "Epoch 18/25\n",
+      "375/375 - 15s - loss: 0.3602 - accuracy: 0.8571 - val_loss: 0.3126 - val_accuracy: 0.8730\n",
+      "Epoch 19/25\n",
+      "375/375 - 17s - loss: 0.3532 - accuracy: 0.8616 - val_loss: 0.3627 - val_accuracy: 0.8478\n",
+      "Epoch 20/25\n",
+      "375/375 - 15s - loss: 0.3537 - accuracy: 0.8615 - val_loss: 0.3348 - val_accuracy: 0.8605\n",
+      "Epoch 21/25\n",
+      "375/375 - 15s - loss: 0.3478 - accuracy: 0.8630 - val_loss: 0.3414 - val_accuracy: 0.8570\n",
+      "Epoch 22/25\n",
+      "375/375 - 15s - loss: 0.3470 - accuracy: 0.8624 - val_loss: 0.3961 - val_accuracy: 0.8330\n",
+      "Epoch 23/25\n",
+      "375/375 - 15s - loss: 0.3465 - accuracy: 0.8626 - val_loss: 0.4215 - val_accuracy: 0.8218\n",
+      "Epoch 24/25\n",
+      "375/375 - 15s - loss: 0.3406 - accuracy: 0.8646 - val_loss: 0.3983 - val_accuracy: 0.8342\n",
+      "Epoch 25/25\n",
+      "375/375 - 16s - loss: 0.3368 - accuracy: 0.8658 - val_loss: 0.3320 - val_accuracy: 0.8600\n",
+      "---Total time in Model 1 : 403.25328826904297 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "history = model.fit(datagen.flow(x_train, y_train, batch_size = batch_size), epochs = epochs, \n",
+    "                              validation_data = (x_val, y_val), verbose=2, \n",
+    "                              steps_per_epoch=x_train.shape[0] // batch_size,\n",
+    "                              callbacks = [reduce_lr])\n",
+    "\n",
+    "print(\"---Total time in Model 1 : %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "legendary-christianity",
+   "metadata": {
+    "papermill": {
+     "duration": 0.070153,
+     "end_time": "2021-04-25T14:21:16.209710",
+     "exception": false,
+     "start_time": "2021-04-25T14:21:16.139557",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Model 1 Evaluation "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "designing-interface",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:21:16.353820Z",
+     "iopub.status.busy": "2021-04-25T14:21:16.352703Z",
+     "iopub.status.idle": "2021-04-25T14:21:16.946908Z",
+     "shell.execute_reply": "2021-04-25T14:21:16.946472Z"
+    },
+    "papermill": {
+     "duration": 0.668904,
+     "end_time": "2021-04-25T14:21:16.947053",
+     "exception": false,
+     "start_time": "2021-04-25T14:21:16.278149",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "188/188 [==============================] - 1s 3ms/step - loss: 0.3320 - accuracy: 0.8600\n",
+      "Loss: 0.3320\n",
+      "Accuracy: 0.8600\n",
+      "--- 0.5913808345794678 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "score = model.evaluate(x_val, y_val)\n",
+    "print('Loss: {:.4f}'.format(score[0]))\n",
+    "print('Accuracy: {:.4f}'.format(score[1]))\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "blond-concern",
+   "metadata": {
+    "papermill": {
+     "duration": 0.07196,
+     "end_time": "2021-04-25T14:21:17.093297",
+     "exception": false,
+     "start_time": "2021-04-25T14:21:17.021337",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Model 1 loss vs no. of epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "canadian-chassis",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:21:17.293698Z",
+     "iopub.status.busy": "2021-04-25T14:21:17.293030Z",
+     "iopub.status.idle": "2021-04-25T14:21:17.421248Z",
+     "shell.execute_reply": "2021-04-25T14:21:17.421715Z"
+    },
+    "papermill": {
+     "duration": 0.256558,
+     "end_time": "2021-04-25T14:21:17.421852",
+     "exception": false,
+     "start_time": "2021-04-25T14:21:17.165294",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAEWCAYAAABi5jCmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAA0t0lEQVR4nO3deXxU5dn/8c+Vyb4BWUiAgOwgiyxGreICAiq41V1sVarVRx+rtbbWpa1Y+/i0tbRVW7V1q3Wp/HhUKO4KFfcFXNh3CBKWkATIRva5fn/ckzAJ2ZPJJMz1fr3mNTPnnJlznwzMd+7l3EdUFWOMMaZGWLALYIwxpmuxYDDGGFOHBYMxxpg6LBiMMcbUYcFgjDGmDgsGY4wxdVgwGNMMERkoIioi4S3YdraIfNQZ5TImUCwYzBFFRLJEpEJEUuot/9r35T4wSEVrVcAYE0wWDOZItA2YVfNERMYCscErjjHdiwWDORI9B1zl9/xq4Fn/DUSkh4g8KyK5IrJdRH4pImG+dR4RmSsieSKyFTi7gdc+JSK7RWSniPyPiHjaU2AR6Ssii0Rkn4hsFpHr/NYdLyLLRaRQRHJE5E++5dEi8ryI5IvIARFZJiJp7SmHMWDBYI5MnwGJInK07wv7cuD5etv8BegBDAZOwwXJD3zrrgPOASYAmcDF9V77DFAFDPVtcwbww3aWeR6QDfT17e9/ReR037qHgIdUNREYAsz3Lb/adwz9gWTgBqC0neUwxoLBHLFqag3TgXXAzpoVfmFxl6oWqWoW8EfgSt8mlwIPquoOVd0H/NbvtWnATOBWVS1R1b3An33v1yYi0h+YBNyhqmWq+g3wJIdqPZXAUBFJUdViVf3Mb3kyMFRVq1X1S1UtbGs5jKlhwWCOVM8BVwCzqdeMBKQAEcB2v2XbgX6+x32BHfXW1TjK99rdvuabA8Dfgd7tKGtfYJ+qFjVSnmuB4cB6X3PROb7lzwFvA/NEZJeIPCAiEe0ohzGABYM5Qqnqdlwn9EzglXqr83C/to/yWzaAQ7WK3bjmGf91NXYA5UCKqvb03RJVdXQ7irsLSBKRhIbKo6qbVHUWLnx+D7wkInGqWqmqv1bVUcBJuOavqzCmnSwYzJHsWuB0VS3xX6iq1bh2+vtFJEFEjgJu41A/xHzgFhHJEJFewJ1+r90NvAP8UUQSRSRMRIaIyGmtKFeUr+M4WkSicQHwCfBb37JjfGV/HkBEvi8iqarqBQ743sMrIlNEZKyvaawQF3beVpTDmAZZMJgjlqpuUdXljay+GSgBtgIfAf8CnvatewLXRLMC+IrDaxxXAZHAWmA/8BLQpxVFK8Z1EtfcTscNrx2Iqz0sAOao6mLf9mcBa0SkGNcRfbmqlgLpvn0X4vpR3sc1LxnTLmIX6jHGGOPPagzGGGPqsGAwxhhThwWDMcaYOiwYjDHG1NHtZnlMSUnRgQMHBrsYxhjTrXz55Zd5qprakm27XTAMHDiQ5csbG4FojDGmISKyvfmtHGtKMsYYU4cFgzHGmDosGIwxxtTR7foYjDFHjsrKSrKzsykrKwt2UY4Y0dHRZGRkEBHR9ol2LRiMMUGTnZ1NQkICAwcORESCXZxuT1XJz88nOzubQYMGtfl9rCnJGBM0ZWVlJCcnWyh0EBEhOTm53TUwCwZjTFBZKHSsjvh7hk4w5KyBJffBwX3BLokxxnRpoRMM+7bCh3+Eguxgl8QY00Xk5+czfvx4xo8fT3p6Ov369at9XlFR0eRrly9fzi233NJJJe1codP5HJPk7g/mB7ccxpguIzk5mW+++QaAe++9l/j4eH72s5/Vrq+qqiI8vOGvyczMTDIzMzujmJ0udGoMscnuvtSakowxjZs9ezY33HADJ5xwAj//+c/54osvOPHEE5kwYQInnXQSGzZsAGDp0qWcc845gAuVa665hsmTJzN48GAefvjhYB5CuwWsxiAiT+MuTr5XVcc0sd1xwKe4yxW+FKjyEFtTY7BgMKYr+vWra1i7q7BD33NU30TmnDu61a/Lzs7mk08+wePxUFhYyIcffkh4eDiLFy/m7rvv5uWXXz7sNevXr+e9996jqKiIESNGcOONN7brXIJgCmRT0jPAX4FnG9vAdxHz3+Murh5YMb3cvQWDMaYZl1xyCR6PB4CCggKuvvpqNm3ahIhQWVnZ4GvOPvtsoqKiiIqKonfv3uTk5JCRkdGZxe4wAQsGVf1ARAY2s9nNwMvAcYEqRy1PBET1sD4GY7qotvyyD5S4uLjax7/61a+YMmUKCxYsICsri8mTJzf4mqioqNrHHo+HqqqqQBczYILWxyAi/YALgMdasO31IrJcRJbn5ua2faexvayPwRjTKgUFBfTr1w+AZ555JriF6STB7Hx+ELhDVb3Nbaiqj6tqpqpmpqa26DoTDYtNthqDMaZVfv7zn3PXXXcxYcKEbl0LaA1R1cC9uWtKeq2hzmcR2QbUnKKXAhwErlfVhU29Z2Zmprb5Qj3PXwwlufBf77ft9caYDrVu3TqOPvroYBfjiNPQ31VEvlTVFo2vDdp5DKpaO8OTiDyDC5CFAd1pbDLkbgjoLowxprsL5HDVF4HJQIqIZANzgAgAVf1boPbbpNgk62MwxphmBHJU0qxWbDs7UOWoIzYJKoqhqhzCo5rf3hhjQlDonPkMftNiWK3BGGMaE1rBYNNiGGNMs0IsGGwiPWOMaU5oBYM1JRlj/EyZMoW33367zrIHH3yQG2+8scHtJ0+eTM1w+ZkzZ3LgwIHDtrn33nuZO3duk/tduHAha9eurX1+zz33sHjx4laWPnBCKxhqmpKsxmCMAWbNmsW8efPqLJs3bx6zZjU/duaNN96gZ8+ebdpv/WC47777mDZtWpveKxBCLBh8NQbrYzDGABdffDGvv/567UV5srKy2LVrFy+++CKZmZmMHj2aOXPmNPjagQMHkpeXB8D999/P8OHDOfnkk2un5QZ44oknOO644xg3bhwXXXQRBw8e5JNPPmHRokXcfvvtjB8/ni1btjB79mxeeslNLr1kyRImTJjA2LFjueaaaygvL6/d35w5c5g4cSJjx45l/fr1Afu7hM6FesANUY2Mt6YkY7qiN++EPas69j3Tx8KM3zW6OikpieOPP54333yT888/n3nz5nHppZdy9913k5SURHV1NVOnTmXlypUcc8wxDb7Hl19+ybx58/jmm2+oqqpi4sSJHHvssQBceOGFXHfddQD88pe/5KmnnuLmm2/mvPPO45xzzuHiiy+u815lZWXMnj2bJUuWMHz4cK666ioee+wxbr31VgBSUlL46quvePTRR5k7dy5PPvlkB/yRDhdaNQZw/QwWDMYYH//mpJpmpPnz5zNx4kQmTJjAmjVr6jT71Pfhhx9ywQUXEBsbS2JiIuedd17tutWrV3PKKacwduxYXnjhBdasWdNkWTZs2MCgQYMYPnw4AFdffTUffPBB7foLL7wQgGOPPZasrKy2HnKzQqvGAK45yfoYjOl6mvhlH0jnn38+P/nJT/jqq684ePAgSUlJzJ07l2XLltGrVy9mz55NWVlZm9579uzZLFy4kHHjxvHMM8+wdOnSdpW1ZmrvQE/rHXo1BpsWwxjjJz4+nilTpnDNNdcwa9YsCgsLiYuLo0ePHuTk5PDmm282+fpTTz2VhQsXUlpaSlFREa+++mrtuqKiIvr06UNlZSUvvPBC7fKEhASKiooOe68RI0aQlZXF5s2bAXjuuec47bTTOuhIWy4EgyHZmpKMMXXMmjWLFStWMGvWLMaNG8eECRMYOXIkV1xxBZMmTWrytRMnTuSyyy5j3LhxzJgxg+OOO3Tdsd/85jeccMIJTJo0iZEjR9Yuv/zyy/nDH/7AhAkT2LJlS+3y6Oho/vGPf3DJJZcwduxYwsLCuOGGGzr+gJsR0Gm3A6Fd024DvPFzWDEP7vq24wpljGkTm3Y7MNo77XZo1hjKC6C64eu2GmNMqAvBYKg5l2F/cMthjDFdVOgFQ0wvd2/9DMZ0Cd2tObur64i/Z+gFg02LYUyXER0dTX5+voVDB1FV8vPziY6Obtf7hOZ5DGBDVo3pAjIyMsjOziY3NzfYRTliREdHk5GR0a73CMFgsBqDMV1FREQEgwYNan5D06lCrynJpt42xpgmhV4wRMZCeIzVGIwxphGhFwzgmxbDhqsaY0xDQjcYrMZgjDENCs1gsKm3jTGmUaEZDLHJNlzVGGMaEaLBYE1JxhjTmNAMhpgkKD0A3upgl8QYY7qcgAWDiDwtIntFZHUj678nIitFZJWIfCIi4wJVlsPEJgPqwsEYY0wdgawxPAOc1cT6bcBpqjoW+A3weADLUpdNi2GMMY0KWDCo6gdAo9+8qvqJqtacTPAZ0L7JPVqjJhisn8EYYw7TVfoYrgUavbCqiFwvIstFZHmHTLZl02IYY0yjgh4MIjIFFwx3NLaNqj6uqpmqmpmamtr+ndpEesYY06igzq4qIscATwIzVLXzvqWtj8EYYxoVtBqDiAwAXgGuVNWNnbrzyHjwRFqNwRhjGhCwGoOIvAhMBlJEJBuYA0QAqOrfgHuAZOBREQGoUtXMQJWnXuFsWgxjjGlEwIJBVWc1s/6HwA8Dtf9mxSbbDKvGGNOAoHc+B41Ni2GMMQ0K3WCI6WVNScYY04DQDYbYZKsxGGNMA0I4GHxXcfN6g10SY4zpUkI4GJJBq6G8INglMcaYLiV0g8GmxTDGmAaFbjDUTothwWCMMf5COBhsWgxjjGmIBYONTDLGmDpCNxisj8EYYxoUusEQ3QPEY01JxhhTT+gGg4hNi2GMMQ0I3WAAm2HVGGMaENrBEJtswWCMMfWEeDAkWR+DMcbUY8FgfQzGGFNHaAdDTR+DarBLYowxXUZoB0NsMngrobwo2CUxxpguI8SDwabFMMaY+kI8GGom0rN+BmOMqRHawVA7Lcb+4JbDGGO6kNAOhpoagzUlGWNMrRAPBpth1Rhj6gvtYIjuAYid/WyMMX5COxjCPBDTy2oMxhjjJ7SDAWxaDGOMqSdgwSAiT4vIXhFZ3ch6EZGHRWSziKwUkYmBKkuTYpOtxmCMMX4CWWN4BjirifUzgGG+2/XAYwEsS+Nikmy4qjHG+AlYMKjqB0BTbTTnA8+q8xnQU0T6BKo8jbIagzHG1BHMPoZ+wA6/59m+ZYcRketFZLmILM/Nze3YUsT2cn0MNpGeMcYA3aTzWVUfV9VMVc1MTU3t2DePTYaqMqg82LHva4wx3VQwg2En0N/veYZvWeeqnRbDRiYZYwwENxgWAVf5Rid9ByhQ1d2dXgqbSM8YY+oID9Qbi8iLwGQgRUSygTlABICq/g14A5gJbAYOAj8IVFmaZFNvG2NMHQELBlWd1cx6BW4K1P5bzJqSjDGmjm7R+RxQtU1JFgzGGAMWDG6uJLCmJGOM8bFg8IS7WVat89kYYwALBicmyZqSjDHGx4IBbFoMY4zxY8EANvW2Mcb4sWAAX43BgsEYY8CCwbE+BmOMqWXBAK4pqbIEKsuCXRJjjAm6FgWDiMSJSJjv8XAROU9EIgJbtE5k02IYY0ytltYYPgCiRaQf8A5wJe4KbUcGmxbDGGNqtTQYRFUPAhcCj6rqJcDowBWrk9kMq8YYU6vFwSAiJwLfA173LfMEpkhBYE1JxhhTq6XBcCtwF7BAVdeIyGDgvYCVqrNZjcEYY2q1aNptVX0feB/A1wmdp6q3BLJgnaq2j2F/cMthjDFdQEtHJf1LRBJFJA5YDawVkdsDW7ROFB4JkQlWYzDGGFrelDRKVQuB7wJvAoNwI5OOHLG9rI/BGGNoeTBE+M5b+C6wSFUrAQ1YqYLBJtIzxhig5cHwdyALiAM+EJGjgMJAFSoobFoMY4wBWhgMqvqwqvZT1ZnqbAemBLhsnctqDMYYA7S887mHiPxJRJb7bn/E1R6OHLFJUGqjkowxpqVNSU8DRcClvlsh8I9AFSooYpKgvBCqK4NdEmOMCaoWnccADFHVi/ye/1pEvglAeYIn1m++pIS04JbFGGOCqKU1hlIRObnmiYhMAkoDU6QgsWkxjDEGaHmN4QbgWRHp4Xu+H7g6MEUKEpsWwxhjgJaPSlqhquOAY4BjVHUCcHpAS9bBPtmcx/mPfExBaSN9CDb1tjHGAK28gpuqFvrOgAa4rbntReQsEdkgIptF5M4G1g8QkfdE5GsRWSkiM1tTntaIjvSwYscB3lu/t+ENrMZgjDFA+y7tKU2uFPEAjwAzgFHALBEZVW+zXwLzfTWQy4FH21GeJo3P6EnvhCjeXrOn4Q2sj8EYY4D2BUNzU2IcD2xW1a2qWgHMA85v4D0SfY97ALvaUZ4mhYUJ00elsXRDLmWV1YdvEBEDEbHWlGSMCXlNBoOIFIlIYQO3IqBvM+/dD9jh9zzbt8zfvcD3RSQbeAO4uZFyXF9zcl1ubm4zu23cmaPTKa2s5qNNeQ1vYNNiGGNM08GgqgmqmtjALUFVWzqiqSmzgGdUNQOYCTznu95D/XI8rqqZqpqZmpra5p19Z3AyCdHhTTcnWR+DMSbEtacpqTk7gf5+zzN8y/xdC8wHUNVPgWggJVAFigwPY+rI3ixel0NVtffwDWKTrI/BGBPyAhkMy4BhIjJIRCJxncuL6m3zLTAVQESOxgVD29uKWuDM0ensP1jJsqwG5kWKsRqDMcYELBhUtQr4EfA2sA43+miNiNwnIuf5NvspcJ2IrABeBGarakCv83Dq8FQiw8Mabk6KTbY+BmNMyOuIfoJGqeobuE5l/2X3+D1eC0wKZBnqi4sK59RhKby7Noc5545CxG/UbWwSlBVAdRV4AvqnMcaYLiuQTUld1hmj09l5oJQ1u+pdayg2GVAoOxCMYhljTJcQksEw7eg0woTDm5NsWgxjjAnNYEiKi+T4QUmHB0Pt1NvWAW2MCV0hGQwAZ4xKZ2NOMdvySg4ttGkxjDEmhINhtLsYzzv+tQabSM8YY0I3GDJ6xTKmX2Ld5iTrYzDGmNANBoAzR6Xz1bcH2FtY5hZExoEn0moMxpiQFtrBMCYdgHfW5rgFIq45yfoYjDEhLKSDYVjveAYmxx4KBrAZVo0xIS+kg0FEOHN0Op9uyaOwzHfJz1gLBmNMaAvpYAB3FnRltR665KfNsGqMCXEhHwwT+te75GdssnU+G2NCWsgHw2GX/IxJgtL94G3geg3GGBMCQj4YwDUnHayo5uPNea7GoF6bSM8YE7IsGIAT/S/5WTstRgMX8jHGmBBgwYC75OfpI3uzeN1eqqN7uYXWz2CMCVEWDD5njk5nX0kFawsi3AIbsmqMCVEWDD6n+S75+d63vvMZrMZgjAlRFgw+cVHhnDI0hdc2VbgFdi6DMSZEWTD4OXN0OhsLBJVwqzEYY0KWBYOfqUf3JkyEg+GJ1sdgjAlZFgx+kuOjOG5gEnnVcZ3XlLRnFTw5HQp3d87+jDGmGRYM9Zw5Op09VXGUFeQGfmdeL7z2E8j+Ata/Fvj9GWNMC1gw1DN9VBr7NYGDnREMK16E7GUQFgGblwR+f8YY0wIWDPX0T4qF2CQk0E1JpQdg8RzofwJM+D5s+wCqKgK7T2OMaQELhgakpPYhvrqQvYWlgdvJ0t+6kU8z/wDDpkNlCez4LHD7M8aYFgpoMIjIWSKyQUQ2i8idjWxzqYisFZE1IvKvQJanpQb070+EVLN05ZbA7GDPavjicci8BvqMg4GnQFi4NScZY7qEgAWDiHiAR4AZwChgloiMqrfNMOAuYJKqjgZuDVR5WiO1t7sW9BdrAxAMqvDmzyG6J0z5hVsWnQj9v2PBYIzpEgJZYzge2KyqW1W1ApgHnF9vm+uAR1R1P4Cq7g1geVpMYpMB2Pbt9kOX/Owoq1+G7R/DtDmHZnIFGHo65KyCoj0duz9jjGmlQAZDP2CH3/Ns3zJ/w4HhIvKxiHwmImc19EYicr2ILBeR5bm5nTBayBcMCd6iQ5f87AjlRfDOL6HvBJhwZd11Q6e5+y3/6bj9GWNMGwS78zkcGAZMBmYBT4hIz/obqerjqpqpqpmpqamBL1WM+yU/IKaUV1fsRlU75n3ffwCKdsPMuRDmqbsubSzEpVpzkjEm6AIZDDuB/n7PM3zL/GUDi1S1UlW3ARtxQRFcviaeyf09LF6Xw0/nr3CX/WyP3I3w2aNuaGpG5uHrw8JgyOmuxuBt576MMaYdAhkMy4BhIjJIRCKBy4FF9bZZiKstICIpuKalrQEsU8tE9wQJY0r/cH46fTivfL2TS/72KbsOtHH4qiq8eTtExsG0Xze+3dBpbiqO3d+0bT/GGNMBAhYMqloF/Ah4G1gHzFfVNSJyn4ic59vsbSBfRNYC7wG3q2rwpzUNC4OYXkjpPm6eOownr8okK6+Ec//yEZ9vbUPx1r0KW5fClF9CXErj2w2e4u43Wz+DMSZ4AtrHoKpvqOpwVR2iqvf7lt2jqot8j1VVb1PVUao6VlXnBbI8rRKTVDvD6rRRaSy4aRI9YiP43pOf8+ynWS3vd6g4CG/fDWlj3HkLTYlPhT7jYfPi9pXdGGPaIdidz11XbHKdazIM7R3PwpsmcdrwVO759xrueHkl5VUt6Av46E9QsMOd4ewJb377oVPd/EllBe0ovDHGtJ0FQ2Nik6B0f51FidERPHFVJrecPpT5y7O57O+fsaegrPH3yN8CHz8EYy+Fo05q2X6HTgOthq3vt6PwxhjTdhYMjYlNavAqbmFhwm1njOBv3z+WTTlFnPvXj/hyeyMT7r19N3gi4YzftHy/GcdBZII1JxljgsaCoTE1fQyN9CWcNSadBTdNIi7Sw+WPf8aLX3xbd4MNb8HGt2DynZCQ3vL9eiJg8Glu2GpHnT9hjDGtYMHQmNgkqC6HipJGNxmelsC/bzqZk4akcNcrq7h7wSoqqrxQWQZv3QkpI+CEG1q/76FTXb9E3sZ2HIAxxrRNC3pDQ5RvWgxK90FUfKOb9YiN4OnZxzH3nQ08tnQLG/cU8dSg9+ixfxtcudDVAFpryFR3v3kJpI5o/euNMaYdrMbQGN+0GA31M9TnCRPuOGskf71iAvt3bSHy0wdZHnsqH3rH4PW2oTmo11GQPAy22PQYxpjOZ8HQmJoaw8GWX8ntnBGJvD50AeGeMOaUzeLKp75g2p/e5x8fb2v9LK1Dp0LWR1AZwIsFGWNMAywYGlMzJXZLgqG6EpY9BQ9PIHrbEiKmz+GVuy/jz5eNIzEmgl+/upbv/O8SfrFgFRv2FLVs/0OmQlUZbP+k7cdgjDFtYH0MjfHvY2iMKqx/HRbfC/mbYMCJcPm/oP9xRAEXTMjgggkZrMw+wLOfbuf/vszmhc+/5YRBSVx90kCmj0ojwtNINg+cBJ4o188wdGpHH50xxjTKgqEx0T3dfWM1hm8/h3d/BTs+h5ThcPmLMGIGiBy26TEZPZl7SU/unnk085fv4LlPt/PfL3xFemI03zthAJcfP4DUhKi6L4qMg6NOtH6GjlBe7EZ59T462CUxpluwYGiMJ9yFQ/3O57xNroaw/jWIT4NzH4Lx32/RdBdJcZHccNoQrjtlMP9Zv5dnP83ij+9u5KElmzhpaAozxqRzxqg0kuN9ITF0mruwT0E29Mjo8EMMGa/fBmsWwK2rISEt2KUxpsuzYGhKbNKhpqTivbD0d/DlMxAR467XfOJN7pd9K3nChOmj0pg+Ko0tucXMX7aDN1fv4a5XVvGLBas4flASM8f2YWb6yaSAa0469uqOPLLQsXc9rJwPKHz9LJx6e7BLZEyXJx12dbJOkpmZqcuXL++cnT05DcR3AZ2PH3YnvB37AzjtDjcTagdSVdbuLuSt1Xt4Y9VutuSWIKIsj7mFgpQJRM56joxesR26z5Aw/2o3vUjqSHc97VtXHn71PGNCgIh8qaoNXCXscFZjaEpMEmx62/UjjDofps6B5CEB2ZWIMLpvD0b37cFPzxjBppwi3ly9h+WfT+TEnI+Z8PvFjM5I4qwx6cwY04dBKa2vqYSc3Sth7UI49eeQPhbmXwkb34aRM4NdMmO6NAuGptR8gZx6O/Q/rlN3PSwtgWFpCZB2Bbz0Ln84sYp/7oAH3trAA29tYGR6AmeMSmP6qHTG9EtEGuj0DnlLfwvRPXxNfvGQ0AeWP2XBYEwzLBiacuxsdwumwZNBwrgwcT0X/uhCdh4o5a3Ve3h7zR7++t5mHv7PZvr0iK7tszhhUDKR4XZ6Cju/hA1vuKvmxfR0yyZeDe//HvZtg6RBQS2eMV2Z9TF0B09OA/XCdXUv+bmvpIIl63J4d20OH2zKpazSS0J0OFNG9Gb6qDQmj0glIboNczUdCZ6/CHZ+5foUohLcssJd8OcxcNKPYPp9wS2fMZ3M+hiONEOmul+6B/cdOiMbN/z1ksz+XJLZn9KKaj7anMe7a/ewZN1eFq3YRYRH+M7gZM4Ync70o9NI7xEdxIPoRN9+5jqcp993KBQAEvu6ZqSvnoPJd0NEiPw9jGklqzF0BzuWwVPT4OKnYcxFzW5e7VW++nY/7651tYlteW7q8IxeMQxOjWdwShxDUuPc49Q40hOjj6w+imfOgdwN8OMVEFlvJNeW9+C578IFj8O4y4JSPGOCwWoMR5p+E93JdpuXtCgYPGHCcQOTOG5gEnfNGMmW3GLeXbuXdbsL2ZpXzJdZ+yipOHS96thID4NS4mpDY3BqHENS4xmUEkdcVDf7J7L1fcj6EM763eGhADDoNEga4jqhLRiMaVA3+18fosI8MGSKCwbVBqfdaIyIMLR3AkN7H2pSUVVyCsvZmlvMlrwStuYWszW3hG927Oe1lbvqXDguo1cMI9ISGJ6ewIi0BEakJzA4NY6o8C54LoAqvHc/JPR155s0JCwMMq+Bd34Be1a5YazGmDosGLqLIVPdtA45ayB9TLveSkRI7xFNeo9oThqaUmddWWU12/MPutDILWZDTjEb9xTx/sZcqnzXlvCECYNS4lxgpCUwIj2e4WkJHJUchycsiE1Sm5e4c07O/lPT/Qfjr4D//MbNiHvug51WPGO6CwuG7mLI6e5+y5J2B0NToiM8jEh3NQN/FVVesvJL2LCnyN1yili9q4A3Vu+urWFEhYcxtLcLiaG94xnme9w/KTbwgaEK7/0P9BwAE65setvYJNckt3K+66COTgxs2YzpZiwYuose/aD3KPereNKPO333keFhDPfVEM4dd2j5wYoqNu8trhMYn23NZ8HXO2u3iQoPY0hqPMPSDoXG8LQEBnRkYGx4E3Z9Def9FcIjm98+81r45gVY+f/g+Os6pgwmNHmr3USXPQe0qpm3K7Ng6E6GnA5fPA4VJW2avC8QYiPDOSajJ8dk9KyzvKiskk17i9mcU8zGnCI27S1m2bZ9/PubXbXbRPoCY0hqnK/T23V4D0qNI7E15194va5vIWkwjJvVstf0mwh9xsHyp+G4Hx4x/6FNJ1F158ms+j9Y8woU50CPAXD0ue7W//huPSdXQINBRM4CHgI8wJOq+rtGtrsIeAk4TlVDbCxqKwydBp/+1V3yc/iZwS5NkxKiI5g4oBcTB/Sqs7yorJLNe4tdaOx1obEyu4A3Vu3G//LYKfFRDE6J842WOnQ/ICnu8DO71/0bclbDhU+0aPpzwAVB5rXw6i3uvIejTmznEZuQkLvRhcGq/4P928ATCcPOgKNOgm0fwLIn4LNHIK43jDzbhcSgU8HTvU40Ddh5DCLiATYC04FsYBkwS1XX1tsuAXgdiAR+1FwwhOR5DDUqy+D3A2HilTDzD8EuTYcqr6rm2/yDbM0rYZtvpNQ23+O84ora7cIEMnrFkpoQRVJcJCmxHn66ZTaesDCWTl1IUnwsyXGRJPlu0RFN/GqrKIE/Hg3DpsPFT3XCUZpuqWAnrH7ZhcGelYC4L/uxl7gv/popVwDKCmHzu7B2EWx6FypL3HxdI2a6bYec7qbtD4Kuch7D8cBmVd3qK9Q84Hxgbb3tfgP8HrCJ8psTEQ2DTnH9DEeYqHDPoYkD6yk4WMm2/BK25blhtVn5B8krKufb/IOkZ71LijeL/664hTfmrz7stXGRHpLiI+mdEM1RSbEMTInjqORYBqXEMTAljsTxs9zopOLfdfhU6qYbO7gP1v4bVr0E2z8GFPpOhDN/C6MvgMQ+Db8uOtENbBhzEVSWuhMq173q5u1a8SJExMGwaXD0ea7WH3X4v/euIJDB0A/Y4fc8GzjBfwMRmQj0V9XXRaTRYBCR64HrAQYMGBCAonYjQ6bCpndCaiK4HrERjI/tyfj+PeuuqK6CR36MRozmf6/6BT87WMW+kgrySyrY57vlF1ewr6ScPYVlfLo1n1f8OsUBjo0dycveSl775wNsHXl9bWgclRxHj5juVf03HaB4L7xxu7uWu7cSkofB5Ltg7MWtn3I/IsZNwTJyJlRXuibgdYtg3WsudBL6wpWvdMlLzgat81lEwoA/AbOb21ZVHwceB9eUFNiSdXFDp7r7LUsg6YfBLUuwrXgR9m1FLn+RnnHR9IyDwc386K85TyMrv4SsvBKy8gewZv0xTMxdyC07TsXLof6LmAgPiTHhJEZHkBgTQWJ0OD1iah5H1FnXw7csKT6S5OaasEzXlPURvHQNlBXACf/lmor6jOuYgQmeCHeS6pApMHOu29cr18PTZ8H3Xur0af2bE8hg2An093ue4VtWIwEYAyz1zdOTDiwSkfOsA7oJyUPdsLgNb8Kx17gzeUNRVQW8/4Cr3o+Y0eKXNXiexuqfwEs/YP1V4WQln8y2PBca+SUVFByspLDM3fKKK9iaV0JBaSWFpZV1Osvri48KJ9kXEsnxUaTEuz6P5LgokuMjSYl390mxkSTGRLQ8SLxedx+qn3sgeL3w8Z/hP//jRrZ9/5WAnitEmAcGnwbXvg3PXQDPngeXPueamLqIQAbDMmCYiAzCBcLlwBU1K1W1AKg97VZElgI/s1Bohohr4/z4IXjsJDj1Z+55Nx4a1yZfPwsF38I5f27/L7qR50B8GpFf/4Ph35vB8Ab6OepTVUoqqiksdaFRcLCSgtLK2qas/OIK8kvKyS+uYMe+g3yz4wD7SiqobiRNIsPDSIx2NZAEX+2kfq0kJayYM7/6L2LK8ykaej7esZeQOCiT6Egbdd5mB/e5X+6b33X9Auc+1Hnt/r0GwjVvuyniX7wMLvi7a7LqAgL2L0pVq0TkR8DbuOGqT6vqGhG5D1iuqosCte8j3tQ5kH4MfPAHePlad6WyU34KYy9t+XDN7qyyDD74I/Q/4VDTWnuER8LEq+CDubB/O/Q6qtmXiAjxUeHER4XTl5aNMvF6lYLSSvJLyskrPtT/UVhWRVFZlauZlFZSWFZFYWkluw6U1j6Oqirihcj7iZGdfOQdw8mrniFq9ZNs8fbhdU7h49jTKU8YUFszSYrzq6XER5EcF0mvOGvmquPbz+GlH0BJLpz9Rzd8ubPPZ4nvDbNfgxevgJd/6ILqhOs7twwNsGm3uzOv13VmfTAXclZBz6PglNtg3BUtO/u3u/rsMXjrTrj6VTdssCMUZMODY2HSrTBtTse8Z0cpL8L77PnI7pXsmfk0u1JPoWDfXuK3vE6/Ha/Rr+BLADZFjuJtz2ksqjqerSXRtXNb1Rcb6akdzltz8w+OpLgokuIO9Zu0qqmrO1CFTx+BxXMgsR9c+k/oOyG4Zaoscz/y1r8Gp93hOrw7OKRaM1zVguFIoAob33Jt7ru+gsQMOPlWN2fQkXQxGm+167R7+VpIHel+aXWkF2dB9jL4yRoIj+rY926rihJ4/mI3OeClz8LR5xy+zYEdsPolN/fT3rUQFo4OmUrpyAvJ6TOV/ApPnZFatSO2SirYX/u4nLJKb6PFiAwPo0dtJ/uhTvia8OgRE0GvuEhSE6Lo7bv1io0krLEpT7KXw5L7XO1swlWQkdk5v9ZL98PCm2DD664J8fxH6p6HEEzVVfDaj+Hr593Z+DMe6NAmYguGUKXqRiu9/wfY8RnEp8OkW9wU1A1dmwDcWOv9WbBvK+Rvcff7trrhsMU57tT+kWe7E3Ra0MTS4VTdl/Xql93sssU5ENUDrloA/Y7t2H1tXuzaey96qmu09VaWwr8uc9eXuOjJFl2Lgz2rYdV8N/6+cCdExrsvwGHTYeApkJDW6EtLK6rJLymvDY7CsqrajvbavpTSSt8y37qyxjviw8OElPgoeidGkeq7T4sLZ8reZxi79Umqo5PwVBYTVlVKac9h5A+/jPwh36UiKhlV8KriVUWV2udhIvSMjXAd93GRrZv+fedX8H+z3d9l+m/gOzd2valQVF1N5uOHYPSFrt+hg2r/FgyhTtV9mbz/gLuPTXHXOU4aAvu2HPri37fV/SfxF5PkRmYkDYaYXrDtfchd79aljXEBMXIm9BkfuP9Uqm6Ki1UvwepXXCezJ8qdEDTmIncfiLNHvV74y0RI6APXvNnx798aVRXw/77nzp797mMwvoVzQNXwet2JWavmuzHzZQVuecpwGHiy73aKa+NuJ69XKa6oYn9JBXuLytlbWE5uUZl7XFROru8+tnAL91Q+xLiwrbxcfQr3Vl6NAud4PuMyz1ImhG2mQj0s9h7L/OrT+MA7rs7w4YbER4WTVKcZLLLOme/J8ZHERXhI3/g8/ZfdT1VMCjumPkp5+rF4wgRPGISJ4AkTwkQICxM8IoT5lgvuPkwEqbdMpGYdta/tMB8/DO/+CgZPgcueh6j4dr+lBYM5ZPunrpN6i9/Z0rEp7mSdmgBIGuxOlqsJg/ryt7gzN9e/4Woi6nVtsyNmuKAYeErH/KrJ3+ILg5cgbyOIx00hMOYiV2vpjOmxP34I3r0HbvwU0kYFfn8Nqa50v2zXvwbnPAiZjVx0qMXvV+Wmcsj60DXFbf8UKorcupQRfkFxcocExWG8XjeH0Lv3oBGxFEz9A9l9ppNbVE61VwkLA0GIK9xE360vkbZtARHl+ymPTSd3yEXkDb2Eyh5HESZQVa3sP1jpq9WUN3Ayo7tVVHsRvKRSwK8inuNcz2f8p3o8t1XeyAE6ftSRCPSIiTgsmGoGAtQPqxbVdr5+ARbdDH3Hu3Md/K733rYyWjCY+vaug6pyFwDRPdr+PiV5sPFtFxSbl0BVKUQlugn+Rp7tRgpJmAsP1N2r19UCah/7PfdWwrYPXRjsXgEIHDUJxlwIo74Lcckd9Ado6fHlw5+OdqOUzp7bufsG14/yynWu6WzGA+5Eq45WXQV7Vri/e9ZH8O2nUFHs1qWOdAEx6FT3mbZ3Ft/CXbDwv2Hre26yufP+AgnpTb+mqgI2vuna2jcvdv9OBp7i+syOPheqytwZysU5bkRRcY7v+V4o2YsW56DFe5GSPESrUQkj65jbyDr6OrwqVHtdE1W1F6pV8Xq1dlnNcteEpXiV2vuaZi1vzXJ8z71KZbW3NrD8m+P2H6xsdIhyTISHuKhwEqLDiYvyEBdZ89jdEqLCGVP8MTPW30VJbAbLT36KAYOGNThtTEtYMJjOUVkKW5e66QM2vuX+k7ZV34muXX/0BZDYt8OK2CavXO9qRz9d3yFV+BbzeuHfN8GKf7kLCHXWdTeqq1woZ31wqEZRWQIRsa7ZbvSFro+itc13q16C129zNaAz73d9Xa1tfizY6f4eXz/v+sIaExYB8Wluvqu43q7mE9/bLet/gvvVHQRer1JYVllbs6mp1ew/WMGBgxUUl1dTUl5Fse9WUu++rNLL8bKOJyPnUkQsb4x/lOsuOKtNZbFgMJ3PW+1Gmuxd62oMEua+BGof+25Qb5m4CxC1dh6aQNrxBTw1HU75meu8b08Nq6VU4bWfwJf/gMl3w+Q7Ar/PxlRXulrEmoWuf+JgnuvEHjHDBffQaU2P2irdD6//1NV6Mo5zHajt/Xxr+kyyPnTNnXGpviDwBUB0z67XkdwBqqq9lJRXU579DUkLZlE+6hLizv1tm97LgsGY9lCFf57rvoTCwt0vzmHTYeh0SBvd8V9AqvDWXfD5Y3DybTD1nq7zJVddBds/coMA1r0Kpftc0+HIs11IDJ5St39py3/ccNCSvTD5Tpj0k9A46bIzFOx0zXBtHMJqwWBMe1VXQfYXblTQ5ndhzyq3PKGvO9t62HQYPLn9tQlVWHwvfPwgfOe/4cz/7TqhUF91pRultmaBC4myAnf8I8+F0d91f6sv/u46tC/8e/BPGjN1WDAY09GK9riO0E3vwJalUF5wqDYxdJoLirQxrf9SX/o7N6VJ5rVuWoauGgr1VVW4/qU1r7g+pvJCt/yEG92Z40G6GI1pnAWDMYFUXelOuqtfm4jr7X5B1468qm5gNJbfzet1ATP++260TnedMbWq3IVEbApkdPBJh6bDWDAY05kKd7vaRNZHUF3uzr+o3+keFnb4MvFAz/5wwg2hNzuu6XRd5dKexoSGxD7uOtwTrwx2SYzpEN207mqMMSZQLBiMMcbUYcFgjDGmDgsGY4wxdVgwGGOMqcOCwRhjTB0WDMYYY+qwYDDGGFNHtzvzWURyge1tfHkKkNeBxeluQvn4Q/nYIbSP347dOUpVU1vyom4XDO0hIstbekr4kSiUjz+Ujx1C+/jt2Ft/7NaUZIwxpg4LBmOMMXWEWjA8HuwCBFkoH38oHzuE9vHbsbdSSPUxGGOMaV6o1RiMMcY0w4LBGGNMHSETDCJylohsEJHNInJnsMvTmUQkS0RWicg3InLEX/5ORJ4Wkb0istpvWZKIvCsim3z3vYJZxkBp5NjvFZGdvs//GxGZGcwyBoqI9BeR90RkrYisEZEf+5aHymff2PG3+vMPiT4GEfEAG4HpQDawDJilqmuDWrBOIiJZQKaqhsRJPiJyKlAMPKuqY3zLHgD2qervfD8MeqnqHcEsZyA0cuz3AsWqOjeYZQs0EekD9FHVr0QkAfgS+C4wm9D47Bs7/ktp5ecfKjWG44HNqrpVVSuAecD5QS6TCRBV/QDYV2/x+cA/fY//ifsPc8Rp5NhDgqruVtWvfI+LgHVAP0Lns2/s+FstVIKhH7DD73k2bfyDdVMKvCMiX4rI9cEuTJCkqepu3+M9QFowCxMEPxKRlb6mpiOyKcWfiAwEJgCfE4Kffb3jh1Z+/qESDKHuZFWdCMwAbvI1N4Qsde2nR34b6iGPAUOA8cBu4I9BLU2AiUg88DJwq6oW+q8Lhc++geNv9ecfKsGwE+jv9zzDtywkqOpO3/1eYAGuaS3U5PjaYGvaYvcGuTydRlVzVLVaVb3AExzBn7+IROC+FF9Q1Vd8i0Pms2/o+Nvy+YdKMCwDhonIIBGJBC4HFgW5TJ1CROJ8HVGISBxwBrC66VcdkRYBV/seXw38O4hl6VQ1X4o+F3CEfv4iIsBTwDpV/ZPfqpD47Bs7/rZ8/iExKgnAN0TrQcADPK2q9we3RJ1DRAbjagkA4cC/jvRjF5EXgcm4KYdzgDnAQmA+MAA3bfulqnrEddI2cuyTcc0ICmQB/+XX5n7EEJGTgQ+BVYDXt/huXDt7KHz2jR3/LFr5+YdMMBhjjGmZUGlKMsYY00IWDMYYY+qwYDDGGFOHBYMxxpg6LBiMMcbUYcFgjI+IVPvNQPlNR87CKyID/Wc8NaYrCw92AYzpQkpVdXywC2FMsFmNwZhm+K5n8YDvmhZfiMhQ3/KBIvIf3+RkS0RkgG95mogsEJEVvttJvrfyiMgTvrny3xGRGN/2t/jm0F8pIvOCdJjG1LJgMOaQmHpNSZf5rStQ1bHAX3Fn0AP8Bfinqh4DvAA87Fv+MPC+qo4DJgJrfMuHAY+o6mjgAHCRb/mdwATf+9wQmEMzpuXszGdjfESkWFXjG1ieBZyuqlt9k5TtUdVkEcnDXRil0rd8t6qmiEgukKGq5X7vMRB4V1WH+Z7fAUSo6v+IyFu4i+ssBBaqanGAD9WYJlmNwZiW0UYet0a53+NqDvXxnQ08gqtdLBMR6/szQWXBYEzLXOZ3/6nv8Se4mXoBvoebwAxgCXAjuMvKikiPxt5URMKA/qr6HnAH0AM4rNZiTGeyXybGHBIjIt/4PX9LVWuGrPYSkZW4X/2zfMtuBv4hIrcDucAPfMt/DDwuItfiagY34i6Q0hAP8LwvPAR4WFUPdNDxGNMm1sdgTDN8fQyZqpoX7LIY0xmsKckYY0wdVmMwxhhTh9UYjDHG1GHBYIwxpg4LBmOMMXVYMBhjjKnDgsEYY0wd/x/uduBaajV6RAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.17384552955627441 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "plt.plot(history.history['loss'])\n",
+    "plt.plot(history.history['val_loss'])\n",
+    "plt.title(\"Model Loss\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Loss')\n",
+    "plt.legend(['Train', 'Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "friendly-milwaukee",
+   "metadata": {
+    "papermill": {
+     "duration": 0.075452,
+     "end_time": "2021-04-25T14:21:17.570993",
+     "exception": false,
+     "start_time": "2021-04-25T14:21:17.495541",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Model 1 accuracy vs no. of epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "palestinian-socket",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:21:17.736309Z",
+     "iopub.status.busy": "2021-04-25T14:21:17.735320Z",
+     "iopub.status.idle": "2021-04-25T14:21:17.864870Z",
+     "shell.execute_reply": "2021-04-25T14:21:17.864254Z"
+    },
+    "papermill": {
+     "duration": 0.220547,
+     "end_time": "2021-04-25T14:21:17.865037",
+     "exception": false,
+     "start_time": "2021-04-25T14:21:17.644490",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAA1xklEQVR4nO3dd3xV9fnA8c+Tm0kIhL0CsqeDEXBgFZy4QOsCawX1p62jblvtr7VU669LW9tq3VZqVcRZVJw4ap2EvWTKCCNAQkJC5s19fn98Ty6XkJCbkJsbcp/3y/u6955z7jnPyZX7nO88oqoYY4wxAHHRDsAYY0zzYUnBGGNMkCUFY4wxQZYUjDHGBFlSMMYYE2RJwRhjTJAlBRMTRKS3iKiIxIex7TQR+W9TxGVMc2NJwTQ7IrJBRMpFpGO15Qu9H/beUQotNJbWIlIkIu9EOxZjGpMlBdNcfQdMqXojIkcBraIXzgEuBMqA00Wka1MeOJzSjjENZUnBNFfPAVeEvJ8K/DN0AxFpKyL/FJGdIrJRRH4hInHeOp+IPCAiu0RkPXBODZ99WkS2icgWEfmNiPjqEd9U4DFgCXB5tX2fKCJfiEi+iGwWkWne8hQRedCLtUBE/ustGyci2dX2sUFETvNeTxeRV0TkXyKyB5gmImNE5EvvGNtE5GERSQz5/DAR+UBE8kQkR0R+LiJdRaRYRDqEbDfS+/sl1OPcTQtmScE0V18BbURkiPdjPRn4V7Vt/ga0BfoCJ+OSyJXeumuAc4ERQCZwUbXPPgv4gf7eNmcA/xNOYCJyBDAOeN57XFFt3TtebJ2A4cAib/UDwCjgBKA98FMgEM4xgUnAK0C6d8xK4FagI3A8cCpwvRdDGvAh8C7Q3TvHuaq6HfgEuCRkvz8EZqpqRZhxmBbOkoJpzqpKC6cDK4EtVStCEsXdqlqoqhuAB3E/cuB++B5S1c2qmgf8NuSzXYCzgVtUda+q7gD+7O0vHD8ElqjqCmAmMExERnjrLgM+VNUXVbVCVXNVdZFXgrkKuFlVt6hqpap+oaplYR7zS1V9Q1UDqlqiqvNV9StV9Xvn/jguMYJLhttV9UFVLfX+Pl9762bglWy8v+EU3N/ZGACsbtI0Z88B/wH6UK3qCHeFnABsDFm2Eejhve4ObK62rsoR3me3iUjVsrhq2x/MFcCTAKq6RUQ+xVUnLQR6Autq+ExHILmWdeHYLzYRGQj8CVcKaoX7tzzfW11bDAD/Bh4TkT7AIKBAVb9pYEymBbKSgmm2VHUjrsH5bOC1aqt3ARW4H/gqvdhXmtiG+3EMXVdlM66RuKOqpnuPNqo6rK6YROQEYABwt4hsF5HtwLHAZV4D8GagXw0f3QWU1rJuLyGN6N4VfKdq21SfzvhR4FtggKq2AX4OVGW4zbgqtQOoaikwC1da+CFWSjDVWFIwzd3VwCmqujd0oapW4n7c7heRNK8u/zb2tTvMAm4SkQwRaQfcFfLZbcD7wIMi0kZE4kSkn4icTN2mAh8AQ3HtBcOBI4EU4Cxcff9pInKJiMSLSAcRGa6qAeAZ4E8i0t1rCD9eRJKA1UCyiJzjNfj+AkiqI440YA9QJCKDgetC1r0FdBORW0Qkyfv7HBuy/p/ANGAilhRMNZYUTLOmqutUNauW1T/BXWWvB/4LvID74QVXvfMesBhYwIEljSuARGAFsBvXiNvtYLGISDKureJvqro95PEd7sd1qqpuwpVsbgfycI3Mx3i7uANYCszz1v0eiFPVAlwj8VO4ks5eYL/eSDW4A9d+Ueid60tVK1S1ENcOcx6wHVgDjA9Z/zmugXuBVxozJkjsJjvGxB4R+Qh4QVWfinYspnmxpGBMjBGR0bgqsJ5eqcKYIKs+MiaGiMgM3BiGWywhmJpYScEYY0yQlRSMMcYEHXaD1zp27Ki9e/eOdhjGGHNYmT9//i5VrT7+5QCHXVLo3bs3WVm19VA0xhhTExEJq/uxVR8ZY4wJsqRgjDEmyJKCMcaYIEsKxhhjgiwpGGOMCbKkYIwxJsiSgjHGmKDDbpyCMc1SIAB568FfAgE/BCrdc2XF/u8DfghU7HvfcSD0GBnt6A9NZQUsfRk6DICeo6MdjTlElhSMaaiS3bDuY1jzPqz5AIp31X8f4oPLZsGA0xo/vkgLBGDZK/Dx/bB7A8TFw4Tfwej/gX23OTWHGUsKxoRLFXKW70sCm78GrYSUdtD/NOhzMqSkux/HuHiI80FcQrX38fseKLx6Ncy6Aq6cA92HR/kEw6QKq96Bj34DO5ZDl6Pgkudg4b9gzh2wfQmc/QDE13XzONMcHXazpGZmZqpNc2GaTFkRfPfpvkSwx7sFdNejYcAZMPBM6DHK/eA3ROF2eOo08JfB/3wI7Y6o+zPR9N1nMPdeyP4G2veF8f8Lw74PcXGuSuzj++GzB6HnsS5RpHWJdsTNTiCgFJX72Vvmp6S8kpKKSkorKikpD1BS4b33lpdUVFJS7q2vqOTco7szpk/7Bh1XROaramad21lSMI0ifzN88jvYugB8ie4qMficBPGJ7n31ZfEp0Hcc9Dq2zkM0qaWvuCvfjZ9DZTkkpkG/8S4R9D8N2hz0zp31s3MVPH06pHaGq9+HVg37Rx9RWxbAR/fBuo8grTuM+xkM/wH4Eg7cdvnr8Mb1kJwOk//lkmaEVFQG2Fvmp6jMz96ySu/ZH1xWXF5JZUBJ8AkJvjjifXEk+IT4uDjifUKizz3Hx3nLfXHEx7mqL1VQlICC6r5nxf2wKxBwG1FeGWBPqZ+Ckgr2eI8C77GnNOR1iZ/C0goC9fzZTYqPIyXRx/+ePYSLM3s26G9lScHsk/edu3rrNAhGToXkNo2375J8+O+f4KvH3Pu+4wB1V76V5fueQ1+HPgcq3OcyRsMJP4HB5zb8qrux5KyAR493V8KDz3GJoOdxLolFysYv4J+ToPtIuOLfkJAcuWPVx85Vrppo5WxIaQ/fux1GXw0JKQf/3Pal8OJlUJRD5bkPsbnnJL7L3cuGXe7xXW4x2buLqQwoAsSJgPsPEfGeveXesl6Vm+nvX82WyrZsrGjH+vK2FPgj+J0cgqT4ONqkJNDWe7RJjnfPIctaJcbTKtFHcoKPlEQfKQneIzHOLfOWJ8f7iIsT2PA59BxTcyIOgyUF4y51FvwT3vv5vh/mpLYw+io49seQ1rXh+/aXwbyn4T9/cInhmMmuKiG9nlcx5Xth0Qvw5cOusbJdbzjuencVmtS64fEdileugtXvwS1Lm/aqffnr8PI0GDIRLp7hqmSiJX8TfPJ7WPwCJLSC42+E42+o9YLCXxlga34pG3L3siF3L9/t2ktuzhau3PZrRlQu40n/2fzOP4VKfLROiqd3x1b0at+KBF+cd0W+76pbUbdMIU7LGV70GSfveYtBpYsPOG5pfBv2JnelrFVXKlK7UZnWHdr0IC69J4ntepLYvge+xFZUBAL4KxV/pQZfV1QGqKgM4A+41/5KxR8IUFGpweQUJy45udcSTGBStRy3TbwvjrYp8bRJdj/8yQmNeGGjCp8/BB/+Gk77FZx4a4N2Y0kh1hVuh9k3wZr3XAPopEdg7w74/K/uqi8u3v2Qn3ATdBwQ/n4DAVj+mqtXzt8IfcfD6fdCt6MPLd5AJXz7NnzxN1dfnZwOmVfBsT86tORVX7vWwMOjYexN7rya2pePuCR+3PUw4bdNe+zCHIpWvEvZindI3/whICztfjGfdfkhOwNpFJX6KSzzU1TqqmaCj1I/JRWV++2qVaKPIzqk0q9DIlcWPcWo7bMo6H4iFec/TYdOXZC6eift3gDzn3VVeHt3QvoRkHklDJwAxblQsAX2ZMOerfteF2yBkrwD9zXgTDj/UUjt0Fh/qaZTUQpv3QKLX3RtN+f/ve5SWi0sKcSy5a/DW7dCRYn7YRt9zf5Xnbnr3I/PoufdFf/gc2DsLXX3Mf/uM/jgl7B1IXQ50u27/6mNH/+mr+HLv8HKt1zyOvoSd6XaZWjjH6u6138My99wpYTWdd6PJDLevRu++juc+X/u6ryRqSo5e8pYu72A3eu+JnXjXI7I+5x+FWsA2K7teK8yk8f8E9lGB+LjhNbJ8bROco+0qtfJCcH3qYnxdG2bRO8OqfTpmEqntKT9f/gXPAdv3wZtusPkF2v+LgOVroSW9Qys/dBdig88y5Vs+54SXsmpvNglij1b3GPnKve3TO0Ml/wTMiLXvtHoinbAzB+4i6Tx/wsn3XlIXX0tKcSikt0w5043kKj7SLjgceg0sPbti3bCN4/DN09CaT70OgHG3uzq0EP/Ae5YCR9Oh9XvQpsMOOUX7oc60nX/uevgq0dd8qoohn6nunaHvuMi0w8+7zv42yhXOmnqq/RQgQD+WVOJ/3Y2S49/iAVp49mSX0L27mK27C7BH1BaJfpISYynVYLPe+3bt6zqdYKPVonx+OKETXl7WZNTxPacbXTd+QXHB+ZzctxiOkghlQirE4awsf1Yio84lfZ9R9KrQyppyQmkJceTFB9X95V9ODZ/Ay9d7np0ff9xGHKeW1643VVzzp/hrvjTurm2r5FXQNseh37cLQtg1lQo3AZn/Q4yr27+4yi2LYEXp7hS0QWPwbDzD3mXlhRizdq58O8bXRXRyT+DE28DX5jDUMqKYOFzrvRQsBk6DXbVSr1PhM8ecEX4xDT43m3uB7OBxdcGK85zV49fP+7Or9sx8INXG/9KfvZNsHgm3Ly4cXsXhaioDOzXM2VXUXnwxz57dwnZ+cVk7y6hpHgvzyX+lmNkHT8sv5vFvmH0aJdCj/QUEnxxFJe77ozF3qOkopLicj+lFYFqR1SGyCbGxy3kjMQlHK2riSNAaUI79mScTNLQCbQZdibSVG0ne7a6xLBlPhx3g/v/bdUcN7q773jXiD1wQoMbU2tVnAevXQtrP4CjL4Vz/wyJqY17jMay8i147RpXhTrlxUYbv2JJIVaU74UP7oF5T7kf8wseg+4jGravygpX9fT5XyBnmVsWlwBjroWT7oh+V0l/GSx5Cd66DYZdABc+2Xj7zt8Mfx0Bo6bCOQ8esFpVKfO77o/F5SFdH8srg10g95b5KSjxH9AVMTQJFJdX1nBwSEnw0aNdChneo0d6K/qkljHuv5eTWLoLufo9pPOQOk8jEFBKK/yUb8oibuVskte8RWLhJrey2/B9Yyu6j4heL6+KUle9ufgF16NpxOUwahp06BfZ4wYCrhfex/e7fyuX/gs69o/sMetD1fXkm3uv68Y7+YVGbU+zpBALNn8Dr//IVXscfwOc8svG6cqoCuvmwqavXC+g9n0OfZ+N6eP/g09/Dz98Hfqd0qBdqCq7iyvYUVhKzp4yenz+S/psepm/DH2J1aXt2FFYyp7SfT/2e73+7uFITfQd0P2wpvdtUxJon5pIRrsU2qcm1lxFs3ujG8PgS4SrP6i9BBMIuLrnFf+GFbNdNUxcvKtqGzLRXX03p4Fkqq5RP71X03e/XfcRvHK1uwg6/xEYOqlpj1+TilKY/RNYOguOvAgmPdzoJXJLCi2Zvxw++a3rptYmAy541FX1xIqKUnj0BNAAXP/lAf94KgPKjsJStua7Kpkt+SVsLyhlx54ycgrd887CMsorXVVLJ3bz36RbeK3yRH4bfx1d2iTTuU0SbVMSSE2MJzUpntQkn3uuep/oq3F5m+R44n2N3JV06yL4x9lu3MSVc/Z1Cw1UuvENK2e7RFC03SWPfqe6H7pBE9wUHOZA+Zvh5amuGuv4G+G06Y1fZRWuwhyYeRlsyXLtdd+7IyJtHpYUWrKXp7lqnhE/dD1UGnMw2mGgtKKSvGUf0P3fl7K83zW82+UatuSXsGV3CVsLStiWX4q/2lV9m+T44I99l7RkOrdJpnNaEl3aJDNq1R/psuJZyq/7hqTOzag6IdSaD+GFS6DPSa677IrZ8O1brrtmfDIMOB2GTHJVQzH2/0OD+cvgvf+FeU+6ThYX/6Npuz8DbFvsGpRLdruOIUMnRuxQlhRaqt0b4S/HRK8ffRMqKK5g7c5C1uQUsXZHEWt2uOct+SUAPJjwKOfFfcF5Fb+lMK0/Pdql0D3dNcZ2T09xdfTpKXRLT6F1Ui2N7nt3wUNHuSqW7z/ehGfXAAv/Bf/2uqgmpMLAM1yJoP/p0Rvo1xIseRnevAkSW7vE0FSl7hWzXfVvSnvXoHyoY33qEG5SsFlSDzcLZrii5ehroh1Jo1BVdhWVs2ZHIeu8H/41OUWs3VnEzsKy4HbJCXH069SazN7tuLRTT3q2T6FX0p/wzT6Dd3q9RtyV7zRsBPCXD7vxHN+7vRHPKkJGXA5Jbdz33+9USGwV7YhahqMvhq5Hul5RMya6UcPH3xi5hvjdG1xPuq/+Dj0yvQbl5tPeY0nhcOIvd4OABpxZ/+kkoqQyoOwsLHPVO/klbPUeW7y6/i35JRSW+oPbpyXF069za8YN7MSALq3p37k1Azqn0SM9xc3/Ul3Zb9zV88LnXM+h+ijOc2M0hl1w8PEczUkEqxdiWuchcM3HMPtG15vvq8fgqItc99WuRx76/v3lruvtghmuoVviXJI/+8HmM8+Vx5LC4eTbt1w//dFXRzuS/ZSUV7J2RxGrcgrZmLs3+IO/tcA18FZUHli/36NdKzLapTCmT3v6dExlQOc0+nduTZc2SfUbKDX8B27upA9+CYPOgtadw//s149BeZHrbmtMchs359TK2bDoRXcl/8VfofMwN1jzqIvrP5gud50bmLfoedf+0yYDxv3cJYTGGJgXAdamcDh59lw339BNi6LSx7zcH+C7XXtZlVPI6u2FrM5xj415xVT9bxQn0LVNcrBOv6qOv6qev3t6MmnJjdzLY+dq1xupPmMXSgtcW0Lv78Hk5xs3HtMy7M1183wtmeW6+yKuveHoS12JLbltzZ/zl7kLuPnPwnf/cXfXGzjBjcXof2rUxodYm0JLs3M1bPgMTr2nSf6n2lZQwuLNBazOKWRVTiFrcgpZv3NvsFePL07o3aEVQ7u34fwRPRjYJY2BXdI4ooOb+bJJdRroRlt/+nsYPiW8sQvfPOkSw0l3Rj4+c3hK7QBjrnGPvPWuQXrJTFfF9PbtrmR6zGTXvhOf6MZdzH/WTV5XnAtte7kupsMvj9gI+UiwksLh4t2fwzdPwG0r6ldFEobSikqWbilg4abdLNyUz8JN+WzfUxpc36t9KwZ2ac3ALmkM6up+/Pt2SiUpPsr3PQhVx9iF/ZQVuVJCRib84OWmi9Ec/lTd2IYlL8GyV92Pf0p7N4ZkS5YbMDjoLFcqCHcSvyZiJYWWpKLE1UkOOe+QE4Kqsimv2Pvx382CTfms3LYnWALo1b4Vx/Ztz4ie6RzTM52BXdJIra07Z3OSkOzms/nnRPjPA3DqL2vfNusZN8XyST9tuvhMyyDiLiYyMt0YoXUfuQSxazWc+ivXxtWMehI1xGHwr92w/HU3i2nmVQ36+NodRby/YjvzN+xm4eZ88vaWA246hmN6pvOjk/syomc7hvdKp2Prw/hm631PhmOmuLmbjrrI9SiprqLE3bOh77i6pwo35mB8CW6w4MAzox1Jo7KkcDjIegY6Dgx7UI2qsjqniDlLt/HOsm2szikCoH/n1pw6uDMjerVjRC9XCvDV1M3zcHbGb9yc/G/dCtPmHFh8nz/D9eA66dmohGdMc2dJobnbtgSy58GE3x10PhRVZfnWPbyzbBvvLN3O+l17EYExvdsz/byhTDiyG13bNq/+0BGR2tElhn9ff+DYBX+ZK0UcMRZ6j41ejMY0Y5YUmrusZyA+xfVyqEZVWZxdwDtLt/HOsu1syivGFycc17c9V53YhzOGdaFzWgwkguqGX1bz2IVFz0PhVndLQ2NMjSwpNGdlhe4uakdeGJztsjKgLNi0m3eXbefdZdvZkl9CfJwwtn9Hbhjfj9OHdqV9amKUA48yEdfo/NhYN+HZhU+6aZL/+2c3rUDfcdGO0JhmK6JJQUQmAH8BfMBTqvq7aut7ATOAdG+bu1R1TiRjOqwseQnKiygfMZXPV+3g/eXb+WBFDruKykn0xfG9AR259fSBnD6kC21bRWna3+aq00B397lPf+fGLuzZCvmb4OwHmv+tGI2JooiNUxARH7AaOB3IBuYBU1R1Rcg2TwALVfVRERkKzFHV3gfbb6yMUygqrSDw9xPIL4OzS++jqKyS1EQf4wZ35oyhXRg/uDNtGntkcEtTUepKC4FKlwiS0uDaTy0pmJjUHMYpjAHWqup6L6CZwCRgRcg2ClRN/t4W2BrBeOqvdI8bDJWS3iSH21VUxocrcnhv+Xb2rvuSWfGr+av8iHOO6s6ZR3bhhH4dSU5oRgPGmruqsQszvBvEX/ovSwjG1CGSSaEHsDnkfTZwbLVtpgPvi8hPgFTgtJp2JCLXAtcC9OrVq9EDrdUrV8KGz10PlhN+Am0zGv0QW/JLeGfpNt5fnkPWxjwCCj3SU/h75y+oLGzN3bf/El9yWqMfN2b0OcndID5nGQw6J9rRGNPsRbuheQrwrKo+KCLHA8+JyJGqGgjdSFWfAJ4AV33UZNHlrYfEVJj3FMx7Go65FMbeesg3+96aX8Kcpdt4e+k2Fm7KB2Bw1zRuHN+fM4Z1ZVi6H/nTxzDyCrCEcOgm/J+bnsBKCcbUKZJJYQsQOul/hrcs1NXABABV/VJEkoGOwI4IxhW+4jw3Xe7Ym90o2AUzXFfHoee7Cdi6HhX2rrYVlDBn6XbeXrKVBV4iGNqtDXeeOYizj+pGn46p+zb+4mGoLIPMKxv3fGKZJQRjwhLJpDAPGCAifXDJYDJwWbVtNgGnAs+KyBAgGdgZwZjCV+l3s2i2au9uaHP2H9y8+1/9Hb55yk2pO+BMd8euXtVrxZztBaXBEsH8jbsBGFJbIqgSCLixCT2Pgy7DInmGxhhzgIglBVX1i8iNwHu47qbPqOpyEbkXyFLV2cDtwJMiciuu0XmaNpdpW0vzAYVWHfYta90ZTpvuSg7fPOUSxDNnwBEnwkm3Q9/x7CgsCyaCeRtcIhjcNY07zhjI2Ud1o2+nOu6lu+E/kLcOxt0VqTMzxphaRbRNwRtzMKfasntCXq8Amud8A8V57jml/YHrUtrByXfC8de7uXS++Cs8dwG5bYfx69wzmeMfyaCubbn99IGcfXQ3+tWVCEJlPeOOOcRuu2iMaXrRbmhuvopz3XOrGpJClcRUOP56SodP4+1//YnMzTN4JP5PlPQ6npQLH4EO/ep3zMLt8O3bcNx1ze6+rcaY2NB87gDR3JR4JYWDJQVcT6JLn17A7etG8MoJbxA49y+k5K5wN3z5/C+ubSJcC56DgB9GWQOzMSY6rKRQm4NVH3m+XJfLjS8soMwf4LHLRzHhyK7AMDe/+tu3wwf3uHshTHwYuh558OMFKt2t/PqOr38JwxhjGomVFGoTrD7qcMAqVeWpz9Zz+dNfk94qgTduGOslBE+bbu5m8Bc/CwXZ8MTJ8NH9burm2qx5H/Zkw+irG/c8jDGmHiwp1KYkD3yJrt0gRHG5n5tmLuI3b6/ktCGdeeOGsfTvXENDsggMuwBu+AaOvAj+8wd4/CTYPK/m42U9A2ndYOCECJyMMcaEx5JCbYpzXSkhZNDTxty9fP/vX/DWkq3ceeYgHrt8FGl1TUrXqj18/3H4wSvuhvFPnw7v3g3le/dts3sjrPnAjWD22SR3xpjosaRQm+Ld+7UnfPztDs7723/ZVlDKjCvHcMP4/kh9RskOOB2u/9JVD331d/j7cbDuY7du/rMu+YycetBdGGNMpFlDc21K8qBVewIB5eGP1/LnD1czpGsbHv/hKHq2b9WwfSa3gXMedDfN+feN8Nz5MOJyd0/hgWdB2x6NegrGGFNflhRqU5xLRYfBXPfcfD5cmcMFI3rwfxccRUpiI0xdfcQJcN3n8Onv4fO/glZC5lWHvl9jjDlElhRqU5zHf0r8fLJ7B9PPG8rUE3rXr7qoLgkpbsqMoefDpi+h3ymNt29jjGkgSwo1CQTQkjxWVCRy6+kDmTa2T+SO1X24exhjTDNgDc01KStANEABaVyc2fg31jHGmObKkkINKorcwLVuXbvTOc3mIDLGxA5LCjVY+O06AEYOsekmjDGxxZJCDb5ctgaAowZEsC3BGGOaIUsK1ewoLCV7y2YA4lt3jHI0xhjTtCwpVPPagi200UL35iAzpBpjTEtkSSGEqjJr3maGpvtBfJDcNtohGWNMk7KkEGL+xt2s37WX4R0CbiK7xhysZowxhwFLCiFemreZ1EQfR6SUWtWRMSYmWVLwFJX5eXvpNs49ujvxpbtrvLmOMca0dJYUPG8v2UpxeSWXjO4ZnCHVGGNijSUFz0vzNtOvUyoje6W7+zOntIt2SMYY0+QsKQBrdxSyYFM+l47uicC+u64ZY0yMsaQAzMrKJj5OuGBEBpQXQaDCqo+MMTEp5pNCRWWA1xZkc8rgznRKS3KlBLCSgjEmJsV8Uvjo2x3sKirn0tE93YLiPPdsXVKNMTEo5pPCrHmb6ZyWxMkDO7kFJV5SsOojY0wMiumkkLOnlI9X7eDCURnE+7w/RVVJwaqPjDExKKaTwqsLsgkoXJLZc99Cqz4yxsSwmE0KqsrLWdmM6dOePh1T960oyQMEUtKjFZoxxkRNzCaFb77L47tde/cvJYDrfZSSDnG+qMRljDHRFNGkICITRGSViKwVkbtqWP9nEVnkPVaLSH4k4wk1Kyub1knxnH1U1/1XFOdZ1ZExJmbFR2rHIuIDHgFOB7KBeSIyW1VXVG2jqreGbP8TYESk4glVWFrBnKXbOH9ED1olVvsT2GhmY0wMi2RJYQywVlXXq2o5MBOYdJDtpwAvRjCeoDcXb6OkopJLMjMOXGmT4RljYlgkk0IPYHPI+2xv2QFE5AigD/BRLeuvFZEsEcnauXPnIQc2K2szA7u0ZnjP9ANXFtu02caY2NVcGponA6+oamVNK1X1CVXNVNXMTp06HdKBVucUsmhzPpdk9kRqurNaca7NkGqMiVmRTApbgNCuPRnesppMpomqjmbN20yCT7hgRA2FlvJi8JdY9ZExJmZFMinMAwaISB8RScT98M+uvpGIDAbaAV9GMBYAyv0BXlu4hdOGdKFD66QDNyix0czGmNgWsaSgqn7gRuA9YCUwS1WXi8i9IjIxZNPJwExV1UjFUmXuyhzy9pYfODahio1mNsbEuIh1SQVQ1TnAnGrL7qn2fnokYwg1K2szXdskc9LAWtolbDI8Y0yMay4NzRG3vaCUT1fv5KJRGfjiamhgBruXgjEm5sVMUnhl/mYCChfXNDahilUfGWNiXJ3VRyJyHvC2qgaaIJ6IuWhUT7q1TeGIDqm1b1Rs1UfGmNgWTknhUmCNiPzB6yl0WOraNpkLRx2klACuTSGpDfgSmiYoY4xpZupMCqp6OW5OonXAsyLypTfCOC3i0TW14jwbuGaMiWlhtSmo6h7gFdz8Rd2AC4AF3iR2LYdNhmeMiXF1JgURmSgirwOfAAnAGFU9CzgGuD2y4TUxmwzPGBPjwhmncCHwZ1X9T+hCVS0WkasjE1aUFOdCx4HRjsIYY6ImnKQwHdhW9UZEUoAuqrpBVedGKrCoKN5t3VGNMTEtnDaFl4HQ7qiV3rKWxV8O5YVWfWSMiWnhJIV47yY5AHivEyMXUpTYFBfGGBNWUtgZOoGdiEwCdkUupCix0czGGBNWm8KPgedF5GFAcHdTuyKiUUWDzXtkjDF1JwVVXQccJyKtvfdFEY8qGqz6yBhjwps6W0TOAYYByVW3sFTVeyMYV9Oz6iNjjAlr8NpjuPmPfoKrProYOCLCcTW9YPWRJQVjTOwKp6H5BFW9Atitqr8Gjgda3givkt2Q0AoSUqIdiTHGRE04SaHUey4Wke5ABW7+o5bF5j0yxpiw2hTeFJF04I/AAkCBJyMZVFTYDKnGGHPwpCAiccBcVc0HXhWRt4BkVS1oiuCalE2GZ4wxB68+8u629kjI+7IWmRDAqo+MMYbw2hTmisiFUtUXtaUqzrPuqMaYmBdOUvgRbgK8MhHZIyKFIrInwnE1rUo/lOZbScEYE/PCGdHc8m67WV1pvnu2NgVjTIyrMymIyEk1La9+053Dmo1mNsYYILwuqXeGvE4GxgDzgVMiElE02GhmY4wBwqs+Oi/0vYj0BB6KVEBRYZPhGWMMEF5Dc3XZwJDGDiSqbNpsY4wBwmtT+BtuFDO4JDIcN7K55bA2BWOMAcJrU8gKee0HXlTVzyMUT3SU5IEvERJTox2JMcZEVThJ4RWgVFUrAUTEJyKtVLU4sqE1oarRzC18fJ4xxtQlrBHNQOh80inAh5EJJ0qKd1vVkTHGEF5SSA69Baf3ulU4OxeRCSKySkTWishdtWxziYisEJHlIvJCeGE3MpsMzxhjgPCSwl4RGVn1RkRGASV1fUhEfLjJ9M4ChgJTRGRotW0GAHcDY1V1GHBL+KE3ouJcSwrGGEN4bQq3AC+LyFbc7Ti74m7PWZcxwFpVXQ8gIjOBScCKkG2uAR5R1d0Aqroj/NAbkU2GZ4wxQHiD1+aJyGBgkLdolapWhLHvHsDmkPfZwLHVthkIICKfAz5guqq+W31HInItcC1Ar169wjh0PQQCXvWRjVEwxpg6q49E5AYgVVWXqeoyoLWIXN9Ix48HBgDjgCnAk95d3vajqk+oaqaqZnbq1KmRDu0pKwANWPWRMcYQXpvCNd6d1wDwqnquCeNzW4CeIe8zvGWhsoHZqlqhqt8Bq3FJoulUDVyzkoIxxoSVFHyhN9jxGpATw/jcPGCAiPQRkURgMjC72jZv4EoJiEhHXHXS+jD23XhsNLMxxgSF09D8LvCSiDzuvf8R8E5dH1JVv4jcCLyHay94RlWXi8i9QJaqzvbWnSEiK4BK4E5VzW3IiTSYTYZnjDFB4SSFn+EaeX/svV+C64FUJ1WdA8yptuyekNcK3OY9osOmzTbGmKA6q49UNQB8DWzAdTM9BVgZ2bCakFUfGWNMUK0lBREZiOsRNAXYBbwEoKrjmya0JlKSB+KD5LbRjsQYY6LuYNVH3wKfAeeq6loAEbm1SaJqSlWjmW0yPGOMOWj10feBbcDHIvKkiJyKG9HcsthoZmOMCao1KajqG6o6GRgMfIyb7qKziDwqImc0UXyRV2yjmY0xpko4Dc17VfUF717NGcBCXI+klsFmSDXGmKB63aNZVXd7U06cGqmAmlyxJQVjjKlSr6TQ4qi6hmZrUzDGGCDWk0J5EQQqrKRgjDGe2E4KwdHM1tBsjDEQ80nBRjMbY0yo2E4KJTZttjHGhIrtpFBsM6QaY0woSwpg1UfGGOOJ8aSQCwikpEc7EmOMaRZiOymU5LmEEOeLdiTGGNMsxHZSsMnwjDFmPzGeFHKt55ExxoSI7aRgk+EZY8x+Yjsp2LTZxhizH0sKKe2iHYUxxjQbsZsUyovBX2LVR8YYEyJ2k4JNcWGMMQeI3aRgo5mNMeYAMZwUbNpsY4ypLnaTQolNhmeMMdXFblKw6iNjjDmAJQUrKRhjTFDsJoWSPEhqA76EaEdijDHNRuwmheJcKyUYY0w1MZwUbIZUY4ypLqJJQUQmiMgqEVkrInfVsH6aiOwUkUXe438iGc9+bDI8Y4w5QHykdiwiPuAR4HQgG5gnIrNVdUW1TV9S1RsjFUetinOh48AmP6wxxjRnkSwpjAHWqup6VS0HZgKTIni8+inebdVHxhhTTSSTQg9gc8j7bG9ZdReKyBIReUVEekYwnn385VBeaKOZjTGmmmg3NL8J9FbVo4EPgBk1bSQi14pIlohk7dy589CPGhzNbNNmG2NMqEgmhS1A6JV/hrcsSFVzVbXMe/sUMKqmHanqE6qaqaqZnTp1OvTIbDSzMcbUKJJJYR4wQET6iEgiMBmYHbqBiHQLeTsRWBnBePaxyfCMMaZGEet9pKp+EbkReA/wAc+o6nIRuRfIUtXZwE0iMhHwA3nAtEjFsx+bDM8YY2oUsaQAoKpzgDnVlt0T8vpu4O5IxlCjYrvBjjHG1CTaDc3RUVV9ZG0Kxhizn9hMCiW7IaEVJCRHOxJjjGlWYjMpFOda1ZExxtQgRpNCHqTYGAVjjKkuNpNCSZ6VFIwxpgaxmRTsXgrGGFOjGE0Kdi8FY4ypSewlhUo/lOZb9ZExxtQg9pJCab57tuojY4w5QOwlBRvNbIwxtYrBpFA1mtm6pBpjTHWxlxRsMjxjjKlVRCfEa5Zs2mxjmo2Kigqys7MpLS2NdigtRnJyMhkZGSQkJDTo8zGYFOwGO8Y0F9nZ2aSlpdG7d29EJNrhHPZUldzcXLKzs+nTp0+D9hGb1Ue+JEhMjXYkxsS80tJSOnToYAmhkYgIHTp0OKSSV+wlharRzPY/oTHNgiWExnWof88YTAq7rerIGGNqEYNJweY9MsY4ubm5DB8+nOHDh9O1a1d69OgRfF9eXn7Qz2ZlZXHTTTc1UaRNJ/YamkvyoPOQaEdhjGkGOnTowKJFiwCYPn06rVu35o477giu9/v9xMfX/DOZmZlJZmZmU4TZpGIvKRTbtNnGNEe/fnM5K7buadR9Du3ehl+dN6xen5k2bRrJycksXLiQsWPHMnnyZG6++WZKS0tJSUnhH//4B4MGDeKTTz7hgQce4K233mL69Ols2rSJ9evXs2nTJm655ZbDthQRW0khEHAlBWtTMMYcRHZ2Nl988QU+n489e/bw2WefER8fz4cffsjPf/5zXn311QM+8+233/Lxxx9TWFjIoEGDuO666xo8ViCaYisplBWABqxNwZhmqL5X9JF08cUX4/P5ACgoKGDq1KmsWbMGEaGioqLGz5xzzjkkJSWRlJRE586dycnJISMjoynDbhSx1dBsk+EZY8KQmrpvHNMvf/lLxo8fz7Jly3jzzTdrHQOQlJQUfO3z+fD7/RGPMxJiMylY9ZExJkwFBQX06NEDgGeffTa6wTSB2EoKJVZSMMbUz09/+lPuvvtuRowYcdhe/deHqGq0Y6iXzMxMzcrKatiHF70Ab1wHNy2E9n0bNzBjTL2tXLmSIUOsi3hjq+nvKiLzVbXOPrSxVVKw6iNjjDmoGEsKuSA+SG4b7UiMMaZZiq2kUJJnk+EZY8xBxFZSsNHMxhhzULGXFKw9wRhjahVbSaGq+sgYY0yNIpoURGSCiKwSkbUictdBtrtQRFREIjvloE2bbYwJMX78eN577739lj300ENcd911NW4/btw4qrrEn3322eTn5x+wzfTp03nggQcOetw33niDFStWBN/fc889fPjhh/WMPjIilhRExAc8ApwFDAWmiMjQGrZLA24Gvo5ULACoWvWRMWY/U6ZMYebMmfstmzlzJlOmTKnzs3PmzCE9Pb1Bx62eFO69915OO+20Bu2rsUVyQrwxwFpVXQ8gIjOBScCKatvdB/weuDOCsUB5EQQqrKRgTHP1zl2wfWnj7rPrUXDW72pdfdFFF/GLX/yC8vJyEhMT2bBhA1u3buXFF1/ktttuo6SkhIsuuohf//rXB3y2d+/eZGVl0bFjR+6//35mzJhB586d6dmzJ6NGjQLgySef5IknnqC8vJz+/fvz3HPPsWjRImbPns2nn37Kb37zG1599VXuu+8+zj33XC666CLmzp3LHXfcgd/vZ/To0Tz66KMkJSXRu3dvpk6dyptvvklFRQUvv/wygwcPbty/F5GtPuoBbA55n+0tCxKRkUBPVX37YDsSkWtFJEtEsnbu3NmwaIpz3bP1PjLGeNq3b8+YMWN45513AFdKuOSSS7j//vvJyspiyZIlfPrppyxZsqTWfcyfP5+ZM2eyaNEi5syZw7x584Lrvv/97zNv3jwWL17MkCFDePrppznhhBOYOHEif/zjH1m0aBH9+vULbl9aWsq0adN46aWXWLp0KX6/n0cffTS4vmPHjixYsIDrrruuziqqhora1NkiEgf8CZhW17aq+gTwBLhpLhp0QBvNbEzzdpAr+kiqqkKaNGkSM2fO5Omnn2bWrFk88cQT+P1+tm3bxooVKzj66KNr/Pxnn33GBRdcQKtWrQCYOHFicN2yZcv4xS9+QX5+PkVFRZx55pkHjWXVqlX06dOHgQMHAjB16lQeeeQRbrnlFsAlGYBRo0bx2muvHeqp1yiSJYUtQM+Q9xnesippwJHAJyKyATgOmB2xxmabDM8YU4NJkyYxd+5cFixYQHFxMe3bt+eBBx5g7ty5LFmyhHPOOafW6bLrMm3aNB5++GGWLl3Kr371qwbvp0rV9NyRnJo7kklhHjBARPqISCIwGZhdtVJVC1S1o6r2VtXewFfARFVt4Gx3dQjeS8FKCsaYfVq3bs348eO56qqrmDJlCnv27CE1NZW2bduSk5MTrFqqzUknncQbb7xBSUkJhYWFvPnmm8F1hYWFdOvWjYqKCp5//vng8rS0NAoLCw/Y16BBg9iwYQNr164F4LnnnuPkk09upDMNT8SSgqr6gRuB94CVwCxVXS4i94rIxIN/OgKs+sgYU4spU6awePFipkyZwjHHHMOIESMYPHgwl112GWPHjj3oZ0eOHMmll17KMcccw1lnncXo0aOD6+677z6OPfZYxo4du1+j8OTJk/njH//IiBEjWLduXXB5cnIy//jHP7j44os56qijiIuL48c//nHjn/BBxM7U2d++7abOvuSfEOdr/MCMMfVmU2dHxqFMnR0792gefI57GGOMqVVsTXNhjDHmoCwpGGOi6nCrwm7uDvXvaUnBGBM1ycnJ5ObmWmJoJKpKbm4uycnJDd5H7LQpGGOanYyMDLKzs2nwTAXmAMnJyWRkZDT485YUjDFRk5CQQJ8+faIdhglh1UfGGGOCLCkYY4wJsqRgjDEm6LAb0SwiO4GNDfx4R2BXI4ZzuInl84/lc4fYPn87d+cIVe1U1wcOu6RwKEQkK5xh3i1VLJ9/LJ87xPb527nX79yt+sgYY0yQJQVjjDFBsZYUnoh2AFEWy+cfy+cOsX3+du71EFNtCsYYYw4u1koKxhhjDsKSgjHGmKCYSQoiMkFEVonIWhG5K9rxNCUR2SAiS0VkkYhE5h7YzYiIPCMiO0RkWciy9iLygYis8Z7bRTPGSKnl3KeLyBbv+18kImdHM8ZIEZGeIvKxiKwQkeUicrO3PFa++9rOv17ff0y0KYiID1gNnA5kA/OAKaq6IqqBNRER2QBkqmpMDOARkZOAIuCfqnqkt+wPQJ6q/s67KGinqj+LZpyRUMu5TweKVPWBaMYWaSLSDeimqgtEJA2YD5wPTCM2vvvazv8S6vH9x0pJYQywVlXXq2o5MBOYFOWYTISo6n+AvGqLJwEzvNczcP9YWpxazj0mqOo2VV3gvS4EVgI9iJ3vvrbzr5dYSQo9gM0h77NpwB/rMKbA+yIyX0SujXYwUdJFVbd5r7cDXaIZTBTcKCJLvOqlFll9EkpEegMjgK+Jwe++2vlDPb7/WEkKse5EVR0JnAXc4FUxxCx1daYtv950n0eBfsBwYBvwYFSjiTARaQ28CtyiqntC18XCd1/D+dfr+4+VpLAF6BnyPsNbFhNUdYv3vAN4HVedFmtyvDrXqrrXHVGOp8moao6qVqpqAHiSFvz9i0gC7gfxeVV9zVscM999Tedf3+8/VpLCPGCAiPQRkURgMjA7yjE1CRFJ9RqdEJFU4Axg2cE/1SLNBqZ6r6cC/45iLE2q6gfRcwEt9PsXEQGeBlaq6p9CVsXEd1/b+df3+4+J3kcAXjeshwAf8Iyq3h/diJqGiPTFlQ7A3X71hZZ+7iLyIjAON21wDvAr4A1gFtALN/X6Jara4hpkazn3cbiqAwU2AD8KqWNvMUTkROAzYCkQ8Bb/HFevHgvffW3nP4V6fP8xkxSMMcbULVaqj4wxxoTBkoIxxpggSwrGGGOCLCkYY4wJsqRgjDEmyJKCMR4RqQyZSXJRY86mKyK9Q2cuNaa5io92AMY0IyWqOjzaQRgTTVZSMKYO3v0o/uDdk+IbEenvLe8tIh95E43NFZFe3vIuIvK6iCz2Hid4u/KJyJPeXPfvi0iKt/1N3hz4S0RkZpRO0xjAkoIxoVKqVR9dGrKuQFWPAh7GjYwH+BswQ1WPBp4H/uot/yvwqaoeA4wElnvLBwCPqOowIB+40Ft+FzDC28+PI3NqxoTHRjQb4xGRIlVtXcPyDcApqrrem3Bsu6p2EJFduJuaVHjLt6lqRxHZCWSoalnIPnoDH6jqAO/9z4AEVf2NiLyLuzHOG8AbqloU4VM1plZWUjAmPFrL6/ooC3ldyb42vXOAR3ClinkiYm19JmosKRgTnktDnr/0Xn+Bm3EX4Ae4ycgA5gLXgbsVrIi0rW2nIhIH9FTVj4GfAW2BA0orxjQVuyIxZp8UEVkU8v5dVa3qltpORJbgrvaneMt+AvxDRO4EdgJXestvBp4QkatxJYLrcDc3qYkP+JeXOAT4q6rmN9L5GFNv1qZgTB28NoVMVd0V7ViMiTSrPjLGGBNkJQVjjDFBVlIwxhgTZEnBGGNMkCUFY4wxQZYUjDHGBFlSMMYYE/T/QwBtopfIF04AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.1372518539428711 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time()\n",
+    "plt.plot(history.history['accuracy'])\n",
+    "plt.plot(history.history['val_accuracy'])\n",
+    "plt.title(\"Model Accuracy\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Accuracy')\n",
+    "plt.legend(['Train', 'Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "powered-warren",
+   "metadata": {
+    "papermill": {
+     "duration": 0.075881,
+     "end_time": "2021-04-25T14:21:18.017407",
+     "exception": false,
+     "start_time": "2021-04-25T14:21:17.941526",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 6.4.1 Same model with different Activation functions :\n",
+    "\n",
+    "i) \"Sigmoid\"\n",
+    "\n",
+    "ii) \"tanh\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "important-advisory",
+   "metadata": {
+    "papermill": {
+     "duration": 0.077396,
+     "end_time": "2021-04-25T14:21:18.172052",
+     "exception": false,
+     "start_time": "2021-04-25T14:21:18.094656",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Sigmoid Model :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "geological-firewall",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:21:18.335575Z",
+     "iopub.status.busy": "2021-04-25T14:21:18.331160Z",
+     "iopub.status.idle": "2021-04-25T14:21:18.464845Z",
+     "shell.execute_reply": "2021-04-25T14:21:18.464373Z"
+    },
+    "papermill": {
+     "duration": 0.217425,
+     "end_time": "2021-04-25T14:21:18.464990",
+     "exception": false,
+     "start_time": "2021-04-25T14:21:18.247565",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model_sig = Sequential()\n",
+    "model_sig.add(Conv2D(filters=32, kernel_size=(3, 3), activation='sigmoid', strides=1, padding='same', \n",
+    "                 data_format='channels_last', input_shape=(28,28,1)))\n",
+    "model_sig.add(BatchNormalization())\n",
+    "\n",
+    "model_sig.add(Conv2D(filters=32, kernel_size=(3, 3), activation='sigmoid', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model_sig.add(BatchNormalization())\n",
+    "model_sig.add(Dropout(0.25))\n",
+    "\n",
+    "model_sig.add(Conv2D(filters=64, kernel_size=(3, 3), activation='sigmoid', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model_sig.add(MaxPooling2D(pool_size=(2, 2)))\n",
+    "model_sig.add(Dropout(0.25))\n",
+    "    \n",
+    "    \n",
+    "model_sig.add(Conv2D(filters=128, kernel_size=(3, 3), activation='sigmoid', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model_sig.add(BatchNormalization())\n",
+    "model_sig.add(Dropout(0.25))\n",
+    "\n",
+    "model_sig.add(Flatten())\n",
+    "model_sig.add(Dense(512, activation='sigmoid'))\n",
+    "model_sig.add(BatchNormalization())\n",
+    "model_sig.add(Dropout(0.5))\n",
+    "model_sig.add(Dense(128, activation='sigmoid'))\n",
+    "model_sig.add(BatchNormalization())\n",
+    "model_sig.add(Dropout(0.5))\n",
+    "model_sig.add(Dense(5, activation='softmax'))\n",
+    "model_sig.compile(optimizer=optimizer, loss=\"categorical_crossentropy\", metrics=[\"accuracy\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "historical-action",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:21:18.622658Z",
+     "iopub.status.busy": "2021-04-25T14:21:18.621598Z",
+     "iopub.status.idle": "2021-04-25T14:27:45.422000Z",
+     "shell.execute_reply": "2021-04-25T14:27:45.421437Z"
+    },
+    "papermill": {
+     "duration": 386.882329,
+     "end_time": "2021-04-25T14:27:45.422126",
+     "exception": false,
+     "start_time": "2021-04-25T14:21:18.539797",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/25\n",
+      "375/375 - 17s - loss: 0.9443 - accuracy: 0.6082 - val_loss: 2.2941 - val_accuracy: 0.2952\n",
+      "Epoch 2/25\n",
+      "375/375 - 16s - loss: 0.7909 - accuracy: 0.6705 - val_loss: 0.7399 - val_accuracy: 0.6860\n",
+      "Epoch 3/25\n",
+      "375/375 - 15s - loss: 0.7386 - accuracy: 0.6963 - val_loss: 0.7326 - val_accuracy: 0.7068\n",
+      "Epoch 4/25\n",
+      "375/375 - 16s - loss: 0.7130 - accuracy: 0.7074 - val_loss: 0.5870 - val_accuracy: 0.7622\n",
+      "Epoch 5/25\n",
+      "375/375 - 15s - loss: 0.6914 - accuracy: 0.7191 - val_loss: 0.5629 - val_accuracy: 0.7735\n",
+      "Epoch 6/25\n",
+      "375/375 - 15s - loss: 0.6711 - accuracy: 0.7265 - val_loss: 0.8373 - val_accuracy: 0.6285\n",
+      "Epoch 7/25\n",
+      "375/375 - 15s - loss: 0.6552 - accuracy: 0.7334 - val_loss: 0.7478 - val_accuracy: 0.6812\n",
+      "Epoch 8/25\n",
+      "375/375 - 15s - loss: 0.6454 - accuracy: 0.7398 - val_loss: 0.5399 - val_accuracy: 0.7773\n",
+      "Epoch 9/25\n",
+      "375/375 - 15s - loss: 0.6298 - accuracy: 0.7427 - val_loss: 0.6697 - val_accuracy: 0.7145\n",
+      "Epoch 10/25\n",
+      "375/375 - 16s - loss: 0.6237 - accuracy: 0.7470 - val_loss: 0.4623 - val_accuracy: 0.8118\n",
+      "Epoch 11/25\n",
+      "375/375 - 15s - loss: 0.6146 - accuracy: 0.7516 - val_loss: 0.4995 - val_accuracy: 0.7902\n",
+      "Epoch 12/25\n",
+      "375/375 - 15s - loss: 0.5974 - accuracy: 0.7604 - val_loss: 0.5919 - val_accuracy: 0.7672\n",
+      "Epoch 13/25\n",
+      "375/375 - 15s - loss: 0.5871 - accuracy: 0.7638 - val_loss: 0.4694 - val_accuracy: 0.8145\n",
+      "Epoch 14/25\n",
+      "375/375 - 15s - loss: 0.5813 - accuracy: 0.7666 - val_loss: 0.5499 - val_accuracy: 0.7613\n",
+      "Epoch 15/25\n",
+      "375/375 - 16s - loss: 0.5759 - accuracy: 0.7681 - val_loss: 0.4648 - val_accuracy: 0.8147\n",
+      "Epoch 16/25\n",
+      "375/375 - 15s - loss: 0.5616 - accuracy: 0.7771 - val_loss: 0.5080 - val_accuracy: 0.8005\n",
+      "Epoch 17/25\n",
+      "375/375 - 16s - loss: 0.5595 - accuracy: 0.7752 - val_loss: 0.4642 - val_accuracy: 0.8065\n",
+      "Epoch 18/25\n",
+      "375/375 - 15s - loss: 0.5536 - accuracy: 0.7786 - val_loss: 0.4430 - val_accuracy: 0.8213\n",
+      "Epoch 19/25\n",
+      "375/375 - 16s - loss: 0.5512 - accuracy: 0.7785 - val_loss: 0.4274 - val_accuracy: 0.8230\n",
+      "Epoch 20/25\n",
+      "375/375 - 15s - loss: 0.5447 - accuracy: 0.7813 - val_loss: 0.4139 - val_accuracy: 0.8295\n",
+      "Epoch 21/25\n",
+      "375/375 - 16s - loss: 0.5356 - accuracy: 0.7871 - val_loss: 0.4236 - val_accuracy: 0.8253\n",
+      "Epoch 22/25\n",
+      "375/375 - 16s - loss: 0.5344 - accuracy: 0.7888 - val_loss: 0.4295 - val_accuracy: 0.8245\n",
+      "Epoch 23/25\n",
+      "375/375 - 16s - loss: 0.5334 - accuracy: 0.7877 - val_loss: 0.4526 - val_accuracy: 0.8182\n",
+      "Epoch 24/25\n",
+      "375/375 - 16s - loss: 0.5305 - accuracy: 0.7901 - val_loss: 0.4114 - val_accuracy: 0.8298\n",
+      "Epoch 25/25\n",
+      "375/375 - 16s - loss: 0.5207 - accuracy: 0.7923 - val_loss: 0.4063 - val_accuracy: 0.8367\n",
+      "---Total time in Model 1 : 386.71697974205017 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "history_sig = model_sig.fit(datagen.flow(x_train, y_train, batch_size = batch_size), epochs = epochs, \n",
+    "                              validation_data = (x_val, y_val), verbose=2, \n",
+    "                              steps_per_epoch=x_train.shape[0] // batch_size,\n",
+    "                              callbacks = [reduce_lr])\n",
+    "\n",
+    "print(\"---Total time in Model 1 : %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gorgeous-minister",
+   "metadata": {
+    "papermill": {
+     "duration": 0.08924,
+     "end_time": "2021-04-25T14:27:45.603358",
+     "exception": false,
+     "start_time": "2021-04-25T14:27:45.514118",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### tanh model :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "american-capacity",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:27:45.796787Z",
+     "iopub.status.busy": "2021-04-25T14:27:45.795898Z",
+     "iopub.status.idle": "2021-04-25T14:27:45.926800Z",
+     "shell.execute_reply": "2021-04-25T14:27:45.926324Z"
+    },
+    "papermill": {
+     "duration": 0.233169,
+     "end_time": "2021-04-25T14:27:45.926930",
+     "exception": false,
+     "start_time": "2021-04-25T14:27:45.693761",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model_tan = Sequential()\n",
+    "model_tan.add(Conv2D(filters=32, kernel_size=(3, 3), activation='tanh', strides=1, padding='same', \n",
+    "                 data_format='channels_last', input_shape=(28,28,1)))\n",
+    "model_tan.add(BatchNormalization())\n",
+    "\n",
+    "model_tan.add(Conv2D(filters=32, kernel_size=(3, 3), activation='tanh', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model_tan.add(BatchNormalization())\n",
+    "model_tan.add(Dropout(0.25))\n",
+    "\n",
+    "model_tan.add(Conv2D(filters=64, kernel_size=(3, 3), activation='tanh', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model_tan.add(MaxPooling2D(pool_size=(2, 2)))\n",
+    "model_tan.add(Dropout(0.25))\n",
+    "    \n",
+    "    \n",
+    "model_tan.add(Conv2D(filters=128, kernel_size=(3, 3), activation='tanh', strides=1, padding='same', \n",
+    "                 data_format='channels_last'))\n",
+    "model_tan.add(BatchNormalization())\n",
+    "model_tan.add(Dropout(0.25))\n",
+    "\n",
+    "model_tan.add(Flatten())\n",
+    "model_tan.add(Dense(512, activation='tanh'))\n",
+    "model_tan.add(BatchNormalization())\n",
+    "model_tan.add(Dropout(0.5))\n",
+    "model_tan.add(Dense(128, activation='tanh'))\n",
+    "model_tan.add(BatchNormalization())\n",
+    "model_tan.add(Dropout(0.5))\n",
+    "model_tan.add(Dense(5, activation='softmax'))\n",
+    "model_tan.compile(optimizer=optimizer, loss=\"categorical_crossentropy\", metrics=[\"accuracy\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "precious-privilege",
+   "metadata": {
+    "papermill": {
+     "duration": 0.09137,
+     "end_time": "2021-04-25T14:27:46.112811",
+     "exception": false,
+     "start_time": "2021-04-25T14:27:46.021441",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Comparision of losses and Accuracy in different activation functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "rolled-marble",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:27:46.300348Z",
+     "iopub.status.busy": "2021-04-25T14:27:46.299224Z",
+     "iopub.status.idle": "2021-04-25T14:34:30.182423Z",
+     "shell.execute_reply": "2021-04-25T14:34:30.181926Z"
+    },
+    "papermill": {
+     "duration": 403.979972,
+     "end_time": "2021-04-25T14:34:30.182553",
+     "exception": false,
+     "start_time": "2021-04-25T14:27:46.202581",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/25\n",
+      "375/375 - 17s - loss: 1.0515 - accuracy: 0.5420 - val_loss: 0.9276 - val_accuracy: 0.5535\n",
+      "Epoch 2/25\n",
+      "375/375 - 16s - loss: 0.8394 - accuracy: 0.6446 - val_loss: 1.0198 - val_accuracy: 0.5458\n",
+      "Epoch 3/25\n",
+      "375/375 - 15s - loss: 0.7761 - accuracy: 0.6758 - val_loss: 0.6459 - val_accuracy: 0.7285\n",
+      "Epoch 4/25\n",
+      "375/375 - 16s - loss: 0.7472 - accuracy: 0.6935 - val_loss: 0.5758 - val_accuracy: 0.7655\n",
+      "Epoch 5/25\n",
+      "375/375 - 15s - loss: 0.7211 - accuracy: 0.7030 - val_loss: 0.6207 - val_accuracy: 0.7455\n",
+      "Epoch 6/25\n",
+      "375/375 - 16s - loss: 0.7062 - accuracy: 0.7100 - val_loss: 0.5701 - val_accuracy: 0.7683\n",
+      "Epoch 7/25\n",
+      "375/375 - 16s - loss: 0.6968 - accuracy: 0.7131 - val_loss: 0.6632 - val_accuracy: 0.7270\n",
+      "Epoch 8/25\n",
+      "375/375 - 16s - loss: 0.6856 - accuracy: 0.7196 - val_loss: 0.5471 - val_accuracy: 0.7750\n",
+      "Epoch 9/25\n",
+      "375/375 - 15s - loss: 0.6646 - accuracy: 0.7311 - val_loss: 0.5987 - val_accuracy: 0.7523\n",
+      "Epoch 10/25\n",
+      "375/375 - 16s - loss: 0.6533 - accuracy: 0.7335 - val_loss: 0.5121 - val_accuracy: 0.7920\n",
+      "Epoch 11/25\n",
+      "375/375 - 15s - loss: 0.6477 - accuracy: 0.7385 - val_loss: 0.5176 - val_accuracy: 0.7905\n",
+      "Epoch 12/25\n",
+      "375/375 - 15s - loss: 0.6382 - accuracy: 0.7418 - val_loss: 0.6051 - val_accuracy: 0.7503\n",
+      "Epoch 13/25\n",
+      "375/375 - 16s - loss: 0.6275 - accuracy: 0.7460 - val_loss: 0.4886 - val_accuracy: 0.8107\n",
+      "Epoch 14/25\n",
+      "375/375 - 16s - loss: 0.6243 - accuracy: 0.7499 - val_loss: 0.5343 - val_accuracy: 0.7852\n",
+      "Epoch 15/25\n",
+      "375/375 - 18s - loss: 0.6119 - accuracy: 0.7535 - val_loss: 0.5096 - val_accuracy: 0.7945\n",
+      "Epoch 16/25\n",
+      "375/375 - 16s - loss: 0.6015 - accuracy: 0.7580 - val_loss: 0.4822 - val_accuracy: 0.8052\n",
+      "Epoch 17/25\n",
+      "375/375 - 16s - loss: 0.5992 - accuracy: 0.7600 - val_loss: 0.4825 - val_accuracy: 0.8123\n",
+      "Epoch 18/25\n",
+      "375/375 - 15s - loss: 0.5903 - accuracy: 0.7649 - val_loss: 0.4918 - val_accuracy: 0.8012\n",
+      "Epoch 19/25\n",
+      "375/375 - 17s - loss: 0.5874 - accuracy: 0.7657 - val_loss: 0.6496 - val_accuracy: 0.7450\n",
+      "Epoch 20/25\n",
+      "375/375 - 17s - loss: 0.5862 - accuracy: 0.7676 - val_loss: 0.4749 - val_accuracy: 0.8075\n",
+      "Epoch 21/25\n",
+      "375/375 - 18s - loss: 0.5755 - accuracy: 0.7720 - val_loss: 0.4822 - val_accuracy: 0.8073\n",
+      "Epoch 22/25\n",
+      "375/375 - 16s - loss: 0.5789 - accuracy: 0.7706 - val_loss: 0.5594 - val_accuracy: 0.7797\n",
+      "Epoch 23/25\n",
+      "375/375 - 16s - loss: 0.5741 - accuracy: 0.7728 - val_loss: 0.4890 - val_accuracy: 0.8033\n",
+      "Epoch 24/25\n",
+      "375/375 - 15s - loss: 0.5669 - accuracy: 0.7748 - val_loss: 0.4912 - val_accuracy: 0.8017\n",
+      "Epoch 25/25\n",
+      "375/375 - 17s - loss: 0.5703 - accuracy: 0.7744 - val_loss: 0.4941 - val_accuracy: 0.8008\n",
+      "---Total time in Model 1 : 403.88015270233154 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "history_tan = model_tan.fit(datagen.flow(x_train, y_train, batch_size = batch_size), epochs = epochs, \n",
+    "                              validation_data = (x_val, y_val), verbose=2, \n",
+    "                              steps_per_epoch=x_train.shape[0] // batch_size,\n",
+    "                              callbacks = [reduce_lr])\n",
+    "\n",
+    "print(\"---Total time in Model 1 : %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "productive-sixth",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:34:30.417178Z",
+     "iopub.status.busy": "2021-04-25T14:34:30.415806Z",
+     "iopub.status.idle": "2021-04-25T14:34:30.596992Z",
+     "shell.execute_reply": "2021-04-25T14:34:30.596354Z"
+    },
+    "papermill": {
+     "duration": 0.309356,
+     "end_time": "2021-04-25T14:34:30.597145",
+     "exception": false,
+     "start_time": "2021-04-25T14:34:30.287789",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEWCAYAAAB1xKBvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAABtXklEQVR4nO2dd3hUxf6H39mSbHolIdQQegkk9F4VwYIVkIsFC14rlmvXq1y9eO0/9YpdxILitaOCjS5FKYbeIYGEEEjPJtk+vz/OZrMhhZBkCSTzPs95zjkzc86Zk7Kfne/MfEZIKVEoFAqF4lToGrsCCoVCoTg3UIKhUCgUilqhBEOhUCgUtUIJhkKhUChqhRIMhUKhUNQKJRgKhUKhqBVKMBSKOiKEiBdCSCGEoRZlZwghfj8T9VIofIUSDEWzQAiRKoSwCSGiT0r/y/2hH99IVTst4VEoGhMlGIrmxCFgWtmJECIRCGy86igU5xZKMBTNiY+B67zOrwc+8i4ghAgTQnwkhDghhEgTQjwuhNC58/RCiBeFENlCiIPARVVc+74QIlMIkSGE+LcQQl+fCgshWgkhFgkhcoUQ+4UQM73yBgohNgohCoUQWUKIl93pJiHEJ0KIHCFEvhBigxAitj71UChACYaiebEeCBVCdHd/kF8NfHJSmf8CYUACMApNYG5w580ELgaSgf7AVSddOx9wAJ3cZcYDN9ezzguBdKCV+3nPCCHGuvNeBV6VUoYCHYH/udOvd79DWyAKuBUorWc9FAolGIpmR1kr43xgF5BRluElIo9IKYuklKnAS8C17iJTgFeklEeklLnAf7yujQUuBO6RUhZLKY8D/+e+X50QQrQFhgEPSSktUsoU4D3KW0l2oJMQIlpKaZZSrvdKjwI6SSmdUspNUsrCutZDoShDCYaiufEx8DdgBieFo4BowAikeaWlAa3dx62AIyflldHefW2mOwyUD7wNxNSjrq2AXCllUTX1uQnoAux2h50udqd/DPwMLBRCHBVCPC+EMNajHgoFoARD0cyQUqahdX5fCHx9UnY22rfz9l5p7ShvhWSihXm888o4AliBaClluHsLlVL2rEd1jwKRQoiQquojpdwnpZyGJkrPAV8KIYKklHYp5b+klD2AoWhhtOtQKOqJEgxFc+QmYKyUstg7UUrpROsHmCOECBFCtAfuo7yf43/ALCFEGyFEBPCw17WZwC/AS0KIUCGETgjRUQgx6jTq5e/usDYJIUxowrAW+I87rbe77p8ACCGuEUK0kFK6gHz3PVxCiDFCiER3iK0QTQRdp1EPhaJKlGAomh1SygNSyo3VZN8FFAMHgd+BT4F57rx30UI9W4DNVG6hXAf4ATuBPOBLIO40qmZG65wu28aiDQOOR2ttfAM8KaX8zV1+ArBDCGFG6wC/WkpZCrR0P7sQrZ9mJVqYSqGoF0ItoKRQKBSK2qBaGAqFQqGoFUowFAqFQlErlGAoFAqFolYowVAoFApFrWhS7pjR0dEyPj6+sauhUCgU5wybNm3KllK2qE3ZJiUY8fHxbNxY3WhJhUKhUJyMECLt1KU0VEhKoVAoFLVCCYZCoVAoaoUSDIVCoVDUiibVh6FQKCpit9tJT0/HYrE0dlUUjYzJZKJNmzYYjXU3LlaCoVA0YdLT0wkJCSE+Ph4hRGNXR9FISCnJyckhPT2dDh061Pk+KiSlUDRhLBYLUVFRSiyaOUIIoqKi6t3SVIKhUDRxlFgooGH+Dpq9YEgpyX7zTcyrf2/sqigUCsVZTbMXDCEEOe/Pw7xqVWNXRaFokuj1epKSkujVqxeXXHIJ+fn5NZafPXs2L774Yq3uvW3bNpKSkkhKSiIyMpIOHTqQlJTEeeedV6vrFy1axLPPPlursgofCoYQoq0QYrkQYqcQYocQ4u4qykwXQmwVQmwTQqwVQvTxykt1p6cIIXw6fVsfGYkzN9eXj1Aomi0BAQGkpKSwfft2IiMjmTt3boPdOzExkZSUFFJSUpg0aRIvvPACKSkp/Pbbb54yDoej2usnTZrEww8/XG2+oiK+bGE4gH+41xUeDNwhhOhxUplDwCgpZSLwNPDOSfljpJRJUsr+PqwnhogInHlKMBQKXzNkyBAyMrQl0g8cOMCECRPo168fI0aMYPfu3ZXKjx492mP3k52dTW294kaPHs0999xD//79efXVV/n+++8ZNGgQycnJnHfeeWRlZQEwf/587rzzTgBmzJjBrFmzGDp0KAkJCXz55ZcN8MZNC58Nq3WvcZzpPi4SQuwCWqMtX1lWZq3XJeuBNr6qT03oIyOxZ2Y2xqMVijPGv77fwc6jhQ16zx6tQnnykp61Kut0Olm6dCk33XQTALfccgtvvfUWnTt35o8//uD2229n2bJlDVY3m83mEZu8vDzWr1+PEIL33nuP559/npdeeqnSNZmZmfz+++/s3r2bSZMmcdVVVzVYfZoCZ2QehhAiHkgG/qih2E3AEq9zCfwihJDA21LKk1sfDYY+MgLLjh2+ur1C0awpLS0lKSmJjIwMunfvzvnnn4/ZbGbt2rVMnjzZU85qtTboc6dOneo5Tk9PZ+rUqWRmZmKz2aqdi3DZZZeh0+no0aOHpxWiKMfngiGECAa+Au6RUlb59UYIMQZNMIZ7JQ+XUmYIIWKAX4UQu6WUlXqmhRC3ALcAtGvXrk51NERG4sjLQ0qphiAqmiy1bQk0NGV9GCUlJVxwwQXMnTuXGTNmEB4eTkpKSo3XGgwGXC4XwGnPIQgKCvIc33XXXdx3331MmjSJFStWMHv27Cqv8ff39xxLKU/rec0Bn46SEkIY0cRigZTy62rK9AbeAy6VUuaUpUspM9z748A3wMCqrpdSviOl7C+l7N+iRa0s3Suhj4gEux2X2Vyn6xUKxakJDAzktdde46WXXiIwMJAOHTrwxRdfANqH85YtWypdEx8fz6ZNmwDq1adQUFBA69atAfjwww/rfJ/mji9HSQngfWCXlPLlasq0A74GrpVS7vVKDxJChJQdA+OB7b6qqz4yAkCNlFIofExycjK9e/fms88+Y8GCBbz//vv06dOHnj178t1331Uqf//99/Pmm2+SnJxMdnZ2nZ87e/ZsJk+eTL9+/YiOjq7PKzRrhK+aXUKI4cBqYBvgcic/CrQDkFK+JYR4D7gSKFvAwyGl7C+ESEBrVYAWNvtUSjnnVM/s37+/rMsCSuZVqzhyy99p/9mnBCYnn/b1CsXZyq5du+jevXtjV0NxllDV34MQYlNtR6L6cpTU70CNHQJSypuBm6tIPwj0qXyFb9BHRALgzMs7U49UKBSKc45mP9MbwKBCUgqFQnFKlGCgzcMAcOQowVAoFIrqUIIB6AICEAEBqoWhUCgUNaAEw40hIgKHsgdRKBSKalGC4UYzIFSd3gqFQlEdSjDc6CMjVEhKofAx8fHxJCYm0rt3b0aNGkVaWlqN5b3NAWvDmDFj+PnnnyukvfLKK9x2223VXuNtcHjhhRdWab9eG8v1b7/9lp07PVZ5PPHEExVcc5sCSjDcGCI0exCFQuFbli9fztatWxk9ejT//ve/G/Te06ZNY+HChRXSFi5cyLRp02p1/eLFiwkPD6/Ts08WjKeeeqrW63KcKyjBcFO2Jobyj1EozgzeVucnTpzgyiuvZMCAAQwYMIA1a9ZUKj9jxowK9iDBwcGVylx11VX8+OOP2Gw2AFJTUzl69CgjRozgtttuo3///vTs2ZMnn3yyyjrFx8d7ZpTPmTOHLl26MHz4cPbs2eMp8+677zJgwAD69OnDlVdeSUlJCWvXrmXRokU88MADJCUlceDAgQr1Xbp0KcnJySQmJnLjjTd6jBbj4+N58skn6du3L4mJiVVavJ9NnBG32nMBfWQE0mpFlpQgvEzLFIomw5KH4di2hr1ny0SYWLcV63766Scuu+wyAO6++27uvfdehg8fzuHDh7ngggvYtWvXad8zMjKSgQMHsmTJEi699FIWLlzIlClTEEIwZ84cIiMjcTqdjBs3jq1bt9K7d+8q77Np0yYWLlxISkoKDoeDvn370q9fPwCuuOIKZs6cCcDjjz/O+++/z1133cWkSZO4+OKLK1miWywWZsyYwdKlS+nSpQvXXXcdb775Jvfccw8A0dHRbN68mTfeeIMXX3yR995777Tf+0yhWhhuDGVzMVRYSqHwKWPGjKF169YsWbLEEyr67bffuPPOO0lKSmLSpEkUFhZirqMZqHdYyjsc9b///Y++ffuSnJzMjh07KoSPTmb16tVcfvnlBAYGEhoayqRJkzx527dvZ8SIESQmJrJgwQJ2nGJphD179tChQwe6dOkCwPXXX88qryWhr7jiCgD69etHampqnd75TKFaGG489iC5udCmUdZxUih8Sx1bAg3N8uXLCQ8PZ/r06Tz55JO8/PLLuFwu1q9fj8lkqvY6b6tzl8vlCTudzKWXXsq9997L5s2bKSkpoV+/fhw6dIgXX3yRDRs2EBERwYwZM07bLr2MGTNm8O2339KnTx/mz5/PihUr6nSfMsos1fV6fY3LyZ4NqBaGmzJ7EIcaKaVQ+ByDwcArr7zCRx99RG5uLuPHj+e///2vJ7+qdTK8rc4XLVqE3W6v8t7BwcGMGTOGG2+80dO6KCwsJCgoiLCwMLKysliyZEmV15YxcuRIvv32W0pLSykqKuL777/35BUVFREXF4fdbmfBggWe9JCQEIqKiirdq2vXrqSmprJ//34APv74Y0aNGlXj889WlGC4KbMHUXMxFIozQ1xcHNOmTWPu3Lm89tprbNy4kd69e9OjRw/eeuutSuVnzpzJypUr6dOnD+vWrauwQNLJTJs2jS1btngEo0+fPiQnJ9OtWzf+9re/MWzYsBrr1rdvX6ZOnUqfPn2YOHEiAwYM8OQ9/fTTDBo0iGHDhtGtWzdP+tVXX80LL7xAcnIyBw4c8KSbTCY++OADJk+eTGJiIjqdjltvvbXWP6ezCZ/ZmzcGdbU3B3CazeztP4CYB+4nyr3msEJxrqPszRXe1NfeXLUw3OiCghBGowpJKRQKRTUowXAjhFD2IAqFQlEDvlyita0QYrkQYqcQYocQ4u4qygghxGtCiP1CiK1CiL5eedcLIfa5t+t9VU9vyibvKRQKhaIyvhxW6wD+IaXc7F6fe5MQ4lcppffg54lAZ/c2CHgTGCSEiASeBPoD0n3tIimlT7/+a461qoWhUCgUVeGzFoaUMlNKudl9XATsAlqfVOxS4COpsR4IF0LEARcAv0opc90i8SswwVd1LUO1MBQKhaJ6zkgfhhAiHkgG/jgpqzVwxOs83Z1WXXpV975FCLFRCLHxxIkT9aqncqxVKBSK6vG5YAghgoGvgHuklIUNfX8p5TtSyv5Syv4tWrSo170MkZG4SkpwuY3BFApF/ZkzZw49e/akd+/eJCUl8ccf2vfGm2++uUZ7jobgdOzK58yZQ1JSEklJSej1es/xa6+9VqtnnYn3aWx8ag0ihDCiicUCKeXXVRTJANp6nbdxp2UAo09KX+GbWpbjbQ+ii4vz9eMUiibPunXr+OGHH9i8eTP+/v5kZ2d7LD3OhMne4sWLa132scce47HHHgO02eInzzaXUiKlRKer+nv22Wwa2FD4cpSUAN4HdkkpX66m2CLgOvdoqcFAgZQyE/gZGC+EiBBCRADj3Wk+Ra/sQRSKBiUzM5Po6GiPX1J0dDStWrUCKi5c9P7779OlSxcGDhzIzJkzPYsmzZgxg9tuu43BgweTkJDAihUruPHGG+nevTszZszwPOezzz4jMTGRXr168dBDD3nSa2NXXhOpqal07dqV6667jl69enHkyJFqbdK93yc4OJjHHnuMPn36MHjwYLKysur4Ezy78GULYxhwLbBNCJHiTnsUaAcgpXwLWAxcCOwHSoAb3Hm5QoingQ3u656SUvr8U9yg7EEUTZjn/nyO3bkNu95Ct8huPDTwoWrzx48fz1NPPUWXLl0477zzmDp1aiUfpaNHj/L000+zefNmQkJCGDt2LH369PHk5+XlsW7dOhYtWsSkSZNYs2YN7733HgMGDCAlJYWYmBgeeughNm3aREREBOPHj+fbb7/1WKdDzXblp2Lfvn18+OGHDB48GKBWNunFxcUMHjyYOXPm8OCDD/Luu+/y+OOP1+p5ZzO+HCX1u5RSSCl7SymT3NtiKeVbbrHAPTrqDillRyllopRyo9f186SUndzbB76qpzeekFSeamEoFA1BcHAwmzZt4p133qFFixZMnTqV+fPnVyjz559/MmrUKCIjIzEajUyePLlC/iWXXIIQgsTERGJjYz1+TD179iQ1NZUNGzYwevRoWrRogcFgYPr06RXsw6Fmu/JT0b59e49YQO1s0v38/Lj44ouBc8O2vLYoe3MvlGOtoilTU0vAl+j1ekaPHs3o0aNJTEzkww8/rBBOOhVl4SydTuc5Ljt3OBwYjcaGrnIFvE0Oa2uTbjQa0aLy54ZteW1R1iBe6EJDQa9XISmFooHYs2cP+/bt85ynpKTQvn37CmUGDBjAypUrycvLw+Fw8NVXX53WMwYOHMjKlSvJzs7G6XTy2WefVQp71WRXfjqcrk16U0O1MLwQOh36iAgVklIoGgiz2cxdd91Ffn4+BoOBTp068c4771Qo07p1ax599FEGDhxIZGQk3bp1IywsrNbPiIuL49lnn2XMmDFIKbnooou49NJLK5TxtiuPiYmpYFd+OnjbpLdt2/aUNulNDWVvfhIHL5mEsV072s59vYFqpVA0HueKvbnZbCY4OBiHw8Hll1/OjTfeyOWXX97Y1WpyKHvzBkbZgygUZ57Zs2eTlJREr1696NChQ4URToqzBxWSOgl9ZATWnbsauxoKRbPi5FnXirMT1cI4CUNEpHKsVSgUiipQgnES+shIXIWFyGoWmFcoFIrmihKMk/DYg6hWhkKhUFRACcZJeOxBlGAoFApFBZRgnIS3Y61CoWhY5s2bR2JiIr1796ZXr1589913ADzxxBP89ttvPn12dfbj8+fP95gdlpGamkqbNm1wuVwV0r3t2U8mNTWVXr16AbBx40ZmzZpVZTlvQ8TqeOaZZyqcDx06tMbyZwo1SuoklD2IQuEb0tPTmTNnDps3byYsLAyz2UzZomdPPfWUz59/Ovbj8fHxtGvXjtWrV3tmje/evZuioiIGDRp0yuv79+9P//61mtpQJc888wyPPvqo53zt2rV1vldDoloYJ6FXjrUKhU84fvw4ISEhBAcHA5oxYYcOHQDNxvzLL78EtDUsunXrRr9+/Zg1a5bHxG/27Nlcf/31jBgxgvbt2/P111/z4IMPkpiYyIQJE7C7B6osXbqU5ORkEhMTufHGG7G6F0Tzth//4IMPPHbqa9asqbK+06ZNY+HChZ7zhQsXcvXVV5OamsqIESPo27cvffv2rfLDfMWKFZ565+TkMH78eHr27MnNN9+M92Tpyy67jH79+tGzZ0/PDPiHH36Y0tJSkpKSmD59uudnBdqaHA888AC9evUiMTGRzz//3PO80aNHc9VVV9GtWzemT5+OLyZlqxbGSejDw0EIZQ+iaHIce+YZrLsa1t7cv3s3Wnp9E66JPn36EBsbS4cOHRg3bhxXXHEFl1xySYUyFouFv//976xatYoOHTowbdq0CvkHDhxg+fLl7Ny5kyFDhvDVV1/x/PPPc/nll/Pjjz8yYcIEZsyYwdKlS+nSpQvXXXcdb775Jvfcc4/nHpmZmTz55JNs2rSJsLAwxowZQ3JycqX6TpkyhaSkJP773/9iMBj4/PPP+eKLL4iJieHXX3/FZDKxb98+pk2bRk0OE//6178YPnw4TzzxBD/++CPvv/++J2/evHlERkZSWlrKgAEDuPLKK3n22Wd5/fXXKy3gBPD111+TkpLCli1byM7OZsCAAYwcORKAv/76ix07dtCqVSuGDRvGmjVrGD58eG1+NbVGtTBOQuj16MPCVEhKoWhg9Ho9P/30E19++SVdunTh3nvvZfbs2RXK7N69m4SEBE/L42TBmDhxIkajkcTERJxOJxMmTAAgMTGR1NRU9uzZQ4cOHejSpQsA119/fSWr8z/++MNjh+7n58fUqVOrrG9sbCy9evVi6dKlpKSkYDAY6NWrF3a7nZkzZ5KYmMjkyZNPuSzrqlWruOaaawC46KKLiIiI8OS99tprnkWWjhw5UsGosSp+//13pk2bhl6vJzY2llGjRrFhg7Zs0MCBA2nTpg06nY6kpCSfWKqrFkYVaPYgKiSlaFrUtiXgS4QQDBw4kIEDB3L++edzww03VBKNmvC2Ove2EC+zOm9oysJSsbGxHvH6v//7P2JjY9myZQsulwuTyVSne69YsYLffvuNdevWERgYyOjRo6u0Sq8t3tbvvrJU9+USrfOEEMeFENuryX9ACJHi3rYLIZxCiEh3XqoQYps7r35ugnVAHxmhRkkpFA3M0aNH2bx5s+e8Kqvzrl27cvDgQc+347IYfW3p2rUrqamp7N+/H4CPP/64ktX5oEGDWLlyJTk5Odjtdr744otq73fFFVewePFiPv/8c66++moACgoKiIuLQ6fT8fHHH+N0Omus08iRI/n0008BWLJkCXnuIfsFBQVEREQQGBjI7t27Wb9+vecao9Ho6ZPxZsSIEXz++ec4nU5OnDjBqlWrGDhwYC1+Mg2DL1sY84HXgY+qypRSvgC8ACCEuAS496RlWMdIKWsee+YjDBGRWA8ebIxHKxRNFrvdzv3338/Ro0cxmUy0aNGCt956q0KZgIAA3njjDSZMmEBQUNBp25CbTCY++OADJk+ejMPhYMCAAdx6660VysTFxTF79myGDBlCeHg4SUlJ1d4vPDycIUOGcOzYMRISEgC4/fbbufLKK/noo4889ayJJ598kmnTptGzZ0+GDh1Ku3btAJgwYQJvvfUW3bt3p2vXrhVW9bvlllvo3bs3ffv2ZcGCBZ70yy+/nHXr1tGnTx+EEDz//PO0bNmS3bsbtm+qOnxqby6EiAd+kFL2OkW5T4HlUsp33eepQP/TFYyGsDcHyHxyNkW//EKXdWfHUDaFoq6cK/bm3pRZnUspueOOO+jcuTP33ntvY1erSXDO25sLIQKBCYD3MlsS+EUIsUkIccsprr9FCLFRCLGxbEx3fdFHRuDMz0eeoqmpUCgannfffZekpCR69uxJQUEBf//73xu7Sgo3Z0On9yXAmpPCUcOllBlCiBjgVyHEbinlqqoullK+A7wDWgujISpkiIgEKXEWFHisQhQKxZnh3nvvVS2Ks5RGb2EAVwOfeSdIKTPc++PAN8CZ69XBe/Ke6vhWKBSKMhpVMIQQYcAo4DuvtCAhREjZMTAeqHKkla9Q9iAKhUJRGZ+FpIQQnwGjgWghRDrwJGAEkFKWDY24HPhFSlnsdWks8I17fLUB+FRK+ZOv6lkVyh5EoVAoKuMzwZBSTqtFmflow2+90w4CfXxTq9rhcaxV9iAKhULh4WzowzjrMESEAyokpVDUl5ycHJKSkkhKSqJly5a0bt3ac26z2Wp1D28jv+q44447SEpKokePHgQEBHieUWZoeCouvPBC8vPza1W2OXM2jJI66xB+fuhCQ1VISqGoJ1FRUR4TvdmzZxMcHMz999/f4M+ZO3cuoK1JcfHFF1cy7nM4HBgM1X/cLV68uMHr1BRRLYxqMEREqJCUQuED3n33XQYMGECfPn248sorKSkpATSL81mzZjF06FASEhIqtA7MZvNpW3evWLGCESNGMGnSJHr06AFUbScO5Ysapaam0r17d2bOnEnPnj0ZP348paWlDfwTOHdRLYxq0EdG4lAtDEUTYvX/9pJ9xNyg94xuG8yIKV1O65orrriCmTNnAvD444/z/vvvc9dddwGa9fjvv//O7t27mTRpEldddRVQd+vuzZs3s337do/7bVV24lFRURWu2bdvH5999hnvvvsuU6ZM4auvvvK4zTZ3VAujGjTHWtXCUCgamu3btzNixAgSExNZsGABO3bs8ORddtll6HQ6evToQVZWlie9rtbdAwcO9IgF1M5OvEOHDh5/qX79+vnEJvxcRbUwqsEQGUHp1i2NXQ2FosE43ZaAr5gxYwbffvstffr0Yf78+axYscKT523R7R12qqt1t7cxYG3txE9+lgpJlaNaGNWgj4jEmZfvk2UOFYrmTFFREXFxcdjt9gpOrL6mJjtxRe1QglEN+sgIcDhwFRY2dlUUiibF008/zaBBgxg2bBjdunU7Y8+dMGECDoeD7t278/DDD1ewE1fUDp/am59pGsreHKBg0SKOPvgQCUsW4+8VA1UoziXORXtzhe845+3Nz1bKZ3urkVIKhUIBSjCqRe82IFQjpRQKhUJDCUY1lK2DoexBFAqFQkMJRjUox1qFQqGoiBKMatD5+6MLDFT2IAqFQuFGCUYNKHsQhUKhKEcJRg0oexCFouEYNGgQSUlJtGvXjhYtWngsyE/HeiM1NZVevXrVWGblypUMGTKkQprD4SA2NpajR49WeY23hfqiRYt49tlnqywXHBxc47Pz8/N54403POdHjx71+GE1BXwmGEKIeUKI40KIKpdXFUKMFkIUCCFS3NsTXnkThBB7hBD7hRAP+6qOp8IQEYFDhaQUigbhjz/+ICUlhaeeeoqpU6eSkpJCSkoK8fHxDfqcESNGkJ6eTlpamiftt99+o2fPnrRq1eqU10+aNImHH67bx87JgtGqVatar8lxLuDLFsZ8YMIpyqyWUia5t6cAhBB6YC4wEegBTBNC9PBhPatFa2GokJRC4Su+//57Bg0aRHJyMuedd57HcHD27NnceOONjB49moSEBF577TXPNU6ns0b7cZ1Ox5QpU1i4cKEnbeHChUybNo0///yTIUOGkJyczNChQ9mzZ0+lOs2fP58777wTgEOHDjFkyBASExN5/PHHPWXMZjPjxo2jb9++JCYm8t133wHw8MMPc+DAAZKSknjggQcqtIgsFgs33HADiYmJJCcns3z5cs/zrrjiCiZMmEDnzp158MEHG+JH6xN8uUTrKiFEfB0uHQjsdy/VihBiIXApsLMBq1cr9JEROHNzkVLiXmNcoThnWT7/HY6nHWzQe8a0T2DMjFvqfP3w4cNZv349Qgjee+89nn/+eV566SUAdu/ezfLlyykqKqJr167cdtttQO3sx6dNm8bMmTN56KGHsFqtLF68mJdffhmDwcDq1asxGAz89ttvPProo3z11VfV1u/uu+/mtttu47rrrvMs0gRgMpn45ptvCA0NJTs7m8GDBzNp0iSeffZZtm/f7lnAyTvcNnfuXIQQbNu2jd27dzN+/Hj27t0LQEpKCn/99Rf+/v507dqVu+66i7Zt29b55+orGtutdogQYgtwFLhfSrkDaA0c8SqTDgyq7gZCiFuAWwDatWvXoJUzREYibTZcxSXog4NOfYFCoTgt0tPTmTp1KpmZmdhstgpW5BdddBH+/v74+/sTExPjaX3Uxn68f//+mM1m9uzZw65duxg0aBCRkZEcOXKE66+/nn379iGEwG6311i/NWvWeATl2muv5aGHHgI0J91HH32UVatWodPpyMjIqGDHXhW///67Z92Pbt260b59e49gjBs3jrCwMAB69OhBWlqaEoyT2Ay0l1KahRAXAt8CnU/3JlLKd4B3QPOSasgKltuD5CrBUJzz1Kcl4Cvuuusu7rvvPiZNmsSKFSuYPXu2J686S/Pa2o9PmzaNhQsXsmvXLqZNmwbAP//5T8aMGcM333xDamoqo0ePPmUdq4ouLFiwgBMnTrBp0yaMRiPx8fFVWqXXlrrat59pGm2UlJSyUEppdh8vBoxCiGggA/CW1jbutDOOsgdRKHxLQUEBrVu3BuDDDz9s0HtPmzaNTz75hGXLlnHppZdWet78+fNPeY9hw4Z5+kK8rdgLCgqIiYnBaDSyfPlyTwd7SEgIRUVFVd5rxIgRnnvs3buXw4cP07Vr1zq/X2PQaIIhhGgp3NIthBjorksOsAHoLIToIITwA64GFjVGHZU9iELhW2bPns3kyZPp168f0dHRDXrv7t27ExQUxNixYz0LKT344IM88sgjJCcn1+pb/KuvvsrcuXNJTEwkI6P8e+v06dPZuHEjiYmJfPTRRx6b9qioKIYNG0avXr144IEHKtzr9ttvx+VykZiYyNSpU5k/f36FlsW5gM/szYUQnwGjgWggC3gSMAJIKd8SQtwJ3AY4gFLgPinlWve1FwKvAHpgnpRyTm2e2ZD25gC29HQOnHc+cXPmEH7lFQ12X4XiTKHszRXe1Nfe3JejpKadIv914PVq8hYDi31Rr9PBEOEOSam5GAqFQqFmeuNywufXwOaPK2WJwECEv7+yB1EoFAqUYIBOD4f/gCN/VMoSQih7EMU5T1NaVVNRdxri70AJBkBkB8hLrTJL2YMozmVMJhM5OTlKNJo5UkpycnIwmUz1uk9jT9w7O4iIh7S1VWYpexDFuUybNm1IT0/nxIkTjV0VRSNjMplo06ZNve6hBAM0wdj6P3BYwVBxmJs+MgLboUONUy+Fop4YjcYKs6cVivqgQlIAER0ACflHKmUZIiJx5KkWhkKhUNRKMIQQQUIInfu4ixBikhDC6NuqnUEi4rV9Ff0Y+shIZEkJrnpM+1coFIqmQG1bGKsAkxCiNfALcC2afXnTwCMYlUNPyh5EoVAoNGorGEJKWQJcAbwhpZwM9PRdtc4wIS3BYKqyhVFuD6LCUgqFonlTa8EQQgwBpgM/utP0vqlSIyCE1sqoKiTl5VirUCgUzZnaCsY9wCPAN1LKHUKIBGC5z2rVGER0gNzKISmDCkkpFAoFUMthtVLKlcBKAHfnd7aUcpYvK3bGiYiHQ6tASq3F4UavQlIKhUIB1H6U1KdCiFAhRBCwHdgphHjgVNedU0TEg70YiitOcNKFhIDRqFoYCoWi2VPbkFQPKWUhcBmwBOiANlKq6RDpntx0Uj+GEAJDeLiyB1EoFM2e2gqG0T3v4jJgkZTSDjQtc5pTzMVQ9iAKhaK5U1vBeBtIBYKAVUKI9kChryrVKIS30/ZVdHzrIyNUSEqhUDR7aiUYUsrXpJStpZQXSo00YExN1wgh5gkhjgshtleTP10IsVUIsU0IsVYI0ccrL9WdniKEaLgl9GrCGAAhraqeixERqUJSCoWi2VPbTu8wIcTLQoiN7u0ltNZGTcwHJtSQfwgYJaVMBJ4G3jkpf4yUMqm2Swc2CNXNxVAhKYVCoah1SGoeUARMcW+FwAc1XSClXAVU+7VcSrlWSln2KbweqJ/vbkMQ2aFaexBXURHSZmuESikUCsXZQW0Fo6OU8kkp5UH39i8goQHrcRPa6KsyJPCLEGKTEOKWmi4UQtxS1vKpt+d/RDwUZYK9tEKyxx4kL79+91coFIpzmNoKRqkQYnjZiRBiGFBaQ/laI4QYgyYYD3klD5dS9gUmAncIIUZWd72U8h0pZX8pZf8WLVrUrzKekVJpFZKVPYhCoVDUfgGlW4GPhBBh7vM84Pr6PlwI0Rt4D5gopcwpS5dSZrj3x4UQ3wAD0RxzfUuE11yMmG6eZGUPolAoFLUfJbVFStkH6A30llImA2Pr82AhRDvga+BaKeVer/QgIURI2TEwHm12ue+pZi6GsgdRKBSK01yi1T3bu4z7gFeqKyuE+AwYDUQLIdKBJwGj+z5vAU8AUcAbQvNucrhHRMUC37jTDMCnUsqfTqeedSYoGoxBlTq+ywRDtTAUCkVzpj5reouaMqWU006RfzNwcxXpB4E+la84AwjhHimVWiFZHxYGOp2ai6FQKJo19VnTu2lZg5RRxVwModOhDw9XczEUCkWzpsYWhhCiiKqFQQABPqlRYxMRD/t/A5cLdOV6quxBFApFc6dGwZBShpypipw1RMSDwwLmLAiN8yQrexCFQtHcqU9IqmniGVpbueNbhaQUCkVzRgnGyVSzLoYKSSkUiuaOEoyTCWsLiEqCYYiIxFlQgHQ6G6VaCoVC0dgowTgZgx+Etam0LoY+MhKkxJmf3zj1UigUikZGCUZVVDG0VtmDKBSK5o4SjKqoQjA89iA5SjAUCkXzRAlGVUTEQ/FxsJo9ScqxVqFQNHeUYFRF2Uip/HKb87KQlEOFpBQKRTNFCUZVlLnWenV868PDAdRcDIVC0WxRggHYLA4cNq/hshGV52IIoxFdWJgKSSkUimZLsxcMS7Gdz/71B5t+8lplLyAC/MOqmIsRodbEUCgUzZZmLximICOtOoez+Zc08o+XaIlCQET7auxBVAtDoVA0T5q9YAAMvbITeoOO1Z/vQ0q3OW9V62JERqiQlEKhaLb4VDCEEPOEEMeFEFUusSo0XhNC7BdCbBVC9PXKu14Isc+91Xv98JoICvNn0CUJHN6Rw6Et2VpiRDzkHwZXed+GISISR24e+zes56v/PIlZiYdCoWhG+LqFMR+YUEP+RKCze7sFeBNACBGJtqTrIGAg8KQQIsKXFU0c3Zqo1kGs/t9e7DanJhhOGxQe9ZSR4WFsCdDx3Yv/JjVlEztXLfNllRQKheKswqeCIaVcBdT0NfxS4COpsR4IF0LEARcAv0opc6WUecCv1Cw89Uan1zHy6q6Yc61sWpJaaaTUicOpLNm5icNRofQ9byKxCZ3Zs3a1L6ukUCgUZxWN3YfRGjjidZ7uTqsuvRJCiFuEEBuFEBtPnDhRr8q06hxO10Et+evXw+Q7tcfJ3IP89fMPLHj0XqwOOwMOHmXouIl0Hz6a46kHyD2aUa9nKhQKxblCYwtGvZFSviOl7C+l7N+iRYt632/IFR0xGHSsWlJMicOf7z7/lWXz3qJdz95cNX0mLYpKcebm0mXIMBCCPetWNcBbKBQKxdlPYwtGBtDW67yNO626dJ8TFObPwEkJpG7dwgeHBpF6JJ/R183k8oeeJLRNG0CzBwmJjKZ11x4qLKVQKJoNjS0Yi4Dr3KOlBgMFUspM4GdgvBAiwt3ZPd6d5nOcDgcFmb9hN3+JXYYyOdlOv4suReh0HsfaMnuQbkNHkpN+mOzDqWeiagqFQtGo+HpY7WfAOqCrECJdCHGTEOJWIcSt7iKLgYPAfuBd4HYAKWUu8DSwwb095U7zCSuOrCCrOIv8Y5ksfPJBNiz6io79R2MIuY7DOb085TyC4R5O23nQUITQsWedamUoFIqmj8GXN5dSTjtFvgTuqCZvHjDPF/XypsBawCOrH6Fvdiu6btKh0+u45N6H6TJ4OEuf/5KUg+PplpZFRPtYdH5+6IKCPPYgQeERtO2ZyJ51qxk65RqEEL6urkKhUDQajR2SanQCpB+3HBlBwhorxRFw7XOv0WXwcACGjDFiEDZW/2+vZwb4yfYgXYeOJC/zKMcPHWiU+isUCsWZotkLhk5vwJhvxzSyO5/12c2nR7/25AW2iWdQ8KccOWDn4F/akN2T7UE6DxqKTq9XYSmFQtHkafaCYTAamfb0C9x++/Nc0nkSb6S8wc+p7v71iHh6Bf5EVEQpv3+xD7vV6bEHKSMgOIT2iUnsWbe63IdKoVAomiDNXjAA9AYDQgieHPIkSS2SePz3x9mRswNMYegCwxnVbRPmPCsbF6dW6VjbdehICk8cJ3PfnkZ6A4VCofA9SjC88NP78cqYV4gwRTBr2SxOlJyAiHjixGa6DWlJym+HKQluiSMvr0JrotOAwegNBhWWUigUTRolGCcRFRDFf8f+lyJbEbOWzcIS3g7yDjHk8k4Y/PSk5Ccg7XZcZrPnGv/AIOKT+rN33Wqky9WItVcoFArfoQSjCrpGduXZEc+yI2cHT3ACmX+EwCAdgy9NIKswgBMtkiuFpboNHYE5L5eM3TsbqdYKhULhW5RgVMPYdmOZ1XcWS0qP8E5YEBSm03NkayIjYF+nKynNyqlQPqHfQAx+/uxWYSmFQtFEUYJRAzf1uomLYwbwekQ4v+79Bp1OMHRsOFb/CP5ak1+hrJ8pgIS+A9i7/ndcTmfVN1QoFIpzGCUYNSCEYPbAx+htsfLYno/YlbOLuO6xxGWuZedeycbFqdhKHZ7y3YaOpLSwgCM7tjVirU+Pkk2byHr+BZwFBY1dFYVCcZajBOMU+EfE8+qJfMJ0Ru5adhf5AU46HfiGuJAS/lh0kI8eW8uGHw9hLXUQn9wPoyngnLE8ly4Xx2bPJnfePA5eehnF6/9o7CopFIqzmGYvGEUWO3cs2Mx3KdW4p+v0RIe15b+GdhTaCrl3/SP4GV0MjdzJ5Ef6E9cpnD+/P8THj60l5dejdEgawL4/1uJ02M/si9QB88qVWPftJ2rmzehMJg7fcANZzz2Py2Zr7KopFIqzkGYvGEF+BlJzinn+pz1Y7NX0PUTE063gOM8Mf4at2VspChQ4cnOJaR/KRbf3ZsqjA2jVWROOI3ujsRSb2b9h05l9kTqQ8977GFrF0WLWLDp8/RXhU6eQ+8EHpE6egmXP3saunkKhOMto9oKh0wkeu6g7GfmlzFtzqOpCEfGQm8p57cZxV/JdHDOWknp4qye7RbsQLrytN1MeG0B8YjIIf35++xv+WHQQS/HZ2dIo2fwXpZs2ETXjBoTRiC4wkLjZs2nz1ps4srNJnTyZnPnz1bwShULhodkLBsDQjtGc1z2GN5YfIMdsrVwgogNYC6A0j5mJMzFFx5B3LJVbf72VZYeX4XBpHd8t2oZw4e3JdOo/GKdtPxt+3M/Hj609K4Uj57330IeHE37VlRXSQ0aPJmHRdwQNH87xZ5/j8E03YT92rJFqqVAoziaUYLh5eGJ3Su1OXvltX+XMiHhtn5eKEIJuCQNp7QhhX/4+7l5+NxO+msBbW97SrESAPuePw+W0MvQyI217RLJxcSofPbqW1Z/v5eBfJyguqEKUziDW/fsxL1tGxPTp6AIDK+UboqJoM/d1Wj71L0pTtnBw0qUULlnSCDVVKBRnEz5dQEkIMQF4FdAD70kpnz0p//+AMe7TQCBGShnuznMCZeNTD0spJ/myrp1igpk+qB0L/jjM9UPb0ykmpDzTIxiHoHVf/KJaEGC28/OVP7PyyEo+3/M5c1Pm8vaWtxnTbgxTOk0mICSUo3s3cPHdD5KTYWbj4lR2rD7K1uXpAIRGm2jZMYy4hDBadgwjslUwOt2ZWYAp5/15CJOJiGumV1tGCEHElCkEDRxIxoMPkXHvfRQtX07Lf/4TfUhItdcpFIqmi88EQwihB+YC5wPpwAYhxCIppcc7Q0p5r1f5u4Bkr1uUSimTfFW/qrh7XGe+2ZzBfxbv5v0ZA8ozvFoYoK2JIS0WdBYb49qPY1z7caQVpvHFni/49sC3/Jr2K+Nj2lO6YQ2DC7OIbh3LBTN74bS7OHGkiGMHCzh2oID0XXns/SMLAKO/ntgOoR4Rie0Qin+gscHf0X7sGAU//EDE1KkYIiJOWd4vPp74BZ+Q/dbbZL/1FiUbN9L6uecIHDDglNcqFIqmhS9bGAOB/VLKgwBCiIXApUB1ZkvTgCd9WJ9TEhXsz+1jOvHcT7tZuz+boZ2itQz/YAhqAblap7jBvba3IzcPP3dIp31oe+4fcD93Jt/JL2m/8KNzARwoZuZbV9Jz6Giu7nY1vaJ70TIhjJYJYXAeSCkpyrF4BCTzYAGbFqciJSAgMi6I2A6hxLQPJaZ9CFGtgtEb6xdFzJ3/IbhcRM6YUetrhNFIi7vuJHjEcDIefIi0664n9vHHiJxefQtFoVA0PYSvFv0RQlwFTJBS3uw+vxYYJKW8s4qy7YH1QBsppdOd5gBSAAfwrJTy22qecwtwC0C7du36paWl1aveFruTcS+tJDzQyPd3Di8PE713Phj8YcYPFK1YQfqttyECAtCHhKALDkYXEow+uPxYBAbx1c4/ESbJwYg0Cgw2nB3b0qpbP3pG9aRHVA+6RnYlwBBQ4fk2i4PjqYUcO1hA5oFCjqcWejrMdQZBdOtgWrgFJKZ9CBFxQej1tRMRZ0EB+8eMJXjcOFq/8Hydfj6u4mLS77mXkj//JOGH7/Fr27ZO91EoFGcHQohNUsr+tSnr0z6M0+Bq4MsysXDTXkqZIYRIAJYJIbZJKSstnC2lfAd4B6B///71Vj+TUc+DE7py98IUvv4rg6v6tdEyIuLh8HoAggYPJub+f+DIzsFpLsJlLsZVVITTXIT92DFcRUW4zGZahgdwJCqU69daMbokDuMRXrq+kEUtFgGgF3oSwhPoEdmDntFuEYnoSptukbTpFln2fhTlWDieVsSJw4UcTyti34YsdqzSJhrqjTpatC0XkRZtQwhtEYDRT1/p3fI++wxXSQlRN99U55+PLiiIuH8/zcGJF3Ls6adp+/bbCHFm+l4UCkXj4kvByAC8v362cadVxdXAHd4JUsoM9/6gEGIFWv9GJcHwBZf0bsW83w/x4s97uCgxjgA/vSYY278Ehw2dyUTUzTef8j7Bu7aTNvthxH+eJr5jNzL+cR+PfllI0AcfsDuogJ05O9mZs5PVGav57sB3gCYiHcM70iOqBz2jetI1sisdwzvSqV8MnfrFACBdkoITpRx3C8iJtCJ2rc1km7tDHcAUbCQk0kRwhD8hkSaCQvUUf7eZ0JGX4mwZj3RJRB072Y2xsUTPuovjzz5H0S+/EnrB+DrdR6FQnFv4MiRlAPYC49CEYgPwNynljpPKdQN+AjpId2WEEBFAiZTSKoSIBtYBl3p3mFdF//795caNGxuk/htSc5n81jruO78Ls8Z1hpRP4dvb4K7NENWxVveQLhfv3nkTLdrHc/lDT2JLSyP16mnoQkOI/+wzT1+IlJKskix2ZO9gR84Oj5DkWcvXDo8JiKFTRCdNPMI70SlcOw4yBgHgcknyj5WQnV5EUa6FolwrRTkWzHkWinIs2K0VZ7Hr9KJcTML9MQUZMQUbMQUZ8Q8yaOdlW7ARo7++QktCOhwcumoyzrw8En78EX1wUH1/5AqFohE4K0JSUkqHEOJO4Ge0YbXzpJQ7hBBPARullIvcRa8GFsqKytUdeFsI4UKbK/LsqcSioRkQH8mEni15a+UBrh7YlhjvobW1FAyh09FlyHD+WvI9FrMZU/v2tHljLodn3ED6bbfT7sP56EwmhBC0DGpJy6CWjGs/DtBEJLM4k/35+9mXt48D+QfYn7+fL/Z8gcVp8TwjLiiOjuEd6RzeWROThE50T+5AoLF8foXLbmfPxVdgj2pLyMP/wpxr1YQk14o5V+t0t5jt2CzV27Lr9AJ/j4gYCAjxw2/s/VgWf8OJZz4n9qqLCQj1IzDEj4BQP/xMehWqUiiaGD5rYTQGDdnCAEjNLua8l1cyuX8b/nNeNLzcHS58EQbOrPU9jh3Yx4JH72X8rbNIHKOFbgp/+YWMu+8h5LxxtH7lFYS+cn9DdThdTjLMGezP3+8Rkf35+zlUcAi7q3w2ecugliSEJZAQlkDS1mLavfgFYS8/Q9zEy6r9IHc6XViLHViK7dpm1vYV0tzppWY7pYW2amew6w06AkKNHgEJDPUjPCaQyLggIuKCCI0y1TkkplAoGo6zooXRFIiPDuLaIe35cG0qM4a0p6vB5JmLUVtiEzoRFtuSPWtXewQjdPx4HI88TNYz/yHruedo+eijtb6fXqenXWg72oW2Y2y7sZ50h8vBkaIjHMg/wMGCgxwsOMihgkN8tfdLen1sJj0Kph7/J6Gfv0RCWAIdwjp49h1CO9AyqCVGvZFA94d7bbHn5LH78qtxte1E+CP/wmK2U1KkiUlJkY3SIhvF+VaOpxVRWpjpuc5g1BHeslxAIt1baLQJnXvUl5RStVIUirMIJRin4O5xnflqUzpzluzho/D2py0YQgi6DhnBhkVfUVJYQGBoGACR112HPeMouR9+iF/r1kRef3296mnQGbQP/7AOFdKLfv+d9KyZmO+fwQMDW3Go4BAHCw6y4sgKvt73dXk9EcQExtA6uDWtglvRKrgVrYNbExcUR+vg1rQMaomfXhOSzH17CAwLJywmFmNUBG3vvY3MRx4hdOco2k+ZUm0drSV28o6VkJtZTG5mMXmZxRzdn8/eP7M8ZXQGQXhsIIF5afhl7CHu+qkEx4Z7hCwgxIhfgEEJiULRCCjBOAXhgX7MGteZf/+4i5yEVkSdpmCAthLfn99+wb4/1tDn/As96TEPPYg9M5OsZ5/D0DLOJ6ONct9/H0NMDP2uu5cBfhVbDvmWfA4WHCStMI3M4kwyzBkcNR9lc9ZmFh9ajEuWO9UKBDGmFvTbE0HMDguYDARdPZQWHTsS3jeM2D7dOPbiCziG9SUiLh6DrvKfln+gsXziohc2i4O8zDIhMXNs9Vay88ASPoSDi9LRjALK0Rt0BIQYCQhxi0hZ30mIEf9ArYPe4KfDz6TH4Kd3n2t7o78evUFZqJ3tqNbl2YkSjFpw7ZD2fLQujdXZwVzKBoSUcBp/zNHt4ols1Yatv/1M54FDCQwLB7RO8VbPP8fhGcc5+uCDGFq0ILCvlztKYSYERIDRVKd6l27bTsm69cQ88AA6v8phpnBTOH1Nfekb27dSnt1l53jJcY6aj3LUfJT0w/swf/MHhuOlpHdwEZZlwf7xCr5N/oKMGAttBkie3+bki3sm8ebFekL8QojwjyDcP5xwUzjh/uG0DGrpabW0Cm5FXFAcfno//EwGbUZ7fAjHn32OyJ8+JHLGDFykkvXpV0S/9Dqu1gmUFtkpKbRRWqiFukqKbJQU2shON1NaZMPlrF1/nE4nMPjrMfrpMJoM+AeePCrM4B4tVj5yzDNarIr5LYqGw+Vy8sMrz1Gcn8/kf87BYGx4exxF3VGd3rXkx62ZbPx8Dk8aP4b790Nwi9O6fsfKpfz81qsY/PwZOOlK+l18GUZ/TQgceXmkXn01roJC2n/2Kf4dOsDeX+B/10KXCTDlwzrVOf3ueyheu5ZOy5ehDw6u0z0Adq5axm/vv4ler2f8bXfTecAQivPz+PI/T5Bz5DC9r5lMYFICujcXEPbFMjY/eQVpCUHkW/LJs+ZRYC0gx5JDdml2hVYLQIuAFloILDCOUd8fJuHHrZRePpawB++jhQgh67Kp6END6fDVl4gaPjyklFhLHNhKHditTuw2Jw6r0+vY5Tm2W9157mNrsR1LscPTyX/yEGRv9EYdAcGaeASG+GEqa+mE+HnSAtytnYAQP4z+SmBOh1WfzmfDd18CkDzxEsbO+Hsj16jpczqd3kowaomUkv+8+gqP5s+m9LqfCEgYctr3yD2azupPP2T/hnUER0QydOo19Bw1Dp1OXz5HIziY+H9dh+G3e0DvB/ZiuG0txPasVR1LCvIJDAvHnpbGgYkXEjVzJjH33XvKa6vCVlrC0vffZOfq5bTu1pML77qf0OhyobSWlPDdi//myI6tjLr2JvqOvYCDF1+CLiiQDl9/XekD3u6yk1Wc5Ql/ZZozOVp8lKNFGSR9s5PzVhbwc7Lg/Qt0nhbcgD0uHvjaxZfjg1k7KpogYxCBxkACDYEEGgMJMAQQaAj0pAcbgwnzDyPcP5ww/zDPFmwMRidqaaFid2EpKR8l5j1iTBMWm2eUWNneYa96oSmDn46AYD/8ArRQmE6vQ28U6PU6dAYdeoPQ0gxCyzfo0LvTA4L9CAzTwm5BYf4EhmmtsabK7jUr+fG1F+hz/kR0BgN/Lfmeyx78Jx37DWrsqjVplGD4iJ1b/qTHN+ezuPNTXDj97jrfJ333DlZ9Mo/MfXuIbtuekdNvID6pH5atW0m79hr8Q0pof20CuqnvwZvDoPN5MHl+tffLy8xg95pV7Fqzkryj6US1aUe8TRK5ej09fvsVQ3T0adcx6+B+fnj1OQqyshh85VQGX3E1uiqG/zpsNpa8/hJ7/1jDgElXktSyHRl33EnM/f+o1Wx4gBOv/ZfsN94gbPJkxIO3cqw0i6Pmo5woOUGJvZgez31H1K5MvnlqLNkhkhJHCaX2UkocJRTbiylxlFBiL6kwrPhk9EJPqF9oBREJ8wsj3BROXFAcbUPa0ia4Da1DWlfy96oNdquT0iIbpUV2bW/WjstGitktTpwOicvpwulwlR/bXTidEpdDS3c5pZbmcFHVv6bBX09QaJmQ+BMUph0Hhfm7BwVoLZ2AECMG47nTusk6dICFTzxIbEJHJv9zDlLCp4//g6KcbK57/jVCIk//b1hRO5Rg+Ap7KcxpyauuyUz9x+u0DKtb3wJorYG969fw+2cfkp+VSbtefRiZFE7gdy+S/nskwWNH0+a/ryNWzIHVL8Pt6yGmm+d6c14ue9etZtfvKzh2YB8IQdvuvWjbqzcH/lhLVtohdELQdfhoeo+7gNbdetaqE1G6XGxa/B2rP/2QwLAwLrzrftr2SKzxGpfLybJ5b7Pl18X0HHUe3bftpXT9ejr+8D3G1q1rvPbEG2+Q/dp/CbvyCuKefhqhq9wKsKVncPDiiwkeMZw2//1vtfeyO+0U2YsosBZ4tnxrvmdfaCuskFZgLSDPmkepo7TCfVoEtKBNSBvaBLfRhCSkfG9NO86RHVvpf8kVGKroF2oopJRYix0UF1gpKbRRUmCluMBW5XF1Ey6N/noCQoyYgt0hsmAjAcHuMJo7zc9kQKcXnk3otNaP0IkK6Tqd1hLylGvADumSwgI+eeQepJRc88z/ERSu2e7nHk3nk4fvoWXHzlz1z3+j0507AnguoQTDhzhe6Mp3RV1Zl/g0L07uU+/7OR12tvy6hHULP8BisdGjjZGenc6n+NXXibjmGmLv+Tvi1d7Q7UKsE19l3x9r2bVmJUe2b0VKFzHxHek+fBRdh44kJEr7Fnb8pZc5tOBjCq6bxp6UjdhKS4hs1YbEcRfQY+RYz9DekykpyOenN1/h0F8b6dh/MBfcOouAkNBavYeUknVffsa6Lz8lvkci3b77hdAhQ2g79/Vqr8l++x1O/N//EXbppcQ9Mweh1+N0ODiw6Q+2/LqE4rxcRl17Ex2S+pH9zrucePll2rz5BiFjxlR7z9NFSkm+NZ/0onSOFB0h3ezeF6WTbk4nqzgLiUTnhOR94fQ6GIpAYG5ppPCidoSHRBNhitA2/4hKx2VDkX2J3eqkpNBKSYE7RFak7S1Fdq2l407T5sjYcDnq9z+vN+g89jFlAwb8g4yYAg34B2pOANq5ZjPjH2goD8cZhBZ2c4uTy+nkyzmPc2zfXq5+6nliEzpVeNb2Fb/x85uvMGzKNQy+8up61VtRNUowfMm8CRzOK2VU9oNcM6g9N4/oQPuoevgoSQkr/oNl2Yv8Kcax+aC2PnjXiFhaL11NyODB5BhzSDOf4IiMxul0Eh4bR7fho+g2dBRRbSraizvNZvaPGUvQsGG0eeX/sFss7Fm3mq3LfiZz7270BgOdBg6l97gJtO2Z6PmmmLYthSWvv4Sl2Myoa28iafxFdfoWmfLLYpbOe5OYsAh6/76JhP++TsjYyh/wOe/P4/gLLxB68cW0eu5ZinJz2Lr0Z7Yv/4Xi/DxColpg8Pcn72g6vcdNYOTUa0mfPh1ZUkrCjz+gCzj9sFFdsDqt7Nz1J+vem0dp5glalpQSnVPE9rYtKIoQrBlcRJbIQ1L1/1GwMZhw/3BC/UMJNLj7XNx9MKc6DjAEeDaTwaTt9aZ6fbuXUmK3OD0hM7vVicspcbm0EJnLKXE5JdIlK6e7JC6HxGZxaAMFShyeAQPWEq2Px2Grui+nOhyly3BYUgiIuIiA0ER0Bnf/jltQQJKX/i2lBTuI7TQD/5D2CKGNdENo85yETtv7Bxo8LSjvQQhlLSpTsPGMrWp5LqEEw5d8cyuugyt4uP3nfPNXBg6XZELPltwyMoHkdqdewa4CUsLPj8H6uZB8DVzyGoW5OaxZ+DE7f1+Bn06Py+HAIcDP7qBVvpnWVict4zti6tEDU/fumLp3w79jR4Q7PJLz/vscf+FF4r/8koBeFTvKsw+nsnXZz+xctQxrcTERca3oNWY81mIzfy76isi41lx094PExCfU60e0d/3vLP7viwTaHAzJK6Xnou8rrB2e++GHZP3nWYImXIDtb1PYuuwXDqVsQiDokNyPPudfSHxSX1wOJ2u/WMCG778mNDqG0WMm4HjsCa0j/x/31auOtcHldPLnd1+y7svP8DcY6LnvMK38g/BPSODQthT+6tSGkJgYLn/kXxBuIt+ST64llzxrHnmWPHItueRbtTSzzezpayl1aP0vpY5SSu2lOKSj1nUSCI94nLwFG4OJCYyhZVBLYoNiaRmo+ZPFBsZi1J+Z4akOuxNriWYlY3ULirXUgcshy/toHC5cThcZe9ayf/1ntOw8mrY9L8HpKuvL0cQKKZES7LZSUje9jpQu2iffgU5nQkpN/KRL27ucElupg9IiO5YSO1XqtwBTkDZ6LSBYax1Jl/T0KTmr6Ec6+RzA4KfN8zEY3XvPufu4bO8+Npr0+AUY8DMZ8A8wYAzQ4+8+19L16I262oWMpfT8LJ1OF067dPd3ScJjAk95fVUowfAlK56DFc/AY1lklcL8tal8sj6NIouDgfGRzByZwLhuMaf+JuNywo/3wab5MOhWuOA/4BW/zzp0gD+/+R9GUwBdBwwmZtN8bGu+x9LmaqwHM7Ds3YssdcfejUb8O3XC1K0b5tWr8e/cifYffFDto+02K/vWr2Hr0p/J2K2ZB/caM56xM27BaKp7v4w3h7dv4dvn/oXeXMz4fsPp/Pg/Acj9ZAFpz/6H4wOTSfXXYc7NISgiksSx40kcO57Q6JhK98rYvZOf3vw/8o9l0iU0ig7r/6Lz11/h37lzg9S1KnKPZvDT3JfJ3L+HtgYTXVN2ETV2LHFPP40uKIijDz9C2vLf2NQ9HmNwCFc++hQt2nc49Y2rwO60VxKTsuOyzSMwjlIsDkuFvLKtyFZEVnEWRfaiSs+IMkV5DC5jA2M9x2F+Yeh1evRCj0FnwKAzoBd69Do9BmGokFe2NxlM9W7pHN27m//962Ha9EjkiodnVzmgwptj+/fy2RMP0LHfIC6575Ean+1yurAUO9yDELzCdEV2r2Mb1hIHOr1wj0orH6lWPlqt8jmAw+7CYXPhtDmx21w47E4cNhcOm3t/0nmZ0NSETi/cAqLH6G+oMDiiTLicDle14cTAUD9ueH74KZ9TFUowfMmWz+GbW+COP6FFVwDMVgefbzjCvN8PkZFfSkKLIGaOSODy5NaYqhqp4nRoVunb/gcj/gFj/3nqiYBFWfBqb+h1FVw2F+l0Yks7jHX3Liy7dmHZtRvLrl04c3NpN38+QYMG1up1ctKPYCstIa5z19P9SZySrEMH+OKxf+CyWrn0jn9QuG0rW5Ys4nhYMBJo3zuZPudPJKHvQPSGmoeL2i0WVn06n5SffyDI7mCgKYLkBZ82+Gxg6XLx188/svrT+eiFoOfRHOJO5BH7yMOET53qeZ50Osl84gnSf/ieTYmdcBqNXPbgP2nTvVeD1MNVXIwIDKzT+xXbi8kqzuJY8TGOlRzTjkuOcay4/LjYXlyv+glEhTCaJ5xm1IY5e6eZDCYMOgNGnRGDzoAosnH8ncUIo4H4O67EPzgYo9Dy9DpNlPz1/p7h0mXblsU/sOqTeZx38+0VHBPOBEf37mbZB29RnJ/H4CuuJnHs+FOKXBlOpwt7qVML5ZU6sFscWEud2Eq1eUM2iwObO79sHlFFIXNvRlE+7LpseLb73M9kICH59OaGlaEEw5cc+RPePx/+9j/ockGFLIfTxY/bMnln1UF2HC0kOtiP64fEc83g9kQEuTs/HVb48kbY/YMmFCPvr/2zlzwMf74DszZrCzpVgctiQddArYSGIHv3Lr549D5K3MLpL3T0vuhSep9/IeEt4077foe3b2HxS89QXGymd48kxjw2u8FmAxdmn+DnN1/h8PYttAqJoNv6vwjrkEDrl1+qsjUjXS6y5jzD0f99zqakrhRLFxff8xCd+td93oDLYiF77hvkfPABQcOGEvfUUxhjY+vzWlVSZCviWPExzHYzDpcDp3TidDlxSmeFc4d0aOfuPLvLjtVppcRe4mkJeYfXvNPKhj/bXDbPc/VOmPBHS8KLjPw49Bj5IdUPhT4ZgzBw/oYYorMNbJlgRLQI9ohJoCGQUP9Qbf6NnzZsOtQ/tHxOjl8YQcag0xbgksICVn/6IduX/0JwZBQh0S3I3LubyNZtGTn9BhL6DjjnLUyUYPgS83F4sTNMfB4GVT0LVUrJugM5vLP6ICv2nCDAqGdK/zZc1z+WhGW3IA4sgwnPweBbT+/ZhZnwah/oczVMeq0BXubMkPHRh6z98D1atY1nwNy38Auq32JLFrOZH2+6llTsRLVqw8RZDxDboXZrlFSFlJKdq5ax7IO3kU4nPUscxO3YS+Tf/kbMgw/UKMBSSk689BKZH3zA5n49yLNbGX/LXfQac/5p18O8Zg2Zs/9FdvZx8nv3QKQdJszhotOse4iePPmc/WByuByebfk7b7J39UpG3HEbrZL7lOdJR4VyVqeVYnuxZ55N2XFxfh7+n2zF4S84NCmKYllKsb0Ys91Mka2IEkdJtfXQC32FOTghfiHodXp06NDr9AgEeqFHp9OhkwLTzjwC1mYi7C7sybE4B7dF52dAfyAP/eo0RF4ptA1HjOmMPi4cgUAndOiE1h+hQzvW6/QYdUbPVtbaMupPOndvfno/Tz3rMifodDlrBEMIMQF4FW0BpfeklM+elD8DeIHypVtfl1K+5867Hnjcnf5vKeUp/THOiGBICc+0hr7XwcRnT1l8z7Ei3l19kGUpe3lT/yIDdHv4NOZ+HH2mM6BDJN1ahqI/nZEbP96v9XvM2gzh7er+HmcQKSUlf24gIKkPOn//BrmnZc8e/rjuGnZ0bIMVF4OvuJqBl00+ZWjrZEoK8vn13dfZv2E9sdGx9NiwlWChJ+6ZOYSMG1ere0gpyZ77BsfemMuW/r3IspYw4m8zGDDpylp9yDtycznw9FPs2fQnmTERmPUnXSMlIXojccn9aNm9JzHxCcR06EhAcMhpvWtj89dP37Psg7cZfMVUhk29ts73Sd2yma+eeYLe4yZw/i13VsizO+0U2CrPw6k0B8dWQJGtCKfLiQsXLpdL20sXQTkuum4ShOUKcqKdbE+2URDiQEqJUzq1EXFOSYdUP3rsCcJk03GoVQl/dS2gKMBe7Yi5umDSmzxebN5bhCmCMP8wza/NFE6kKZJukd1OfcMqOCsEQwihR1ui9Xw0u9ENwDTvlfPcgtFfSnnnSddGAhuB/mjjHTYB/aSUedTAGREMgDeGah/Wf1tYc7miLNi7BHYvRh5cgXQ5+TjuEd7J7UtGvtZhHeJvoF98BAPiIxkQH0nvNmFV93uUUZAOryZpgnXxyw33TucgWc89z7GPPiRtyqXs27mV2IROJI69AIfNht1qKd8sVs+x46Tz4oJ8pNNJYmA4cav/IGjQIFo9/1ydwkA577/PsRdfZEf/RI7YSuh38eWMmn5DlZMRQQt3bHlrrjZD36SF1dp060n3kWPpMmgYdquFrIP7SfvuGzI3b6QgwA+LofxvI7RFLDHxCcR26EhMh47EJnTyTHo72ziyYytf/PtxOiT357L7H6/2Z1JbVi34gA2LvuLiex6m65C6dfaejMVs5veFH7HltyUEhoYx+tqb6DZ8dI2iby0pYcOiL9n0w7dI6SJ54iQGXjoZ/+AgXFIToLIWlN1px+7SNofLUfHYWX5sdVo94pZvzSfPkueZZFqWVmAtqFCPSFMkK6eurNN7ny2CMQSYLaW8wH3+CICU8j9eZWZQtWBMA0ZLKf/uPn8bWCGl/KymZ54xwfjsb5B7AO74o2K6lJC9F3b/CHsWQ/pGQGri0vUi6D0FWmvOsBn5pWw4lMufqblsOJTLvuNmAPwMOvq0CdMEpEMkSW3Cy/s/yvj+HkhZALNSIKzmmdRNGVdxMQcuuhh9aCj2h/7B0g/eorSo0JMvdDqM/iaMJhNGf3/t+KRzfXYGLdZuI+DoMVrMmkXUzTed1gqIJ5O7YAHHnv43+/onst9eQo+RYxn/91melo/dZuXgpj/Z/vOPpO3ajgRC0dHzggvpNemKKkeJAdhSUzn62OMUpPyFbdAAHGNHkZN9nOOpB8jLPOopFxLVgrhOXWjZuStxnboQm9DJY3LpuVdaGoVLllD48y/gdBIy4QJCJ07UTC99QOGJ43zyyD0EhITytzkv4x9Yt+Gf3jgdDhY++SB5RzO49rnXCIupez+PdLnYsXIpqxZ8gMVsJnnCxQydMh3/wNqHTotyslnz+SfsWLUUU1Awg6+YSp/xF/nMbdfhclBoK9QExJKP1WllSKvT97eDs0cwrgImSClvdp9fCwzyFge3YPwHOIHWGrlXSnlECHE/YJJS/ttd7p9AqZTyxZqeecYE46dHYeP78NgxkC6tI3zPj7B7sSYkAHFJ0O0i6HqhZhx4itBEbrGNjam5bEjN5c/UPHZkFOBwab+blqEmuseF0KNVKN3jQkkMKqDdguGI/jfBhc/7+GXPbgp//ZWMu2YR8+CDhE6fRmlRkVsQTOgNlRdakg4HpSkpmFeuwrz4S6wZeRgjA2j9xjwCkpIapE75X33F0cf/SVpyT3Y6S0noO4DkCZewe+0q9q1fg81Sir/dQetiK4lXTCHh5ltqNeJGulzkffIJx1/+P4TRSOyjjxJ22aXYSks5kXaQrIMHyNy/h2P791BwXFuUSuh0RLeLJzauDWEFRZi2bMdv524EENC3L+gEpZs2g5SYevQg9MKJhE6ceEpLl2rrKCXWkmIsZjOWokIs5iJWffYhhcez+Nucl4ls1XBfcPKzjvHxQ7OIatuOqU8+e9rhSIDjqQdZ+v6bHN27i1ZdujPuptvqNQ/peOpBVi34gLStfxEWE8vwadfTrlcfXE4nLqfDPQnS4T733tx5Lu3Y6XDgcjhxOezasdOJ86Rjbe/A5bBj8DMx/Oq6hfnOJcGIAsxSSqsQ4u/AVCnl2NMRDCHELcAtAO3ateuXlpbmk/epwJ/vwuL7odeVcHAllGSDzggdRmgC0fXCen/zL7E5SDmcz/ajBew8WsiuzCIOnDB7RORFv3eZpPudF7v/j7btEugeF0q3uFCC/Zuum2lVSClJv/U2ijdsoOOPP2CMqzzyypGbS/Hq1ZhXrsT8+xpchYWg1xEYVUpwQgDhrTLQ/20e9LqiwepV8MOPHH3oITJ7deUvYQMpMfr5E1dspeXho7QfPpK4Rx/FGFN1i6ImylobpZs2ETxqFC2fegpjbMX7lBTkc+TP9Rxe9hvHDuwl12XH4RYlo8FIy4ROtOrZm7CYWBwFBVi2b6d0+zbsR9IBgbFtG0y9euHfo4fHGl+izQC3lZZgMRdiMZspLXLvzUWaQBSbka6K8w6ETsdlD/6ThOQBdfth1kCZw+2gy6cw/OrrKuVLlwubxYK1pBhbSTHW0lJtX1JMxp5dbPllMaaQEEZOv4GeI8fWO1RWRmrKJlYu+IDsw6kNcr/q0BuN6PQGgiMiufGVt+t0j7NFME4ZkjqpvB7IlVKGnfUhqdQ1MP9C8A+DzudDtwuh03lgqtqjqaGwOpzsyzKzK7OQzNTd3LF9Cp8ykX9apnvKtIsMpGvLELq1DPHs46OCMOib7ipztvR0Dl58icecULpcWHbt0gRi5UosW7eBlOijoggeOZLgTkEEHXwJfY9xMOUjmH8xZO+DW1dDRPsGq1fhr7+Scd8/KOiSgGjXjqCffsM/riUtn3iCkNGj63Vv6XRqrY3/ewXh50fsI48QdtmlOI6foOjnnyhcvITSlBQATD17EjJxAo7kJLKL8jm2fw+Z+/Zy4vChSh/utcXob8IUEoIpOISAYPc+JARTcCim4GACQrS9KTiUsBYxBEdG1et9a+Lnt15l+4rfaJ+YhL1MHEpLtb2llCptfwGEoM95Exl+9XWY6rFeTHW4XE72b1hPcV4uOr0BnV5fzWZAp9OjM+i1vV6PzmBAbzCg02t7vcFQnmYwoNcbELrazQ4/FWeLYBjQwkzj0EZBbQD+JqXc4VUmTkqZ6T6+HHhISjnY3em9CShbCm4zWqd3bk3PPGOCIaX2ARMRDwbfm8tVy7e3I7d/RdYNf7Kj0MSuTK0lsvtYIYeyi3E3RvDT6+gYE+wRkTIhaRlav9m6ZxNlRobB542jdMsWnCeyQQhMiYmaSIwahalnD8ThdfDx5RDXG677DvyCtHXa3xoBLbrBDUtA33CtNPPq1aTfeRfSbify2mtpMesudPUcVuyNLTWVo48+RunmzRjbt8N++AhIiX+3boROmEDoxAn4ta9aBO1Wi7vPx+0+6/5TEJpJE7a0NMzLllO0dCn2tDTQ6Qjq35/Qfn0J6NIV/06d8GvbFlGHUFBDYrdYWDL3ZYpyTuAXEIh/YJB7H4hfYBD+AQHaPjAQ/4BA/AK1MgGhYdUacTYnzgrBcFfkQuAVtGG186SUc4QQTwEbpZSLhBD/ASYBDiAXuE1Kudt97Y3Ao+5bzZFSVu914eaMCcbZQs4BeL0/DLkDxv+7QpbF7mT/cTN7s4rYc6yI3ce0/bFCi6dMqMlA15YhdGwRTHSwP1HBfkQF+xMd5Ed0iD9RQX6EB/qd3rDfRkLabByaMhV7RgZBw4cRPHIUwSNHYIjy+mZ7bDt8cCGExMKNP0NgZHneti/hq5tg5AMw9vHKD6gHlj17NR+jLl0a9L5llLU2in79jcAhg7UO7IT6+YFVuL+UWPfsoXDxEop+/hmbV9hX+Pnh16ED/p064d+5E34dO2pC0q5dvQYPnOs4zcVY9+7Fun8ffu3aEdi/f6MLa3WcNYJxpml2ggHw9S2w63u4ZxsEnXqRmYISO3uyithzrNAjIqk5JeSV2HC6Kv8t6AREBvkRFVQuKFFBfrQI8ScmxJ+YUJO2D/EnItCvUd1Apd0OQlT9j5mXBu+PB6GDm36B8LaVy3x7hzb67Prvtf4oRZW4iouxHjyIdd9+rAf2Y92/H9u+/diPlo/W8hYSv44J+LVpg7FVK4ytWmGIjW0yYiJdLuxHjmDZswfrnr1Y9uzGumcv9iNHKpTTh4cTPG4soePHEzhkCDofrqVyuijBaE6c2AtzB8Lwe+C82XW+jcslyS+1k2O2km22kVNsJcds086LtX2O2UZOsY3sIitF1soOqwad8AhJixATMaFuUQkxudO0LTrYHz/DGexTKc6GeRdA8QmtZRHTvepyVjO8MwpsxXDrGgjyXdy9KVIbIQHAYMAYG+sREGPr1hhbex23bOlxX25spJRImw1XSQmypAT7sWMecbDu3o1l3z5kiXt2uU6HX3w8/l27YOraFf+uXfHv2BHL7t0U/fIr5hUrcJnN6IKDCR4zhpDzzyN4xIgzZtVfHUowmhtf3gh7f9ZaGd5hFh9SanNyosjK8SILx4usHC9078u2QgsniqzkFNuqvD480FguIsHlYqKdm9zC0gAhMasZPrwEju/U+izaDa65fOYWeO88bRDD1Z+e2hRScUpcFgv2o5nYjx7FnpGh7cu2jAwcx4+Dd+e7EOijozDGxGKIjcUQG4MxNhZDjNdxbCy64OAa++CklMjSUpz5+Tjy8nDm55dvefk4CwpwlRTjKilxC0Kp59h7w1l5RUNdWBimLl3w79YNU9cu+Hfthn+njuUf/lJCYYYWBjWFQmxPXLoAStato/CXXzAvXYYzPx8REEDwiBGEjB9P8OhRnhFpZxIlGM2N47vgjSGakWEDx9/ri93pItts5XihlRNFVk6Y3fuiiufHiyxY7JVH7JSFxCqExYK00FhkkB/RwV7HQf6EmAzlYTGHDT6bCgdXwNQF2mi22rDuDfj5EbjwRRg4s+F+GIoqkXY79qws7BlegnIsE0fWcRxZWTiysnAWFFS6TgQGYoyJ0UQlJgZpt+P0Foa8PKSt6i8sALrgYG0LCEAXGFi+BQUiAgPRBQRWTA8MRB8VialbNy2sViZWUmoODJkpcDSlfF+SXfGBYe2gZS+I7YmM7k5JJhSt307Rb0txnDiBMBoJGjqU4LFjMURHIUwmrQ4BJvdxADqTCREQgPDza7ABK0owmiP/ux4OLIN7tkLA2WkPURNSSordrZbyzUJusc0TEssttpFjtpFttlJoqX7RoUA/PUFGwRzmMt65kjdC72Fd2IUE+RkI9NdX3PvpiQj084hSZJAfkYFGAr/6G+LgSrhluTbxUtGouCwWHMc1AbGXCclx7+PjCH9/9OHh2hYR7jk2RER4pbuPw8Lq1gktJeQfrigOmVugJEfLF3ot5BmXBK2SoGVvsBbCsW2QtR2ydmgjLKW71WIMRLboRqmlLUUHnRT9lYY9K+fU9RAC4RYQncmEITaW+M8+Pf33QQlGY1ejcTi2Hd4aBqMehjGPNHZtfI7N4SKvRBMPbyEpsjgosdoZlfoqw7M/55uIG/kq6GqKbQ5KrE5tb3NSbHVgrWFhmzhDEd8bHqJYH8pTLV8nJCSUiCCtdRMW6EeAUY/JqMNk0GMqOzZWcWzQNek5MM2GjE3wx9uw7xcodVva6QzQoju06uMWiGTty4XxFH0Sdguc2K0JyLHtbiHZDqV52gqDxX44EyYie0zDZQhFWkpxlVpwWUqRpRZcFguu0hL3sZYmTCbi/jW7Tq+mBKO5snA6HFoNk+dB+2Gn/sNtqqx5FX59Agb+HSY+V20/hMPpotjmJL9E68zPK9b2ue7jyKy1zEz7B7+YJvCM7u/kFtswV9HZfyoMOkGAn55gf61Fo+0NBPnrCSo79tOOy9KC/AyYjDr8jXq3KJ0kSG6h8jfotBCctQgyNmuLeoW0rO9PUAFaSHPnd/DHW5CxEfxCoMckzQ8urkwcGmjtGSmhKFMTkP2/wSb3LIJ+N2iLrIU0/JooZSjBaK5k7YB5E7QmsMEE7YdCx3HQaZw2Ka05dOCmfKqtZtjzcrhyXoVlb+vEr0/Cmle0GeE9LsXqcFJQasdqd2GxOym1O7G4jy12JxaHdmw9Ka/E5qTE5qC4rJVjdWK2OiixOTBbtbwSW+XO1VMhcHGVYS0PGD4jBu2bb46I5JBfZ46YupIZ1I3s0B64AmMI8tefJE6agAW6Q3OaUOkJcKedC/NvfEJRlvaBvXEemLMgqhMMvAX6TNM6sM8EBemw8nn46xMw+GvPH3a3Twa1KMFozthKIG0tHFgK+5dC9h4tPaQVdBwLncZCwpj6/eG5XJr4nE0CZD6hhQsW3QXxw2H6F9o/Wn1x2rUhuTn7taG2Vc3faCCcLkmpXQuXma0Otwi5sNqdWN1CZHGUi1BIznaG7nuOVkXbSA/swbLo6QRajtGqeBftrHtp5TiCzr02wzGi2OqMZ6srgW0ygW2uDuRS84efyagjyM9AgF95v0+gn94djtO2gErhOO08oEK+nhCTgWB/A8Huvb+hGlsLu0Uz8izOgdb9oGXimXNTKAs7bf8aXHbodD4MulX7v2kgj6nTJucArHgWtn0B/iEw5E4Ycrt23EAowVCUU5CudYbvX6qNFrLkA0KLt3Yap/0zxPbS0ktytH/UkhxthEdJjjaHoSSnfCvO1mK4pjCI6aF18MX2gJie2nFAuG/fp6zpnrml4lboXoMrLkmbeNeQ3wRzD8JbI7URLtf/0KDWIXXCfAKW/kv79hnUQpt/02da5Q81a5HW2Xr0Lzj6F/JoCiJnnyfbHtya4ohuFAe1oyCgLXmmNhw3tiFHH4PZLj19PaW2in0/pW4R825hldpPr3Vk1AuC3a2cYH8D3fUZTLT9zLDipQS5yi3q7cKPYwGdORzUkyMBPTkc1JM8QywI7U9BSjwLFvkb9BUGM5SF/cpaVYFeLagyIdS57Oh3fYduwzuIsrBT8nQYMBOiO9X5V9TgZO2E5XO0pZ0DImH4vdoIvgYIOyvBUFSNy6l9eOxfqrVA0jdo9uzVIfQQGKXNIA+M0lolgdHavjhbm9twfJcWAisjtLUmJLE93ILSQ4ur1+XbvmdEypby0SiZW7QJeFoFIboLxPXRRqTE9YE2AxqmZXEyW7+Ar29u3EEFTrvmlLziWbAXw+DbYOSDpyeOlgLI3OoREU7s0QTRUVpeRmfUTBgjO0JkgrZFufdh7aoUTCklVocLq1s8ylpDpTZtM1sdFNscmC0Oiqza3lZSSKcTvzIg93s6Wndhx8DvhkF86RrHHlccvTlAb/bSm3105wABaENkswlnm+jCDtGF7bou7BadsAgTVoeTYpsTm2cwg8SEjRBKCRKlBGEhGAvBooQgLHTUHWWafjkxIp8Drjg+co7nK+cIikUgOiHQCc1XSwjQCW0vACGEZrtVTbpwZ5alm4x6t4DpPWFAT8vN67xM7AL8tL4pP4MOf4N2XHYelL2N0HXP4pe6HBncEkbej+h7fb1aYUowFLWjNB8OrdI+MAKjyrcgtyiYwk8ddiobg358p7Zlufcn9mjNetCEJyJe61fB/bWwNvvSfHeLiPIRKXF9yreWvTTzwDPFN7fB1oVaKyN+2Jl7LmitxCUPayHGjuNgwrPQooG8qaSEomPaWi65B7Ut5wDkHtKO7cXlZXUGiO6qmTe27O3eJ9beqVlKOLoZNn8E274CW5Em+n2v19aqr87exmnX+ujSN2gLk6VvKF97Rui0LyYGE9jMSGuhNmHTZkbU9IUISIscRkrcVFLDByOFwCXdE/4kuKTUznGfu7S2jPRKA62cd1pZGdznVoeLYqu7hebuvyqxl4/aq2r+0akYKHbxD+MXDNLtJl224BPTNB5+aDboTt9yRQmGovFx2rUPnTIhyd4HLvcIIyEAceq9f7D2YRTXRwt5NdSIlLpiLYK3R2nhunZDtA+6Fl21AQXRXXzTIZp7CH55XAtFRMRrQtFlwpnrP5JS6/j1CMl+bSTPsa1aehkR8V4C0kfbe4/WKs3TWmmbP4KsbWAI0AYm9Lse2g6q2/sU52j9DukbNBGSLvAL1uL7ZXv/YK/jsvRgLfQUGHVW2L84XdIz6MF7yLfN4cLqcLr3Lq+91qdlszuJy1nLsLQ3CXQWEPbA1jq1NJRgKBS+4sQeWPkcHN8NOfvA6TWTOKSV9q0/uqtbSNxiUgtTyErYiuH3/4M1r2nfGkfeD4PvaHzR9KYoSxOOzC3u/VbIO1SeHxSjCb5/COz9CRwWTfz7Xg+JV/l8/ZhmQ5kNSVibOl2uBEOhOBM4HZCfpolI9h5tf2KPtq67zVxeLiBS65yWLjwhN+9jT1rZscsdUimCxMlw3r/OnbXbLQXlLZDMreUtke6ToO91Wl+T4qzidATj7DRoVyjOBfQGiOqobXj5VJV94/MIyB6tP8YTctNVDL8JHZVCcnojJE6B9kMa483qjilM69850308ijOCEgyFoqERQgsPhLXRhi4rFE0En85GEUJMEELsEULsF0I8XEX+fUKInUKIrUKIpUKI9l55TiFEintb5Mt6KhQKheLU+KyFIYTQA3OB84F0YIMQYpGUcqdXsb+A/lLKEiHEbcDzwFR3XqmUMslX9VMoFArF6eHLFsZAYL+U8qCU0gYsBC71LiClXC6ldC9XxXqgbt38CoVCofA5vhSM1oD3wrbp7rTquAlY4nVuEkJsFEKsF0JcVt1FQohb3OU2njhxorpiCoVCoagnZ0WntxDiGqA/MMorub2UMkMIkQAsE0Jsk1IeOPlaKeU7wDugDas9IxVWKBSKZogvWxgZgLe1Zxt3WgWEEOcBjwGTpJTWsnQpZYZ7fxBYAST7sK4KhUKhOAW+FIwNQGchRAchhB9wNVBhtJMQIhl4G00sjnulRwgh/N3H0cAwwLuzXKFQKBRnGJ+FpKSUDiHEncDPgB6YJ6XcIYR4CtgopVwEvAAEA1+4vfEPSyknAd2Bt4UQLjRRe/ak0VUKhUKhOMM0KWsQIcQJIK2Ol0cD2Q1YnXOJ5vzu0LzfX71786Xs/dtLKVvU5oImJRj1QQixsbZ+Kk2N5vzu0LzfX71783x3qNv7N9K6gwqFQqE411CCoVAoFIpaoQSjnHcauwKNSHN+d2je76/evfly2u+v+jAUCoVCUStUC0OhUCgUtUIJhkKhUChqRbMXjFOt2dHUEUKkCiG2udcdadLr2woh5gkhjgshtnulRQohfhVC7HPvIxqzjr6kmvefLYTI8Fp75sKa7nGuIoRoK4RY7l5/Z4cQ4m53epP//dfw7qf9u2/WfRjuNTv24rVmBzCtOc0qF0Kkoq1J0uQnMAkhRgJm4CMpZS932vNArpTyWfcXhggp5UONWU9fUc37zwbMUsoXG7NuvkYIEQfESSk3CyFCgE3AZcAMmvjvv4Z3n8Jp/u6bewvjlGt2KJoOUspVQO5JyZcCH7qPP0T7R2qSVPP+zQIpZaaUcrP7uAjYhbbcQpP//dfw7qdNcxeM012zoykigV+EEJuEELc0dmUagVgpZab7+BgQ25iVaSTudC+TPK8phmRORggRj+Z+/QfN7Pd/0rvDaf7um7tgKGC4lLIvMBG4wx22aJZILT7b3GK0bwIdgSQgE3ipUWvjY4QQwcBXwD1SykLvvKb++6/i3U/7d9/cBaNWa3Y0ZbzWHTkOfIMWpmtOZLljvGWx3uOnKN+kkFJmSSmdUkoX8C5N+PcvhDCifWAukFJ+7U5uFr//qt69Lr/75i4Yp1yzoykjhAhyd4IhhAgCxgPba76qybEIuN59fD3wXSPW5YxT9mHp5nKa6O9faOsnvA/sklK+7JXV5H//1b17XX73zXqUFIB7KNkrlK/ZMadxa3TmcC9/+4371AB82pTfXwjxGTAazdY5C3gS+Bb4H9AOzRp/ipSySXYMV/P+o9FCEhJIBf7uFdNvMgghhgOrgW2Ay538KFosv0n//mt492mc5u++2QuGQqFQKGpHcw9JKRQKhaKWKMFQKBQKRa1QgqFQKBSKWqEEQ6FQKBS1QgmGQqFQKGqFEgyF4hQIIZxejp4pDelqLISI93aPVSjOZgyNXQGF4hygVEqZ1NiVUCgaG9XCUCjqiHstkefd64n8KYTo5E6PF0Isc5u6LRVCtHOnxwohvhFCbHFvQ9230gsh3nWvVfCLECLAXX6Wew2DrUKIhY30mgqFByUYCsWpCTgpJDXVK69ASpkIvI7mGADwX+BDKWVvYAHwmjv9NWCllLIP0BfY4U7vDMyVUvYE8oEr3ekPA8nu+9zqm1dTKGqPmumtUJwCIYRZShlcRXoqMFZKedBt7nZMShklhMhGW7DG7k7PlFJGCyFOAG2klFave8QDv0opO7vPHwKMUsp/CyF+Qlvw6FvgWyml2cevqlDUiGphKBT1Q1ZzfDpYvY6dlPctXgTMRWuNbBBCqD5HRaOiBEOhqB9Tvfbr3Mdr0ZyPAaajGb8BLAVuA215YCFEWHU3FULogLZSyuXAQ0AYUKmVo1CcSdQ3FoXi1AQIIVK8zn+SUpYNrY0QQmxFayVMc6fdBXwghHgAOAHc4E6/G3hHCHETWkviNrSFa6pCD3ziFhUBvCalzG+g91Eo6oTqw1Ao6oi7D6O/lDK7seuiUJwJVEhKoVAoFLVCtTAUCoVCUStUC0OhUCgUtUIJhkKhUChqhRIMhUKhUNQKJRgKhUKhqBVKMBQKhUJRK/4f9pblEUfkMsEAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 404.2924921512604 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "plt.plot(history.history['loss'])\n",
+    "plt.plot(history.history['val_loss'])\n",
+    "plt.plot(history_sig.history['loss'])\n",
+    "plt.plot(history_sig.history['val_loss'])\n",
+    "plt.plot(history_tan.history['loss'])\n",
+    "plt.plot(history_tan.history['val_loss'])\n",
+    "plt.title(\"Model Loss\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Loss')\n",
+    "plt.legend(['Relu Train', ' Relu Validation', 'Sigmoid Train', ' Sigmoid Validation', 'Tanh Train', ' Tanh Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "graduate-archive",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:34:30.829672Z",
+     "iopub.status.busy": "2021-04-25T14:34:30.828764Z",
+     "iopub.status.idle": "2021-04-25T14:34:31.023078Z",
+     "shell.execute_reply": "2021-04-25T14:34:31.022601Z"
+    },
+    "papermill": {
+     "duration": 0.319615,
+     "end_time": "2021-04-25T14:34:31.023212",
+     "exception": false,
+     "start_time": "2021-04-25T14:34:30.703597",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAB9eklEQVR4nO2dd3wVxfbAv3NLbnpv9ITeCb03sYAFRFBAn4rP8lTsFaxYn+09K/aC+lRQUUB/2KiC0gKEXgIhIYH0fpPcPr8/9uaSQAJJSEgg8/187md3Z2dnz96bzNk5Z84ZIaVEoVAoFAoAXWMLoFAoFIqmg1IKCoVCofCglIJCoVAoPCiloFAoFAoPSikoFAqFwoNSCgqFQqHwoJSColkghIgRQkghhKEGdWcKIdadDbkUiqaGUgqKJocQIlkIYRNChJ9Qvs3dscc0kmgVZfEXQpiFEL80tiwKRX2ilIKiqXIYmFF+IIToBfg2njgnMQWwAhcJIaLP5o1rMtpRKOqKUgqKpsqXwA0Vjm8EvqhYQQgRJIT4QgiRLYRIEUI8IYTQuc/phRCvCSFyhBBJwGVVXPuJECJdCHFUCPG8EEJfC/luBN4HdgD/OKHtEUKIv4UQBUKIVCHETHe5jxDiP25ZC4UQ69xlY4QQaSe0kSyEuNC9P1cI8b0Q4n9CiCJgphBikBBivfse6UKId4QQXhWu7yGE+EMIkSeEyBRCPCaEiBZClAohwirU6+f+/oy1eHbFeYxSCoqmygYgUAjRzd1ZTwf+d0Kdt4EgoD0wGk2J3OQ+dytwOdAXGABMPeHa+YAD6OiuczFwS00EE0K0A8YAX7k/N5xw7he3bBFAHJDgPv0a0B8YBoQCjwCumtwTmAR8DwS77+kE7gfCgaHAOOBOtwwBwHLgV6Cl+xlXSCkzgNXANRXavR5YIKW011AOxXmOUgqKpkz5aOEiYC9wtPxEBUUxR0pZLKVMBv6D1smB1vG9IaVMlVLmAf+ucG0UcClwn5SyREqZBbzubq8mXA/skFLuARYAPYQQfd3nrgWWSym/kVLapZS5UsoE9wjmn8C9UsqjUkqnlPJvKaW1hvdcL6VcLKV0SSnLpJRbpJQbpJQO97N/gKYYQVOGGVLK/0gpLe7vZ6P73Oe4Rzbu73AG2vesUACgbJOKpsyXwJ9ALCeYjtDekI1ASoWyFKCVe78lkHrCuXLaua9NF0KUl+lOqH8qbgA+ApBSHhVCrEEzJ20D2gCHqrgmHPCu5lxNqCSbEKIz8F+0UZAv2v/yFvfp6mQAWAK8L4SIBboAhVLKTXWUSXEeokYKiiaLlDIFzeF8KfDDCadzADtaB19OW46PJtLROseK58pJRXMSh0spg92fQCllj9PJJIQYBnQC5gghMoQQGcBg4Fq3AzgV6FDFpTmApZpzJVRworvf4CNOqHNiOuP3gH1AJyllIPAYUK7hUtFMaichpbQA36KNFq5HjRIUJ6CUgqKpczNwgZSypGKhlNKJ1rm9IIQIcNvyH+C43+Fb4B4hRGshRAgwu8K16cDvwH+EEIFCCJ0QooMQYjSn50bgD6A7mr8gDugJ+AAT0Oz9FwohrhFCGIQQYUKIOCmlC/gU+K8QoqXbET5UCGECDgDeQojL3A7fJwDTaeQIAIoAsxCiK3BHhXM/Ay2EEPcJIUzu72dwhfNfADOBiSiloDgBpRQUTRop5SEpZXw1p+9Ge8tOAtYBX6N1vKCZd34DtgNbOXmkcQPgBewB8tGcuC1OJYsQwhvNV/G2lDKjwucwWud6o5TyCNrI5kEgD83J3MfdxEPATmCz+9zLgE5KWYjmJP4YbaRTAlSajVQFD6H5L4rdz7qw/ISUshjND3MFkAEkAmMrnP8LzcG91T0aUyg8CLXIjkLR/BBCrAS+llJ+3NiyKJoWSikoFM0MIcRANBNYG/eoQqHwoMxHCkUzQgjxOVoMw31KISiqokFHCkKI8cCbgB74WEr50gnn26HZgCPQbKz/kFKezpaqUCgUigaiwZSCe1rdATSHVxqac22GO+CnvM53wM9Sys+FEBcAN0kpr6+yQYVCoVA0OA0ZvDYIOCilTAIQQixAC9XfU6FOd7RphACrgMWnazQ8PFzGxMTUq6AKhUJxvrNly5YcKeWJ8S8n0ZBKoRWVozDT0IJ8KrIduArNxDQZCBBChEkpcytWEkLcBtwG0LZtW+Ljq5uhqFAoFIqqEELUaPpxYzuaHwJGCyG2oeVtOYqW6KsSUsoPpZQDpJQDIiJOq+gUCoVCUUcacqRwlMppBlpTIaEZgJTyGNpIASGEPzBFSlnQgDIpFAqF4hQ05EhhM9BJCBHrzvM+HVhasYIQIrw8/z0wh+PRqAqFQqFoBBpMKUgpHcBdaKkG9gLfSil3CyGeFUJMdFcbA+wXQhwAooAXGkoehUKhUJyecy6iecCAAVI5mhUKhaJ2CCG2SCkHnK5eYzuaFQqFQtGEUEpBoVAoFB7UymsKRX1gL4OsPeCwgssBLidIp7Z1ObWyisfSXRbeGdoOaWzpzwxbCez9CULbQ5tBjS2N4gxRSkGhqAuWIkjdBCl/QcrfcHQLuOx1aEjAZf+BgTfXu4gNTtEx2PQhxH8GlgKtbPDtMO5p8PI95aWKpotSCgpFTSjNgyPrNQWQ8hekbwfpAp0BWvaFoXdC64Hg5a+V6fTaVuhBp6uwX35Or7X7y6Pwfw+AzQzD723cZ6wpR7fA+ndhz2LtO+h6OQy6Ffb9H2x8HxL/gMnvq1FDPSGlxOGSWB0uDDqBt1HfoPdTSkFRP0ipdZqZu0FvBJ0R9F7avmdbvu+ldY56LzCYILgd6JvYn2JJLhxe7VYCf2umIQC9Sev8Rz4E7YZpHZ+XX93vM+1/8MNt8MdTmhlmzBwQ4vTXnW2cDtj3M2x4F1I3gilQGxUMuhVCYrQ6saOgy6Ww5C749BJNyY2Zo/3GZxmXS1Jmd1Jmd+KSEoNOh0EvMOgEep3AqNOh09Xv92x3ujBbHJitDordW7PVTrHFQYnVidlqx2xxUGx1YLY4KLU7sdqdWB0urHYXFocTq92F1eHE4t5aHS4sdicu9yTRFyf34trBbU8tyBnSxP4TFQ2C1Qw7v4WQWIgdrb251hcup2ZP/utNOLa1bm34R0OfaRD3D4joXH+y1ZWSHJg3GEpztDf/NoOh5xRoNxxa9avfTk5vhCkfa+aWNS9rv9UlLzQdxWAphK1fwsYPoPCIpsDHvwRx14F34Mn124+GO/6C3x+Hda/Dgd9g8vvYInqRUWghraCUo/llHC0oI7PIgtMlEQiEKH9k9z7Hv4Ly897OEkIsR8iRQeS4Aily6Ci1aR1/qc1JmWffgcXuOu2jCQEGndAUhk6gr6A0QHvP0TpjiZQgAZd070uJdNeRUmJ3SWyOmt3T38uAv7cBHy893gY9JqMOk0FHqJ8XJoMOb6Mek0GHyaDH26htTQYdEY4Mereu4juvZ5RSOJ9xuWDHQlg+F8wZWllwW63z7XsdBLWue9u2Ukj4CtbPg/zDmpPxsv9qpgTpAqcNnHbNzl6+77RV2HcfW4s1s8Pf72iKpfVAiLtW64S9g+rla6g1K5/TbOTXL4aYkQ0/itHp4Yq3NQW0YR7YiuHyN46bmBqDvCRNEWz7n2baajccxv8bukw4SS6bw0WpzUFWsZWj+WWkFZRx1DiLoFbdmZb+CoEfjOUdx2TedUzEUaHLCff3wqDTISt0urJCJwxgkhZGynguln8zgm2YOO63KRb+FOpDKdSHUmIMo9Q3DIt3OFZTOHbfSFy+Ebj8IrGbQnG6NBOMwyW1fafE4XJVfezUbq69Ox1XUjpRUWGV7wuPcvE3aZ29v8lAgLcBf5PxhGMDPkZ97UcoUsKmj+CPJyH4OWh1Wy1/zNqhgtfOV1I3wa+zNftvq/5w0XNQnA5bv4DDawABHS6AftdrQ/6avv2W5MLmjzQHY2kutBqgmQm6XnZmnZg5S1Ng276C7L1g8IZuV2gKInb02esg07fDB6NhyB1aJ3g2kRJWPg9rX4OeUzW7vN54Vm5tM+eTu/dPbEnr8Dm2kYjCHbiEnoSgcfwReBUHdB0osTootWlv4qU2p+fY4Tq5DzHqBS2CfOgcaOeOsg/pX/gHeUHdSR75X0JjetMi2BuToZrf1G6Bg8th1yI48CvYS7XRZI8rNZNdWYH292LOdH8q7NtLT26vZV+Y+DZE96rX7+ysUJQOS2bBoRXQ8SKY9A4ERNepqZoGrymlcL5ReFQbGez8VvtHuugZ6HVNZZNRfrLW+SZ8BUVHwScU+kyHvtdDVPeq2807rI0Ktv0PHGXQebymDNoOrV9Th5RwbJsm287vNPNFYGuImwF9ZkBYh/q7V1X3/mwC5CTC3VvAJ7jh7nUq1r2u/YZdLoWpn4HRG4fTRY7ZpplcpMTboNfMD0Yd3ga9x+RwqrfQIoudI7mlpOSWkpmRhjFtI2G58bQv3U4n12H0QmKTenbIDvwle7FUfxElXpH4mvT4eWnmDj8vPb4mA75GPX4mA75eeny99Ph4GQj396J1iA+tgn2JCDB5zDAA7FkCP9+vmccueByG3lVZ0TvtcGgV7P5BGzlai8A3DLpPgh5XacrgdC8GUmqjmopKouAI/P02lOXDiPth1MON4uOoE7sXw8/3aUrykudhwM1n9L+mlEJzw1aq/fH/9YZm5x92t/ZPYPKv/hqXU/tH3PYF7FummXpa9deUQ88pms346Fb4+y3tn1roNdv/0LshsmvDP5PdAvuXaQri0ErNLNV2GPS/EXpPq3+7+87vYdHNcMWb0H9m/bZdDVJKisocZBRZyCyyaNtCC+0Of83EtP+SYOzDPfIR0koEVbyQn0S5TdrbqMPHqCkLvU5gz0+jq3UXg3R7GaTbR2edlrDYihcpvj3IDRuAvfVQ/DsMoXVkGBEBJkR9f7/mbK2T2/ez5qeZNE97Kdm1SPNLleVrJsOuV0DPq7QRYn2Y7krz4LfHYfvXWlzIxLebdmyIpRCWPQI7FkDLfnDVRxDe8YybVUqhuSCl9nb1x9NQmKq9WV307PEZITWlJEcz32z9UjPfGH21f6D0BDAFwYCbtNkmgS0a4ilOT9Ex2L5AUxC5B+GSF2HorPpr31YC7wzU3k5vW33at1K706XNbnE7ODWHZ4VZJyfOQrE4KHbPRKl4Pr/UVqVTNNjXyHXef/Ng6Zsc8e3Ozz3fJDg0gqhAbww6gcXuxOKepWJxz7Kx2F1Y7U4sdidYimhTGE/H4k10K9tClOMYAA6DH5YWAzF2GImp/UjNtGLwqr/v8XRIqY0Alz2kdX6g+VK6XKopgg4XNNyb/MHl8NN9UJgGg26DcU+d+qWpMUheBz/erv29j3oYRj1UbyZEpRSaA8e2wa9ztKmg0b20WSExI86sTSm10cG2L7Rt72ug341VzzRpDKSEhf/QZrX88zdo3b9OzTicLvJKbeSabeSV2Ajf/Bpd9r/HNz0+ZIe+O3klVsxWh6fDt5TPcHErgqrs6NXhbzJU4YTUPkE+RqKDvIkK1D7Rgd5EBpqOz0XfswS+vxkiu8H1P4JfeNU3cTq0v4dDKzX7c1q8FjXt5a85y2NHaiaYqF5NY/pv0TEt6C26J3S6GIw+Z+e+1mJY8ZzmEwtqrTn0O114du59KhxWbYLD3+9okzau+hBan7b/rhVKKZzPmLNhxVzNL+AbBuOe1Ew+jTlb5WxSlg8fjNL2/7XWY/t3uST5pTayiq1kFlnIKrKSVWwhs8hKdrGVvBIbOSXatqD0+CyW1iKb5V4P8ZtrIPc77iLUz4tQPy/8TQZ8vQx4G912c6Nmx6+4f/xYs7mXd/rlHb+fl+HM58MnLoeF12nTQW9Ycny0VnBEUwIHV2iTByyFgNDe/juO0966Ww88a87qc4ojG2HpXZBzQPNVXfIi+IY2jiyZu2HRrZC1Gwb8Ey5+/sxiX6pBKYXzFSnhowsgYycMuV0bYjbW1M2ziNMlySiykJJbQlp+GSItnqsSbma771Ce9Z1DVrGVbLMVu/Pkv+dgXyMR/iZC/bwId2/D/L0I8/Mi1M/EkPj7CDm2hsJbNhAY2a6yg7SpkPwXfD0N/MK0N+tDKzUzGkBgK00BdLgA2o9pvM7tXMNu0WZ6rXsdfEJgwivQY/LZixFxubQpyCueBe9gbWZR50uqre4sLAS9Ab1/3RRGTZVCExhHKmrFweVakNjEt6HfDY0tTb1isTtJzdNmx6TklXIkt0Tb5pWSlleGzVnR9u5Fis91PFT6BVO8fiahwwwiA01EBZiIcptgIgO8iQgwnTotwOE/4civMPYJQqJjGvoR607McLhxCfxvqjYDLGYEDLwFOoyD8E5NJ9jtXMLoDRc8ofnhltwF39+kTTa47D8N7zvLS4Kl90DyWi2254o3PaZB6XJhT03Fsm8/ln17se7bj2X/PhzH0mnx/HMET53aoKKpkcK5hJTwycVavME9284ps4DF7iS73KxzwjYtr4yUvBIyi6yVrvE3GWgb6ku7MF/ahvnSLtSPdmG+tAnx1ezuBh18M0NTlDf/rkUb1wanAz4YqU1jnLXp7Nm1zwSHDZDnzrTKcwWnQ3trX/Wiln6l5xQtUC92VP39XRSmaT6i3YshbRN4+eMa+xwWU1+sB/Zj2bcP6779WA8cwFXqjrfQ6/GKjcG7S1dMXbsQMGYMpk6d6nR7ZT46H0laDV9McmfVvKWxpfFgsTtJyS0lObeEo/llZBZbyC6ykllcbte3Ulh2cgZRg04QEWCidYgPbd0dfrswX7ci8CPE13j6aZGlefC+O+r4X3/WzpS28UP45WG45kvoPvH09RVnHelwYEtJwZqYiPXAARy5eRgiIzBGt8AQHYWxRQuM0dHofOspK2vuIc3he+B3sJdos/Daj4Uu46HTJRAQVbv2ClI1RbBnMaRtxuUQlFg6U5wbTVlaKba0Y+Vh3OgCAvDu0gVT1654d+uKqUtXTJ06ojPVzwuAUgrnI/Mv1+zI9yRoQ9+ziMXu5EheKck5JSTnlnA4R9tPyS3hWKGlUl2jXnhMN1FuM075NrLCcYivV/0kJTuyUQs663Y5XP15zUwppXnwVl9o0Udz3irzS6MipcSRlYX1wAHPx3IgEduhQ0ibTauk06EPDMRZUHDS9bqgIIxRURhaRGOMboGxRTSG6GiM0dHoAwMRRqPng8GI8Dp+LAwGhP4EE6PDqpl29v8K+3+BojStvFV/6DxBG0VE9aj67+YEReCwCswlnSjOCqNkbwbSakUXFITfoIGYunXDu2tXvLt0wdCyZf3HhlRA+RTON1LWa3+k419qUIVQbLGzL6OYvelF7M8oJjm3hOScUo4VllHx/SHE10i7MD8Gtw8jJsyPmHBfYsL8aB3iU3+dfU1pO1ibc778adj8sZa583SsfF6bnjjhZaUQGgDpciEtFlylpbjKyrSt+yPLynCVleEsKsJ26BDWA4lYEhNxFRZ6rjdERmLq3Bm/oUMxde6Ed+fOeHXogM5kwmWz4cjMxJ6ejiMjA3t6Bo5MbWvPyMCyfUeViuOU6HTHlYTJhFebNpg6dcTUqTemIVdhCnKiz16PSPwVVj2vfYLaaJH9XcZrySb3L9NMQ0fjsZfoKS5uT3F6f0oPZoLTjCHan+CpUwm46EJ8+/fXFFQTRI0UzhW+vAoydsC9O+plAROXS5KaX8re9CL2pGtKYG96EWn5ZZ46gd4G2kf4ExPmS0y4H7HhfrQL8yM2zI8g3yb2B+1ywdfXaFMzb1mujQCqI2OnNqV14K1w6StnT8bzEGmzUbx8OQWLfsB25IhHCcjSKnIQVYHO3x9Tp06YOnf2dP6mTp3QBwefkVwui0VTGBkZuMxmpN2OdDiQNru2X35styPtNqTDAe5yV5kFW3Iy1sREnPn5njb1wcGarO1aYQoowySTMJVsRq8v1TJsFBkoLoih+JgvlpQcALw6diBg3IUEXHgh3j17NOhI4HQo89H5RNoW+PgCuPAZGHFfrS93uiS7jhay61ihu/MvZl96ESU2JwA6AbHhfnRrEej+BNCtRSDRgd6N+kdca0py4f0R2kjqtjVVB9xJqZnhsvbAPVu1qYiKWmNLTib/u+8o/HExzrw8jK1a4dOvHzpfX3Q+PtrW1wfh64vOx9dzXOm8nx/68PAm/TfmyM11+zMSte3Bg1gTE3GZzZ46htBAhB7s2UUA+PTpg/+F4wi48EJMsbGNJfpJKPPR+cSfr2qdVy2WbEzLL2VtYg5rE7P562Cux9Eb4G2gW3QgU/u39iiBzlEB+HidB4FvfmEw9ROt0//5PpjyycmmoT2LIWWdlua7HhWCq6SEoj/+IHDChHpzDFZFweLFCL2BgIsuROd9dv1K5aOC/G+/o3TDBtDrCbjgAoKvuQa/4cMQ9blORxPBEBaGISwMvyHHcyVJKXFkZGhKIjERa+JBnEVFhI0cgf8F4zBGRTaixGeOUgpNnfQdcOAXGPs4mAKqrVZidbAhKZe1iTn8mZhNUnYJAC2CvLmkRxQjOkXQr20wrYJ9mvSb2elwFhaS//XXBE2ahLFly5MrtBumZeFc8ayW3mHATcfP2Urh9ye1VA/1mPBOSsmxOY+Rs3IFLfbuJWrOnHpruyLFq1eTPltrWxcQQODllxF81VV49+x5xr+ptbSErOQksg4fIuvwIWwWC7Fx/WnfbyBeRcUnjQoi7ruPoKsmY4w8tzvAuiCE0GY9tWiB/6hRjS1OvaOUQlNn7Wva0oeDKi+s4XJJdh8r4s/EbP48kM3WI/nYnRJvo44h7cO4bnA7RncOp0OE/zmtBE4k74svyZk3j5wPPiTs1lsIu/nmk9+Yh9+vRQD/OltL8xDdUyv/+y0taeDkD+o1JUjep5+yb9PfbO8RQ8uVv3LJkCGEjh1bb+0DOPLzSX/iSUydOxP56CMULllC4Q8/UvDNAkydOhE05SqCJk7EEHr6aOaSgvxKCiArOYmCzHTPeb+QUHQ6HQc3rwcgsNRCVHEZMb17EnvtP/AfMbzRRgWlRYW4nE73Ijee5do8+wJtFRztb14gdAKj6RwzgzYyDepTEEKMB94E9MDHUsqXTjjfFvgcCHbXmS2lXHaqNpuVTyFrH7w7BEY+COOeJDWvlL8O5rDuYA5/Hcwh352/p3uLQEZ2Dmd0pwj6x4RUv3jJOY50uTh04UUYIiMxtIim+JdfMbZsSeSjjxJw8UWV//HN2Zp/wRSgZT0ty9eyoHYZD1fPrzeZSjZs4OCtt7K2Z3u8goMx5+ZgckkmPPgY7YeeYXJCN1JKjt5zD+bVa4j5/ju8u3QBwFlcTNGyXyj4YRGW7TvAYCBg7FiCplyF/4gRCIMBS4mZtD27yDx80KMEzPl5nraDoqKJbBtLaFAIIUJPQFEJ+rQ0zBs2UlhqJqd1NDktIskuLgAp8Q8No32/gXToP5g2PXtj9Dp7QXR/f/c167//utbXtejUhcvueYSgyFrGGJxnNLqjWQihBw4AFwFpwGZghpRyT4U6HwLbpJTvCSG6A8uklDGnarc5KQXrwpvRH1jGv7t8yx/JDo7kaTM6IgNMjOgYzqjOEQzvGE5EQPOIbi1Zv54jN/2Tlv95jaDLLqNk4yYyX3gB64ED+A4ZQtRjc/DuXGGN5+R18PkV0OtqbenP/b/CXZshuE29yGNPT+fwlKnsjA4hxaTjH/9+g7IDifzy7n8pMRmJu+RyRl03E6PpzGz/BT8uJn3OHCIffoiwm6v2K1kTEyn44UcKliyhoNRMbosIcltFkV1SjHS5EEJHaMtWhIWGE2I0EVhmwy8rG5KSsaWmglObdIAQGFu1wrtXT4KvmuLxFZQWFpC0dTOHtmwiZcc27FYLBpOJdr360qH/INr3G4hfcMM57XOPpvLFw3cT06cv7fsN1KZHS6kt5emSgNSOPct5ah+7xcKW/1uM0AkuueM+Og0cWu+yHYzfyL6/1mAwemH0NmH09sFoMuHl7YPR5I3R27vS1svbG6O3DwYvL3QGA3qDAZ3egF6vb9ARWFNwNA8CDkopk9wCLQAmAXsq1JFA+RSRIOBYA8pTe5x2bWGXs5RSoMzmZHNyHn8dzCFp/3beL1jEx85LWbi7lCHtw/jn8BiGdwynY+T5ZRKqKQWLfkAXGEjAhVqqY7/Bg4j9YRH5335L9ptvcXjyVYTMmEHE3XehDwrS8gONmQOrXtAaGDOn3hSCy2Yj7b77yMNJshH6T5hIZEx7iGnPlYkH+WvRNyT89jMpO7YxYdYDtOjUpU73saUdJfP55/EdMIDQmTOrrlNWypGCHA6H+HC4d0fM+bkABGZl0b6olJYh4QQWmpEJq49fZDBAu3aYOnUiYMJ4TO07YOrYAa+YGHQ+J6d18A0KpufYi+g59iIcNhupe3ZyaMsmkrZs4lD8BgAGT76GEdPrPx+XlJJV8z/EaDJxye334hsUXKvru4+6gJ/feJmlr71A3wlXMOq6f2KohxgBc34eKz97n8SNf+MXHILOYMBusWC3WnDaT47grwk6vV5TFHqDR2F4lIbBwJAp0+kydOQZy34qGnKkMBUYL6W8xX18PTBYSnlXhTotgN+BEMAPuFBKuaWKtm4DbgNo27Zt/5SUlAaR+SS+mQGH12prCgy4qd7XeHW5JDuPFrI2MZt1B3PYmlKAzenCqBd8EPgZo6xr2H31Wnp07oRBf/7N7KgNzqIiEkeOInjKVUQ/9dRJ5x35+eS8/Tb5CxaiDwwk4r77CL56qmZy/voabTnR29fVS4wHQPrcueQtWMimsYOxIbnpv+/h5aO1LR0OUv5xPUePpbKrW3tKCgsYPPlqhkyZjt5Q885IOp2k3Hgj1r37iF2yBK/WrbRyKck7msrhbfEcTognbe8eXE4HXj4+tOvdl9i+A4jt0x9vp4vCpUsxr/lTCwbr0B6vDh0wdeiAV9u29RI8JaUkO+UwGxd/x4H1a5n29Eu07t7zjNutSOKmv1n6nxcZO/Nf9JtwRZ3acNjtrP3qM7b+spSo9h25/L7ZBEfVba1j6XKxc9Xv/Pm/z3DYbQydei0DLp+M3nD8HdvldGK3WrBZyrBbrNgtZditFo/SsFksOO02nA4HLocDp/vjcjpOLnPY3eec9B53CTFxdVtDpCmYj2qiFB5wy/AfIcRQ4BOgp5Ty5KWo3JxV89GbfbQVuSxF4LRqIe79Z2rJsuqY7zy72MraxGzWHMhmbWIOeSVaCH/3FoGM6BTOsA5hDA4x4/P+QC2/0YSX6/GBzl3yFywgY+4zxHz/PT49e1Rbz7JvH5nPv0BpfDymbt2IfuJxfPv21cxH9RQJXvDDj6Q/9hhZl19MfOohrnhgDp0HD69Ux3bkCElXTsbQqyeJg/qw58+VRMZ2YMKsBwhv065G98n95BOyXn2NFv/+N8axo0nds5PU3TtI3r6VouwsAMLbtNOUQN8BtOzcrVLHdDaxWyx8/vAshNBxw6tvn7HJzNOu1cL8B+/Ey8eX6196E92J6ShqSeLm9fz23htIl+SS2++h85Da+X3yjqXxx4fvkLZ3F2269+Ki2+4ipEWrM5LpbNEUlMJQYK6U8hL38RwAKeW/K9TZjaY4Ut3HScAQKWVWde2eVaXwQkttPeBRD2tLVcZ/Bjn7tdlAva/RFMRpRg92p4utKfmsOaApgt3HtACXcH8vRnaKYHTnCEZ0Cifcv4KJ6uf7tfTI9yRA0LnxB9fQHL5mGtJiwfu1l1n7zXykS2o2Wi8TBpMJo+fjjcHLhPPQIUpXrIT8AgL69aPDrLsI73HmIz3Lnj0kz7gW2acXf4gyWnftweTZc6s05+V/9x0ZTz5F1JzZ5HbvzB8fvoOtrJQR066n32WT0J1iBlRe/GYS7rmLos4dyA8NIu9oKgBePj606dGH9n0HEBPXn8DwiDN+pvriyK4dfPfcY/S/bBJjbqhBqpEa8Ne3X7Fh0Tf1OgIpzMrk/958hfSD++lz8WWMuf5mDF6nXpLU6bCzeekPbPhhAQYvL0b/42Z6jr2o1mZcp8uJ2W6myFpEkb2IElsJxfZizDYzZruZYtsJ+3YzZpvZU+e+/vcxsUPdkjc2BaVgQHM0jwOOojmar5VS7q5Q5xdgoZRyvhCiG7ACaCVPIdRZUwq2EnixJYx7GkY+oJVJCUc2wJbPtBwnntHDTdr6su7RQ1p+KWsOaFNF/zqYi9nqQK8T9G8bwugumiLo3iKw6vxARce0EUrcdXDFGw3/nOcA1sREkq6YiHHW7fy67W+MJm9Coltit1lxWK3asNxqxW7VjqsaaOpdLsYPG0eXu+9F1PFt2llQwOEpU5FOJ3vGjyF513Zu/M+71ZohpJSkzbqLknXriPn+O1xRkfz+4Tscit9A6249GX/n/Z4ZMaVFhaTt2Unqnp0c2bWdvKNaAjajyZvW3XrQpkdv2nTvRWRshzN+W25Iln88j+3Lf2X6M6/Qqku3M2qrIDOD+Q/eQadBw7jsnofr1EaJvYS8sjxKHaXax65tS8qKyfj1b0rW74OoAByXdaE0QFJqL6XMUYZBZ8BL54WX3gufLDumFYcROaXou7bAb3wcPkFBeOm18ya9CYGgyFZ0/GOtet9sMyM5dZ/rY/DB3+iPv5c/AcYA/L388Tf6E+AVwGXtL2Ng9MA6fReNrhTcQlwKvIE23fRTKeULQohngXgp5VL3jKOPAH80p/MjUsrfT9XmWVMKeYfhrTiYNA/6/uPk86V52kLyW+Z7Rg8ZMRN55tggfsnWFstoFezDqM6aEhjWMYxA7xrYcH+Zra0fe89WCImpzyc6Z8l8+RVSF37D5v7d0RmNzHjmFQIjqg6aklLidDiwWy0ehVGclMQv8/6DzWZjlMubLs88g0/v3rWSQTqdpN5+hxbJ+8wT/N/CLxg+7XqGXDXtlNc5cnNJmjgJQ0QEMd8uRBiN7F6zglXzP0BK6DxkOJmHEslJ1fxkRpM34SYfAvcdpNvd9xA75ZomrQROxFZWyvyHZmHwMnH9y2+e0ZTVxa8+x5Gd27npjfcJCK1mbWq03zyzNJOkwiQOFx7mcOFhkguTOVx4mKyyao0OALTO9GHkjjB0Useu/nYKY034GHxwSAcui422O5y0TdRR5u1iU68CkiPMp2wPwKgzEugVSKApkECvQIJMQdpxhbJAr0ACvAII8AqopAD8vPww6homr1iTUAoNwVlTCkc2wqcXw7XfQeeLq68nJWWH1rH//96mW95KTMLOkbARcOHTtOk6sHbDS3MWvNFbG3Vc+e6ZP8N5gLTb2THuAv5uFYb082XaMy8T1qr2M4jyM9L5Zva9SLOZoQfSaDl1KhH3348+oPoo8Ypkv/U2Oe++S/iTT7Bk4yp0egM3vPJ2jWaxFK9cRdqddxJ26y1EPvggAEXZWfz2/pukJ+6nZZdutOneizY9euGfW8DRf95M8LRraDF3bq2fsymQvH0ri158ioETpzDquptOf0EVHN4Wzw8vzWXktTMZNGkqTpeTYlsxWWVZno7fowCKkilzHE/kGGAMIDYolpigGGKDYon0jcTP4IeP0Qdfgy++Rt9KW2t+Icveeo1jB/bS+8LxjLnxVlJ372D5x+9SnJtD3MWXMmL6jZh8fXFJFzanDavTenzrsuFyuQjwCiDQFIi3vmkGyymlcKbs/QkW/kNLrNYyrtpqfx/M4ZFFOzhaUMbtg0K5P+QvvNa/BdYiiLsWxj4GQa1rds8/noK/34ZZmyG8Y/08xzlO9v/9zA8fvoU1wJ9pz75CVPu6fy/ZKYdZ8PSjmJwuBiXsxzc4mOg5cwiYMOGU/8TFq1aRdsedBE2eTFKfbmz8cSFXP/kCbXueIhPrCaQ/+RQF339Puy+/wHfA8f9LKaXn3s7iYpImTUIYjbT/8cf6WzimAXG6nBRYC8i15GJz2jzlu776nqPrtzDkoVkEx7SBCl+vcB9IKSmyFVFoLaTAWkCBtYBCayGFpfkEfLUPFy7WX+wk31FAsa34JLNLS7+WxAbFnvQJ8w6rva3f4eCvhV+yeeki/IJDKCnIJ6x1Wy667e4zNoM1FZRSOFM2fwL/9wA8sBcCT86xY7Y6eOmXvfxvwxFiw/14ZWpvBsa4UwyU5sHa/2hmIKGDwbfDiPvBJ7j6+5Xmwes9tcU7pn7SMM/UwOR/+y2OjAwi7rmnXtqzlpby1S3/oNBhZeqTL9KmV8074eo4um8P37/wJMGhYQxNy8W5ew9+I0YQ/dSTeLVte1J9W0oKh6dejbFNawJfe5Uvn3iQLsNGculdD9bqvq6SEpImXwUOB7FLl6D39z+pzrHZcyj86Sdivv4Knz5n9qwWh4WdOTuJz4xnT+4ejDojfkY//I3++Bp9K+8b/PD30vb9jf74Gf0QCHItueSU5ZBblkueJc+zn2vJJbdMO5dvzcdVhQ/HaBdcubYlNoOLn4an46qhBczP6EefpBA679STekkoXh2iCTIFEewdTJBXEOE+4cQExdAusB0+hvpfPvXwtnhWf/kJXYaOZNCVV9dLPENToSkEr53blGRrW7+TZ3esS8zh0UU7OFZYxi0jYnnw4i6Vs4z6hsIlL2j5ila9AH+9CVs/h5EPaQvAVBUMt+E9bfm/UQ+dUixnURElf/2FsXVrfHrVb9zEmeC0Wvn9848o0sHYVi3oOOXqM2rPbrPy4wtPUuCwMqZz73pRCACtunbnigdms+TV59nWqxtjL7+C/HfeIemKiYTfcTth//wnwj0TxVVWRto994JOR6s332TJZ+9h9DYx+h//rPV9dX5+tHz5JVKu+weZL7xIy3+/WOl80W+/U7h4MeF33lknhVBqLyUhO4H4jHi2ZG5hZ85O7C47AkFskJa+ucRe4vmcztlZFV46L8J8wgj3CaeFXwt6hvckzCeMMO8wwnzCKnXSUkoK2iZx8JNFPOKYRquLRnjKKxLgFUCwKdjT6VsKCvn0/n8RM7AvD/7ziVrLeKaUT+89HdIlsVudWMsc2Moc2CxObBZt315h31bm3re467jr2i0OnE6JEGgTTtxbIbR8TULg3gqEDk95v0va0qFvwyYhVEqhOsxZWmpl/fE3hWKLnReX7eWbTam0j/Dj+9uH0r/dKRKQhbSDqz6EoXdpq4L9/jhs+gAueBJ6ToXykHZLIWz8ALpdAZEnD1VtaUcxr1xJ8aqVlG6OB4cDr5gYOvz6S30/dZ1Z//Z/SfM3YXS6WPLt53RPP8LoG27BN7AWaya7cToc/Pz6Sxw9uJ+4I1n0eKl+pjeW077vQMbfeT/L3n6Nv/38mfDTUrJffoXsN96k8KefaTH3aXwGDCD96aexHjhAmw8/ICn5IKm7dzDu5jvrnM7Bt29fwm//Fznvvof/2DEEXqz5quxZWWQ8/TTePXsSfsftNWqr2FbMtqxtxGfGsyVjC3ty9+CQDvRCT7fQblzX7Tr6R/Wnb2RfgkyVfwMpJWWOskpKovxjtpsptZfilE5Phx/uE06YTxj+xlpG0rcZzS+J+exdtZoLL5xeI9Pfb19+Ai7JmBtqtga5lJKyYjvmfAvFeRbMeVaK8y2Y8ywU51kx51twOlwYjHoMXroKWx0GLz0Gow59pXI9eqMOh9WJ1eLAXubAWlbemZd39A5sVic10atGbz1e3ga8vPV4+Whb/2ATRh8Der1AurTUHNIlcUmJdGnPdHx7/LyUEr2h4YNYlVKojpIs8DuukdccyGbOoh1kFFn416j23H9RZ7yNNRwTt+gN1/8Ih1bCH0/DD7dqvoOLnoUOYzUzk7VQi4dAi5i07N5N8cqVmFeuwrp/PwBeHToQdtNMnGYzBd8swJ6ZiTHq9Em+CjIz2Lzke7qPuoBWXbvX/rs4DWl7drFp81+0sDi45Na7Wfvai+xbt4akrZsZMeNGeo+7pMY5XVwuJ7+++zpJWzfTxwodYjpiat++3mXuNmIMFnMxKz/7gFV+/lzy+n8pWbuWjGefI+X6G/AZ0J+y+C2E33M3hr59Wf3A7UR36ETvCy85o/uG33EH5j/XkvHU0zi6d6Ak0IuSR+fgKiul6JHrSc1cj8VhweK0YHFYKHOUUeYo85SV2kvZl7eP/fn7cUkXBp2BXuG9uKnnTfSP6k9cZBx+xlMHVgohNCer0ZcIGjbOYcyNt5KyYxu/vfcG1/379VNGdCdvT2D/+rX0u/QaHHZ/0g8VYrMcf/O2W5xYSsoVgNbhm/OsOB2VzVcGow7/UG/8Q0y07RGGwajDYXfhtDlx2F043NvSIptWbnditx0/73JK9EadpyM3+RgwehsIDvTFy8fdyfsYPJ18+b5W7/h5o0l/dpelrSeUT6E6PrkE9EaKpv/ICz/vZWF8Kh0j/Xl1am/6tj2DxF8uF+z6HlY+BwVHSAsew459ucR1jyKwzz0Ur1yFedUqHFlZoNPh278//hdcQMDYMXjFxABaANXhq6bQ8pWXCZpYfSCLw24n/qcf2PjDQhx2G14+vkx/5mUi2tXfalDm/Dy+fORuyM5m4qjxtLz/flJvvoWsfXs4dMFw0hL3Ed2xMxfeMouo2A6nbEtKyYpP3mX7H78wZMzFhL75HtHPPUvI1WdmijoV5Zk3+192JaOvvxlpsZDz7rvkfjYf/5EjaT3vHVZ8+j47lv/KdS/+t8q3XZd0UWgtJLcsl3xrfiXHaYHluAO1vMx0NIcn3i9gd1vBlk6CW39z8cnFOn7rX73iNOqMeBu88dZ7ExMUw4CoAQyIGkCviF4NYls/HVJKLCV2inIsFOWUUZRThq3MidPhwuVw4XRKz7YgfRepO78ktM0FhLQcg9MhcTldOB0utynFidVixZL3JWDHK/BGhKhGeQjwCzIREGrCP8Qb/1Bvz35AqDf+oSa8/YxnNPtHuiTiHOzMT4dyNJ8pb8aRE9idy9NvJqvYwu2jO3DPuE41Hx2cDoeV1B9e5ocfNuCQWmcQXWCma0EpUUOGEXDBWPxGjcIQcrICki4XB4YOI2DcOFq++EKVzZdPqcs7lkbnwcPpf/mV/PT6SyAlM55/jcDwM7dLupxOvnvucTL272Xo3mTifv4/vFq3xpqURNLESQROmkjh+AtZ8+UnlBUVETf+MoZf8w9MvlW/ya795nM2Lf6OgROn0OlACoVLltBp3doqnbL1hZSSlZ99QMJvPzNixo0MvlJTQPasLEr9DCQmbmfNS/8hdGhvjBd19zhfPU5XtxPWIR1Vtu+t99YcpW67ebBJ+/RYk0rXz/5E6gSWuC6YX74PH6Mv3npvrfM3eONj8MFb743JYGqwueunwmFzUpRb3ukf7/yLciwU5ZZhtzgr1dcZBHq9zrPVG9z7Bh35R3+krGAPrXr8C5/Alto5vdDerE0Gco6sI3nbj/S+5HZad+2H0aS9hRvdphejSXsDN/ro0TfzPGB1RTmazxBZks3vBeDrp+fHO4fTp01wvbZ/ZN9+fvwpAR+XngEp6WQP6Mc+YzZrQgPp3asTQ0aNrFIhAAidDr9BAynduPGkc6WFBaz58hP2rF1FUGQUV82e63GcXTXnGRY+/SiLXniK6c++gk9AFWsY14K133xO2t5d9Cu2ExXXD6/W2tRbU/v2hF5/PXnz5xM7fTrtX3+fdQu+ZNuvP3Ngw1+Muf5mugwbVeltbtOS79m0+Dt6jxvP8MnTODhqNIGXXNKgCgE0U8oFM2+jtLiQdd98zpbC7exslcv2rO2YrcVc/nc0Pl56vvL7GfvmnzAIA6E+oR5be9fQrh7na6h3KCHeIZ6OP8gUVO1bvBwsSU26HcuOnfR6/f0amQHrgt3mpCTfqjlET3B+2i0VHaGVnaNlZhulhbZKbRmMOgLCfQgK96Zl52CCwn0ICPMmKELbenlX352UFnXl84dmYS/9nWse/2+lgLySgnw+ve83YuL6c+FNlzXJOf7NCTVSqApbKbzYglfs0xh1878Z0j6sXps/smsHP778DP5GL/pv2kn7V14h8NJLKSnIZ8MPC9ix/Fd0BgMDLp/MgMuvwlTFfPW8/31F5vPP02H5H3i1bq1lblz5O2u/no/NYmHgxCkMnnz1SYnJUvfsZNGLTxEZ24Grn3i+zonLyjNXdu/dn5gvv6Xlq68SdMXlnvNOs5lDEyZgbNGSmAXfIHQ6Mg4eYPkn75KZdJC2veIY9887CG3Zih3Lf+WPj96hy9CRXHrPQxT/3zKOPfwIbT//HL/Bg+ok3+kothWTkJXA1qytbM3cyu6sXYzcHEzLbG/2DdfTZkA/ovc5KPktgc43TKbbsNGE+4QTaApEJ+rnTVU6HLhKS9EH1k05SymxmO0U51VwsuZaPMfFeRYs5lOncPbYzr0r28hNfkYCw7wJDPfxdPq+gV5n1GEf2LCOn15/iRHTb2Dw5Gs85b+++wZ7163mxtfmEdpS5fpqKNRI4QxwFmeiB7xDWjA49vTLG9aGI7u28+PLzxIYHEK/tfGEXTCOgAkTAPALDmHcP++g36WT+GvBl2xYtIDtvy9jyJTp9L5wQqU50+WdZenGjRQ4bCz/eB7piftp070X426+k7DWVUf9tunei0vvfoifXn+J/3vrVSY+8Fit0yjkpx/l13ffILpDJ3rkmSkLDCTgogsr1dH7+xP54IOkz55D4Y+LtZTXHTtz7Qv/Yfsfv7Dumy/44uFZdB46kr3rVhMb158Jdz2ATqenYNEPGNu0wXfg6acG1pSs0iy2Zm71KIED+QeQSAzCQLewbkzvPoO44b1In/8bhg1JXNxnJCv/fJ92vfty+aX/bJC3V2EwVKsQnHYXJUVWSgu1N/aSQiulRdrWnG91z66x4LCd4GT10hEQ6k1AmDcR7QK0/RATJl+j5iT1Mbhnw2hO0bMxm6WczkNG0HnwcNZ//zUdBw4hrHVbjh3Yy+41yxk4aapSCE0ENVKogvWrf2Ho6ulsHvY+Ay+eUW/tliuEoMgoBqdkoT96jPY//4QhrOqRSMahRNZ+/RlHdu0gKDKK4dOup+uwUQidDikle0eOJKlrew6UFODtH8CY62+m28ixNerAtv36Eys/+4De48Zz4a2zatzp2a0Wvn7iIcx5uVz7+HNkXjmF4KlTiX7qyZPqSpeLlGuvw5aaSodff6mUUqKkIJ81X37C3nWradW1B1MeewajyRtb2lEOXXgh4ffcTcSdd9ZIJtDm6aeXpHPUfJRj5mMcMx87vl9yjDyLtgSlj8GH3hG96R/Zn35R/egV3gtf4/GRmMVsZuEzs8k5kozeaOTG1+YREn1y8GJdcTpclBRaKSmwUVJgpaTASmmRlZJCm3tf6/itJSf7KIQAnwAv/ENMbqeqt0cBBLj3TX6GJm1+KS0s4LMH7yQkqgXTnnmJr594iNKCfG564wO8vM++w7w5oUYKdURKycotuxgK9Otet9WyqiJlZwKLX3mO4KhoLmjbBfP/rSL6jderVQgA0R06MfWJF0jZsY0/v57PsrdfY/NPPzDq2pnYrRZWtw2nrDiPXuMuYeS1M/Hxr1keH4C+46/AnJ/HpsXf4RcSyrCrrz3tNVJKln/8LjmpKVw1ey5ywyakzUbQlKuqrC90OqKefILkqVeT8847RM2Z4znnFxzCpXc/xODJ1xAYGeVJnFb4448gBMFXXlnpvkW2IjJKMsgoySC9JL3aTr8cL50XLf1b0sq/Fd3CuhETGEO/qH50Ce1ySqett78/Ux57liWvPU+3EWNqrBCklFhLHZQUWDG7O/sT90sKrJQVn2zO0ekFvkFe+AWZCIrwoWXHYM9xxa2PvxHdOe5k9Q0K5oKb/sWyt17lu+ceJ+vwIS6752GlEJoQSimcwMbDeZTkpYMR9AH1EzlYUSFMvPZmMm6cScCE8QSOH3/aa4UQxPTpR7tecez7+0/WLfiSRS9qK4+FBIUQF7+T/i9djqkWCqGcEdNvoCQ/j/Xff41/aCi9x51anp0rfmPPnysZOvVaYuP6c/jZFzF164ZPj+oXvfHp0YPgq68m739fETx1KqZOnSqdD2vdllJ7KamFSWQUH8Pvu68w92zNc4ffJ2OXpgAySzMrJTyD451+S/+WdA3rSiv/VrT0a0mrgFa08m9FqHdonW3//iGhXPfCfyuV2W1OzBWDo9wmHLN7vypTDoBPgBG/YBN+wSYiYwLxd+/7Bbm3wV5nPIXyXKPrsFHs/3utlkK8e0+6DBvV2CIpKqCUwgl8+GcSg7zMWrRiFSkuakvKzgQWv/wswdEtmDrnGbJu/Rf6gACinzzZ3HIqhE5HtxFj6DR4OHvWrACgc2wnDl92OaUbN2KKrX3sgRCCi267m9LCApZ/9C6+QSF0HDC4yroZhxJZ+dn7xMT1Z+iU6Vj27sWyZw9RT1RORSClpNheTIGlgDxLHgXWAoomdiJ2mZFNj97O7w8MpcBaSJ41jwJLAfmWfIrtxQD0THbxVJaLL4cWc+DoOqL9oukU0omRrUcS7RtNtN/xT7hP+Bk7fMvf7suKbZQV291bG6VF2rG5wOqJlD3JnCPAN9AL/xBvQlv60bZHGP4hWkdfsePXG8/tN/uGQAjBRbfOwsvbmyFTpjcrhXguoJRCBfZnFLNyXxb3xbogP7jqHEW1oKJCuPqpFyn96msse/bQ6s03MYTWzYFtMBrpfaH2Ri+lxBAVRcnGjYRMn16n9vQGA5ffP5vvnn2M/3vjZaY++cJJWSHLiov46fV/4xscwqV3PYjQ6cj7/nvwMhLf25v9294mMT+RgwUHSTenVzln/5JhLm7+/Rhlf6wiY0BLgk3BtApvRbApmEjfSKL9omm3+UcI2MGbT6/C5HtmU1EdNidFORYKc8ooyi7DnG/xdPylxTbKimyUme24nFX71Lz9tDd8/1AT0bFB+HsCpLStX7DprDppzzfKzYeKpodSChX48M8kfIx6ugaUgf3MTEcehdCiJVc/+QK69Ayy332PwEsvJfCSU6zPUAuEEPgNGYx57bpKKZhri5e3D5Nnz+WbJx9i8SvPMv3ZVzxrFricTn5880WK83LxvXEEc7e9wOHs/Ty8aD/bOwje3DYXvdDTLrAd3UK7cXG7iyvN1w/xDtH2rwkgM+UG/rW2iA6zv0DnU9mG7CwqInHtEwRPuapGCqF8OmZhthZQVZitdf7lSqDkhDn2eqMO3wAvfAK98A82EdEmAJ8AL3wCjPgEeOEb6HX8+Dyw3SsUdUUpBTfphWUsSTjKP4a0wysnt1Leo9qSsiOBxa8cVwg+Pr4cnj0HfVAQUU/Wb+ZH30GDKVyyFGtiIt6dO9e9ncAgLn1kDt89PYcvn3mIoqs7st+ejNfGY/Tc58f6Hrnsz/iCFn4tmHAoAH8LxFx3C99fcBkxQTGY9KcfVUU/8Tgp199A7kcfVUqv7XK6yFr8CyW6QHyHXcGR3blYSx1YyxxYS+1YS9zbUgeWUgcWs73KiFq/IC8CI3xo0y2UwAhtfn35PHtv/+Zlt1co6opSCm4+XXcYCdw8Ihb+l6UlsasDJyoE38Agst+Zh3XvXlq/83a1Ucp1xW+I5gMo3bCxxkpBSkl6STr78/azP3+/Z5tanEpoby8mbIjC/u0WwvuF0mafH7592vP4zc/RMaQjAV4BHPnnzdhatmTcVffVONEdgO/AgQRedhlZn35BQY+LSD0GKTtzKS2yAREweC58nw/kV7pOb9Bh8jV4PgGhJk9EbWCEjxZZG+6N0evcWbZSoWiqKKUAFJbZ+WZTKpf3bkGbUF9tLYU6jBQsZjOLX3uukkKw7N1LzvvvE3jFFQRceOHpG6klxlatMLZuTcmmjYTecP1J5x0uB4cKDrEndw/78/ezL28fB/IPUGzTnLsCQZuANnQN7cqkDpPoEtqFwMFO1rz5FsGriwhv045rH3zFE/lsP3qUkvXrCZ81q1YKwWK2k7wrh0Ntp3Fk4IW4vkvHy1tP255hBBotFH/xCaHjxxJ+yQWYfA14+Rrw9jVi8jVgUJ29QnHWUEoB+HrjEcxWB7eNag/2Mm0pTf/aK4WMg/txWK2MvfFWfAODkDYbx2bPQR8STPTjjzWA5Bq+QwZT/Psf2O1Wks1H2J27mz25e9idu5v9efuxOq2AFrjVKaQTE2Im0CW0C51DOtM5pHOl4C0A2oDvLAOblnzP5ffNrpQKo+DHxQAEXzX5tHIV5ZRxeHsOSQnZpB8qRLokfsEmYqPK8F/xAb3+/QBBY3qS+fIr5GWuo9PNL9TZAa9QKOqHZq8UrA4nn/51mJGdwunRMgjyU7QTdVEKSQcBPOmVc97/AOv+/bR+dx764OD6EhnQ1sZNLkpmT+4eCsOz6F9UxLVvDmNfhOZg9TX40i2sG9d0uYYeYT3oHtaddoHtajyNs+vw0XQdPrpSmXS5KPzhB/yGDcPY8uSgLiklOalmkhKyObw9h9yjZgBCW/rR75K2tI+LIKJtANJu5/DmD8h56UUCBi2icOlSAsaOUQpBoWgCNHulsHjbUbKLrbx+TZxW4FmGs/ZKITMpkZAWrTD5+lG2ezc5H3xA0KSJBFxwQb3Iml2azarUVaw8spKtWVs9AV0tvE30B6aZu2OarCmBdoHt0Ovq1+xSsn499mPHiHzoQSwldnKPmsk7VnJ8e6wEW5kDIaBFx2CGT+1IbJ9wgiIqj0SElxdRj80h9V+3kzprFs7cXIKuqjoqWqFQnF2atVJwuSQf/plEj5aBDO/oTjdhztK2/rUPXMtIOkjrrj1w2Wykz3kMQ2goUY+dmdkopSiFFUdWsOLICnZk7wCgbUBbJnWYRM/wnvQI60FsUCzJS65gULovbTtccUb3OxG7zUl+utbxp3yzh4J+97JhdSClS9d66ph8DYS29KPzwCiiYgNp1ysMH3+vU7brP3o0/mPGYF69Gn1EOP4jR9ar3AqFom40a6WwYl8Wh7JLeHN63PHpiiVupVDLkUJJQT7m3ByiO3Qi5913sR44QOv330MfVLs1iqWU7M3by4ojK1h5ZCUHCzSTVLfQbsyKm8W4tuPoGNzxpOmVvkMGU7RkKdJuRxhPvSCLdEkspXbKiuyUmStH85YVHy8zF1gpyinzrEWrc7YhMMxG2+6hhLb0J6yVH6Et/fELrltK5ajH5lCyYQPBV01BGJr1n6JC0WRo1v+JH6w5RKtgHy7r1eJ4obncfFS7kUKm258QjJ7cjz4maPJkAsaMqdG1DpeDbVnbPIogvSQdndDRL7Ifjw58lLFtx9LK/9Rphf0GD6bgmwVYdu/GJy4Ol0tSkFlKTmoxOalmco6a3QnZbFjMdqpLjuvtZ/QEdEW2DaDrkGhCW/ph2LyCkv8+R/vFP+DdtWttvppq8Wrblg6//1bv03QVCkXdaVClIIQYD7wJ6IGPpZQvnXD+dWCs+9AXiJRSBjekTOXEJ+cRn5LP3Cu6Y6gYvVqSBd5BYKzd4jMZhxJBCBzvfoAhPJyoObNPWb/YVszfx/7mz7Q/WZu2lnxrPl46L4a2HModfe5gdJvRhHrXzPFqtzkpbtGDoy1GkPLdYcy/OchNM+OwawnadAZBWEt/giJ8iO4QhG+AF97+Rm0boG19Arzw9jNUGckrpeTwM9/i06N7vSmEcoyR9ZN0UKFQ1A8NphSEEHpgHnARkAZsFkIslVLuKa8jpby/Qv27gb4NJc+JfPBnEsG+Rq4ZeMJiNObMWpuOnAUFHPn9F/zLrJCeS8t33q5y8ZQjRUdYk7aGNWlr2JKxBYd0EOgVyIhWI7ig7QWMaDUCP2PV6xd77mV3kZlcSMbhIm0EkFpMQWap9ubfZQbGHCuRYTp6jGpFeBt/ItoEEBzte0br2lr27MG6bx/RTz9V5zYUCsW5QUOOFAYBB6WUSQBCiAXAJGBPNfVnAE83oDweDmaZWb43k7vHdsTX64SvwJxd4+mo0mYj/5tvyHr3PXJaBdMysgUdPvkaQ3g4AHaXnYSsBNakaooguSgZgA5BHbi+x/WMbj2aPhF9MOiq/xlcThdZKcUcPZBP2r58Mg4VekYA/iEmwtsE0KF/JBFtApBLvsD24//o8vZGdF6ndvTWhsJFixAmE4GXXVZvbSoUiqZJQyqFVkBqheM0oMq8zEKIdkAssLKa87cBtwG0bdv2jAX7eG0SXnodNwyLOflkSRZE9Tzl9VJKzCtWkPnqq9hTjqAbOgRraTYxV03F7G9gXdLP/Jn6J+uOraPYVoxRZ2Rg9ECmd53OqNajaBNQ9VKZoDmBc9LMmhLYn8+xxAJPjp+wVn50H9mSVp1DaNEx6KQZPsW5caR98zGW7dvxHTiw1t9LVbgsFgp/+pmAiy+u81rCCoXi3KGpOJqnA99LKZ1VnZRSfgh8CNpynGdyo6wiCz9sPco1A1sT7l9FEjdzNnSofqRQtns3WS+9TOnmzXh17ECbjz4kw9sIrz3Pdn0St33/DFanlTDvMC5seyGjW49mSMsh1ZqFpJTkZ5RydL+mBI4eyPfk7g+O8qXzoGhadwmhVedgfAJO/fbvO2AACEHJxk31phSK/1iOq7iY4ClT6qU9hULRtGlIpXAUqPhK3NpdVhXTgVkNKIuHz/5OxuFyccuI9ieftFvAWlilT8GekUH2629QuHQp+pAQouc+TfDUqQiDgUNfvo8U8GbaJwxvN5Lbe99Oj/Aep4wellKSvDOXLb8kk3m4CICAUG9i+0S4lUAI/iG1W89BHxSEd/fulG7YAHfVz9dZsGgRxjZt8B1UP0pGoVA0bRpSKWwGOgkhYtGUwXTgpIWAhRBdgRBgfQPKAoDZ6uB/G1KY0LMFMeFVvLmXRzNXCFxzlZSQ+8mn5H76KbhchN1yM2G33eZZhP7X5F9ZsflHvP0Fj494kqmdpp5yzr7LJTm0JYstv6aQe9RMQJg3I67pRGzvcALDz3ydWt/Bg8n/8ktcZWUnrVlQW2ypqZRu2EDEvffUKvmdQqE4d2kwpSCldAgh7gJ+Q5uS+qmUcrcQ4lkgXkq51F11OrBAyupmztcfCzYdodjiTnxXFZ5o5ijtcO1a0h97HEd2NoGXXkrEAw/g1VqLFyiyFfHvjf/m50M/c11hDJ36D2ZK56urvbfT4WL/xgy2/ppCYXYZIdG+XDizGx0HRp3RzKAT8RsymLxPP6Vs2zb8hg07o7YKf/wRdDqCJp8++Z1CoTg/aFCfgpRyGbDshLKnTjie25AylGNzuPhk3WGGtA+lT5vgqiudEM2c9frrCJOJdt98jW/f47NlN2ds5rF1j5Fdms3tsTdh+WUlHbpUPZvWbnOyZ90xEv44gjnfSkTbAMb/qyft+0QgdPW/6ItPv/6g11OycdMZKQXpdFLww4/4jRiOMTq6HiVUKBRNmabiaG5wftp+jPRCCy9e1av6SifkPXJkZRMwdoxHIdicNt7e9jaf7/6ctoFt+XLCl3gnFbOUlUR16FipKWuZg11r0ti+IpWyYjstOgYx9h9dadM9tEFXANP7++HTq5fmVzgDileuxJGRQdTsUwfhKRSK84tmoxQiA01M7tuKMZ1Pkb6iwkhBOp048/IwRGj1D+QfYPba2STmJzKtyzQe6P8AvkZf1i7/HJ1eT0TbWADKim1sX5HKztVp2CxO2vYIo//4drTsFNzAT3gc38GDyf34Y5zmEvT+pw6GqwpHXh4Zzz6LqVNHAi4Ye/oLFArFeUOzUQojO0UwstNp8hmZs8EUCEZvnNnZ4HKhCwvj892f8+bWNwn0CmTeuHmMaj3Kc0lm0kHC28Rg8PLi8I4c/vh0N3arkw59I+g/PoaItgEN/GQn4zdkMLkffEDZlnj8R48+/QUVkFKS/tRTuAoKafnxx4h6DIJTKBRNn2ajFGpESZYnEZ4jJweAD49+y9eOJC5ocwFPD3u6Uj4iKSWZhxLpNHg4CcuP8Neig0S2DWDczO6Etqj9G3p94dO3L8JopGTjplorhcJFizAvX0Hko4/i3aVLA0moUCiaKkopVMSc7Zl5VJaZDsAuVxrPDnuWKzteeZIvoDArE0uJmcJsfxK3HaRDvwjGzeze6AvI67y98enTh9KNG2t1nS0lhYwX/43vkCGE3nhDA0mnUCiaMmryeUXMmR4n85/blwBw94VPMbnT5Cqdw6l79gGQkezNgEtjuOSWno2uEMrxHTIEy549OAsLa1RfOhwcfeQRhMFAy5f+reISFIpmivrPr0hJFvhFkm5OJ2HfagAG9bi4yqoFmaWsW7gO0HPhP0cyeGL7BpliWlf8Bg8CKSmNj69R/Zz33seyfQctnpmrpqAqFM0YpRTKcVjBUgj+kbwa/ypBZgl+flVGBafuy+P7l+OxlR4jtFU7ug1r3QgCnxrvPn0Q3t6UbDi9Cal02zZy3n+foEkTCZww4SxIp1AomipKKZTjTnGxXpbyR8of9NPH4FXFAjC7/jzKT29txzfICyGyadO9fhedqS90Xl749ut7Wr+C01zCsUdnY4yOJurJJ8+SdAqFoqmilEI55izswL8z/6RNQBva2AM86yKAlrNo3beJrPl6P226hTLuhhbYLWUnBa01JXwHD8F64ACOvLxq62S+9G/saWm0fPkl9P7+Z1E6hULRFFFKoZySbL4KDOCwJZvZg2bjysnFEKEpBVuZg2Xv7mD7ylR6X9Cay+7sRd7RwwBEt+/UmFKfEr/BgwAo3bSpyvNFf/xB4feLCLv1Vi3ttkKhaPYopeAmK/8Q74UEMTpqIKNaj8KRnY0+PJyinDIWvbqFI3vyGH1tF0Ze0xmdXkdmUiIGoxdhrc980Z+GwrtnT3R+fpRUkfLCnplFxpNP4d2jBxGz7mwE6RQKRVNExSm4+U/qrzgQPDpoDq6SElylpRT6tmbZy/E4HZIr7u5Dm27HA9cyDh0kIrY9On3TmIJaFcJgwGdAf0o3Vh4pSJeL9Mcew2Wx0PLVV1TUskKh8KBGCkB8RjzLSg5zk9lCm9BOOHJzkcCGlJYYvPRMfbR/JYXgcjnJOnyoSZuOyvEbPATb4cPYM7M8ZflffU3JX38R9egjmNpXk0ZcoVA0S06rFIQQVwhxiiXEznEcLgcvbnqRlsKLm6XmaHXk5FAUGIu5TMegy2MJia6csiL/2FHsVgtR7Zuuk7kcX49fQZuFZE1MJOu11/AfPZrg6dMbUzSFQtEEqUlnPw1IFEK84l4l7bxi4f6FJOYn8ogrCB8/LcWFIyubjKhB6A2C9n1PTqKXcSgRgOgOTX+k4N21K7qgIEo2bMBls3H0kUfR+fnR4oXnGzSFt0KhODc5rVKQUv4D6AscAuYLIdYLIW4TQpz99J/1TE5ZDu9se4dhLYdxgbnYk+LCmpVDZmQ/YrsH4eV9stslM+kgRpM3IS1bnW2Ra43Q6/EdOIDSjZvIfvNNrHv30uL55ytNt1UoFIpyamQWklIWAd8DC4AWwGRgqxDi7gaUrcF5Y8sbWJwWZg+ajSg5ngwvLcWKw+hPl+FVRypnJCUSGdsBna7pOpkr4jdoMPa0NPI++ZTgadPUGgkKhaJaauJTmCiE+BFYDRiBQVLKCUAf4MGGFa/hSMhKYMmhJdzQ/QZi/VpBWb5nGc7kbF+MjhLa9jz5bdrldJKdfJjoJhy0diK+QwYD4NWuHVGPPtLI0igUiqZMTaakTgFel1L+WbFQSlkqhLi5YcRqWJwuJy9ufJFI30j+1ftfnhQX+EdgKbGTYQ2jrW0XOv3JOjP3aCoOm5Wo2HNHKZg6dSL87rsIuOgidL6+jS2OQqFowtREKcwF0ssPhBA+QJSUMllKuaKhBGtIFiUuYm/eXl4d9Sq+Rl8o2a+d8Ivk0NYsXEJPG5/MKq/NdDuZo84BJ3M5QggiZs1qbDEUCsU5QE18Ct8BrgrHTnfZOUm+JZ83t77JwOiBXBJziVZoLh8pRLJ/YwZ+1mzCwqr2F2QkHcTLx4eQ6JZnSWKFQqE4e9REKRiklLbyA/f+ORsC+9a2tyixlzBn0JzjUzJLtMCuIlsw6QcLiUrfiDGy6vWcM5MSiYrtqBahUSgU5yU16dmyhRATyw+EEJOAnIYTqeHYnbObRQcWcW23a+kUUsH8Y9aUwoE92mFUxkYM4ScrBafDTnbK4XPKdKRQKBS1oSY+hduBr4QQ7wACSAXOuQV8XdLFixtfJNQ7lDv63FH5ZEk20ujPgS15RLXywseSV+U8/pzUIzjt9nMiklmhUCjqQk2C1w5JKYcA3YFuUsphUsqDNWlcCDFeCLFfCHFQCDG7mjrXCCH2CCF2CyG+rp34NWfJwSXsyNnBgwMeJMDrhLg7cybZ+r7kZ5TSvrXmPilPm12RzCR3JPM5kPNIoVAo6kKNsqQKIS4DegDe5XZ4KeWzp7lGD8wDLgLSgM1CiKVSyj0V6nQC5gDDpZT5QoiTlzqrJ2KCYpjSaQqXt7/85JPmLPaXjURnELTyyyMPMEScbD7KPHQQk58fQVFqDWOFQnF+clqlIIR4H/AFxgIfA1OBqldtqcwg4KCUMsndzgJgErCnQp1bgXlSynwAKWXWSa3UE30j+9I3sm+V51zmXBLzehLbKxx9oTYIMoSFnVQvIymRqPadVM4ghUJx3lITR/MwKeUNQL6U8hlgKNC5Bte1QvM/lJPmLqtIZ6CzEOIvIcQGIcT4mghd3xzJjqDM7kPnwdE4c3LQ+fqi86ucGdVhs5FzJIVo5U9QKBTnMTVRChb3tlQI0RKwo+U/qg8MQCdgDDAD+EgIEXxiJXcCvnghRHx2dnY93dqN086Bwn6YvBy06xmGIzu7StNRzpFkXE6HmnmkUCjOa2qiFH5yd9SvAluBZKAmDuGjQJsKx63dZRVJA5ZKKe1SysPAATQlUQkp5YdSygFSygERVXTYZ4ItN5PDlsF0al+K3qDDkZ2Dvgonc0aSZlZSTmaFQnE+c0ql4F5cZ4WUskBKuQhoB3SVUj5Vg7Y3A52EELFCCC9gOrD0hDqL0UYJCCHC0cxJSbV6gjMkactRHJjo3MsIaAvsVBWjkJmUiE9AIAFVnFMoFIrzhVMqBSmlC20GUfmxVUpZWJOGpZQO4C7gN2Av8K2UcrcQ4tkKwXC/AblCiD3AKuBhKWVuHZ6jzuzfZiZQn0F0R82xrCmFKqajHkokqoNyMisUivObmkxJXSGEmAL8IKWUtWlcSrkMWHZC2VMV9iXwgPtz1jHnW0k7AgP81iAChuCyWHAVF5/kU7BbLeSkHaHDgMGNIaZCoVCcNWriU/gXWgI8qxCiSAhRLIQoamC5zgoHNmcAgi4+a8AvEkeOlr3jxJFCdsphpMtFlPInKBSK85zTjhSklOf8spvVcWBjJlEhhQT7FIHJH0e2FrF8YjRzxiHNyRx1Di2so1AoFHWhJsFro6oqP3HRnXONnDQzuUfNjOp6AIRmLnK4p7ueOFLITErELzgE/5CTA9oUCoXifKImPoWHK+x7o0UqbwEuaBCJzhIHNmag0wk6+m8BtOwaHvPRCT6FzKSDRLXvqJzMCoXivKcm5qMrKh4LIdoAbzSUQGcDl0tyYFMGbXuG4WM9AmEdAHDm5IBOhz401FPXZikj72ganYeMaCxxFQqF4qxRl5Vi0oBu9S3I2eTogXxKCm10HhSlLbDjV24+ykEfGorQH191LSs5CSldRKtIZoVC0QyoiU/hbaB8KqoOiEOLbD5nObAhAy9vPbE9guHnPPB3m4+qSHGRWe5kVjmPFApFM6AmPoX4CvsO4Bsp5V8NJE+DY7c5ObQtm44DIjE48gF5fKRQReBaZlIi/qFh+AWHNIK0CoVCcXapiVL4HrBIKZ2grZMghPCVUpY2rGgNw+Ht2ditTroMigazO4mrfxSgKQVTp8pmooykgyo+QaFQNBtq4lNYAfhUOPYBljeMOA1HcV4OWclJ7Ft/DP8QEy07BWv+BAD/SKTLhSM3t9JIwVpaSv6xNJUuW6FQNBtqMlLwllKayw+klGYhhG8DytQg7PlzFeu++RwwEBDehtVf7CbakEOU1YcQnzCchYVgt1fyKWQdLg9aUyMFhULRPKiJUigRQvSTUm4FEEL0B8oaVqz6p/vIsRRk6tj713Z8AkrYseI3ttqswABMjzxOeHQrTC1CsZUUYsjJIiAswpMuWzmZFU0du91OWloaFovl9JUV5zXe3t60bt0ao9FYp+trohTuA74TQhwDBBANTKvT3RqRgLBwivLa0qJLG6Y9PgiX00nutw+Tsfl3MrvdwbEd2zgWHkzS6l9h9a/4BgUjhCAwIhLfwKDGFl+hOCVpaWkEBAQQExOjgiybMVJKcnNzSUtLIzY2tk5t1CR4bbMQoivQxV20X0ppr9PdGpH8jBKyUooZPlV769fp9UR4FRPRVtDr1lkULllC6uw5BH74LrmlZjIPJZJxKJFOg4Y2suQKxemxWCxKISgQQhAWFsaZrFBZkziFWcBXUspd7uMQIcQMKeW7db5rI3BgUyZCQKeBUccLS7IqzTzSS0mrvgNp6+9XTSsKRdNFKQQFnPnfQU1mH90qpSwoP5BS5gO3ntFdG4F+49txxb1x+AWZjheas8GvPHAtB+Hjg87vnPOhKxQKRb1RE6WgFxVUjxBCD3g1nEgNg9FLT5uuoZULS7LAv3LgmnrbUijqhl6vJy4ujp49e3LFFVdQUFBwyvpz587ltddeq1HbO3fuJC4ujri4OEJDQ4mNjSUuLo4LL7ywRtcvXbqUl156qUZ1mzs1UQq/AguFEOOEEOOAb4BfGlass4DTASU5FUYKJ6e4UCgUNcfHx4eEhAR27dpFaGgo8+bNO/1FNaRXr14kJCSQkJDAxIkTefXVV0lISGD58uMhUw6Ho9rrJ06cyOzZs+tNnvOZmsw+ehS4DbjdfbwDbQbSuU1pLiCP5z3KycHUoUPjyqRQ1APP/LSbPcfqd3HE7i0DefqKHjWuP3ToUHbs2AHAoUOHmDVrFtnZ2fj6+vLRRx/RtWvXSvXHjBnDa6+9xoABA8jJyWHAgAEkJyef9j5jxowhLi6OdevWMWPGDDp37szzzz+PzWYjLCyMr776iqioKObPn098fDzvvPMOM2fOJDAwkPj4eDIyMnjllVeYOnVqrb6P85mazD5yCSE2Ah2Aa4BwYFFDC9bglEczV8h75DdYrcGsUJwpTqeTFStWcPPNNwNw22238f7779OpUyc2btzInXfeycqVK+vtfjabjfh4LUVbfn4+GzZsQAjBxx9/zCuvvMJ//vOfk65JT09n3bp17Nu3j4kTJyqlUIFqlYIQojMww/3JARYCSCnHnh3RGhhzeYqLKFw2G67CQgyRynykOPepzRt9fVJWVkZcXBxHjx6lW7duXHTRRZjNZv7++2+uvvpqTz2r1Vqv95027XjYVFpaGtOmTSM9PR2bzVbtXP0rr7wSnU5H9+7dyczMrFd5znVO5VPYh7a62uVSyhFSyrcB59kR6yxQ4p7H6x+Js5plOBUKRc0p9ymkpKQgpWTevHm4XC6Cg4M9/oCEhAT27t170rUGgwGXywVQ66hsP7/jU8jvvvtu7rrrLnbu3MkHH3xQbVsm0/FZiFLKKus0V06lFK4C0oFVQoiP3E7m82dqjvm4+ah8GU69UgoKxRnj6+vLW2+9xX/+8x98fX2JjY3lu+++A7QOePv27SddExMTw5YtWwD4/vvv63zvwsJCWrVqBcDnn39e53aaM9UqBSnlYinldKArsAot3UWkEOI9IcTFZ0m+hqMkCwzeYAo4vjZzuDIfKRT1Qd++fenduzfffPMNX331FZ988gl9+vShR48eLFmy5KT6Dz30EO+99x59+/Ylx/3/WBfmzp3L1VdfTf/+/QlXL3l1QtRm6CSECAGuBqZJKcc1mFSnYMCAAbLcqXRG/HAbpKyH+3eSv2ABGXOfoeOaNRijIs+8bYXiLLN37166dTunV8lV1CNV/T0IIbZIKQec7tpardEspcyXUn7YWAqhXjFXCFzLzgEhMISq1dUUCkXzplZKobYIIcYLIfYLIQ4KIU6KHBFCzBRCZAshEtyfWxpSnkqUVEhxkZODPiQEUcdUswqFQnG+UJPgtTrhTocxD7gISAM2CyGWSin3nFB1oZTyroaSo1rMWdCqP1D12swKhULRHGnIkcIg4KCUMklKaQMWAJMa8H41x+WE0pzj0cwqxYVCoVAADasUWgGpFY7T3GUnMkUIsUMI8b0Qok1VDQkhbhNCxAsh4s8kT7iH0jyQrgrmo2w1UlAoFAoa2KdQA34CYqSUvYE/gConFrud2wOklAMi6uONvjzFhX8EUkqc2TkYIpRSUCgUioZUCkeBim/+rd1lHqSUuVLK8pj3j4H+DSjPcczusHa/SFyFhUi7XZmPFIp6JCYmhl69etG7d29Gjx5NSkrKKevPnz+fu+6quWtx7Nix/Pbbb5XK3njjDe64445qrxkzZownR9Kll15aZWrvmqTzXrx4MXv2HHeNPvXUU5WytZ7rNKRS2Ax0EkLECiG8gOnA0ooVhBAtKhxOBE6Of28IzMdTXKhoZoWiYVi1ahU7duxgzJgxPP/88/Xa9owZM1iwYEGlsgULFjBjxowaXb9s2TKCg4PrdO8TlcKzzz5b43UdzgUabPaRlNIhhLgL+A3QA59KKXcLIZ4F4qWUS4F7hBATAQeQB8xsKHkq4TEfReI4qOkhFc2sOG/4ZTZk7KzfNqN7wYS6LVIzdOhQ3nrrLQCys7O5/fbbOXLkCKC93Q8fPrxS/ZkzZ3L55Zd7Mpf6+/tjNpsr1Zk6dSpPPPEENpsNLy8vkpOTOXbsGCNHjuSOO+5g8+bNlJWVMXXqVJ555pmTZIqJiSE+Pp7w8HBeeOEFPv/8cyIjI2nTpg39+2sGi48++ogPP/wQm81Gx44d+fLLL0lISGDp0qWsWbOG559/nkWLFvHcc8955F2xYgUPPfQQDoeDgQMH8t5772EymYiJieHGG2/kp59+wm638913352UPryp0KA+BSnlMillZyllBynlC+6yp9wKASnlHCllDyllHynlWCnlvoaUx4M5C/QmMAVqgWugfAoKRQPx66+/cuWVVwJw7733cv/997N582YWLVrELbfULTQpNDSUQYMG8csv2npfCxYs4JprrkEIwQsvvEB8fDw7duxgzZo1nnUdqmLLli0sWLCAhIQEli1bxubNmz3nrrrqKjZv3sz27dvp1q0bn3zyCcOGDau0yE+HCmuwWCwWZs6cycKFC9m5cycOh4P33nvPcz48PJytW7dyxx131HjFucagwUYKTZqSbG06qhA4yjOkKp+C4nyhjm/09c3YsWPJy8vD39+f5557DoDly5dXMr0UFRWdNAqoKeUmpEmTJrFgwQI++eQTAL799ls+/PBDHA4H6enp7Nmzh969e1fZxtq1a5k8eTK+vtra7BMnTvSc27VrF0888QQFBQWYzWYuueSSU8qzf/9+YmNj6dy5MwA33ngj8+bN47777gM0JQPQv39/fvjhhzo989mgsWcfNQ7mrEqL6wiTCZ2/fyMLpVCcX6xatYqUlBTi4uJ4+umnAXC5XGzYsMGTRvvo0aP4n/C/VzGNtsvlwmazVdn+pEmTWLFiBVu3bqW0tJT+/ftz+PBhXnvtNVasWMGOHTu47LLLap2Ku5yZM2fyzjvvsHPnTp5++uk6t1NOebpuvV5/yqVDG5vmqxT8K8coCHH+ZAVXKJoKBoOBN954gy+++IK8vDwuvvhi3n77bc/5hISEk66pmEZ76dKl2O32Ktv29/dn7Nix/POf//Q4mIuKivDz8yMoKIjMzEyPeak6Ro0axeLFiykrK6O4uJiffvrJc664uJgWLVpgt9v56quvPOUBAQEUFxef1FaXLl1ITk7m4MGDAHz55ZeMHj36lPdvijRPpVByfKTgzMlRpiOFogFp0aIFM2bMYN68ebz11lvEx8fTu3dvunfvzvvvv39S/VtvvZU1a9bQp08f1q9fX2kRnROZMWMG27dv9yiFPn360LdvX7p27cq11157khP7RPr168e0adPo06cPEyZMYODAgZ5zzz33HIMHD2b48OGVnMLTp0/n1VdfpW/fvhw6dMhT7u3tzWeffcbVV19Nr1690Ol03H777Zxr1Cp1dlPgjFNnu1zwXDiMuB/GPUnSFVfgFRND6wpvLwrFuYZKna2oyFlLnX1eUJYH0lkh71GOilFQKBQKN81PKVRYhlPabDgLClTeI4VCoXDT/JRCxcC13FxATUdVKBSKcpqfUihPceEXqdZmVigUihNohkrBnQzPP0JFMysUCsUJND+lUJIFei/wDsaRo6KZFQqFoiLNTymY3WszV0xxERrayEIpFOc+L7zwAj169KB3797ExcWxceNGAG655ZZKqS0agtqkwn7hhReIi4sjLi4OvV7v2S9P2nc6zsbzNCbNL/dRSRb4H09xoQ8ORnh5NbJQCsW5zfr16/n555/ZunUrJpOJnJwcT3qKjz/+uMHvv2zZshrXffzxx3n88ccBLSr6xKhqKSVSSnS6qt+Zz8bzNCbNTymYsyBAW8ZBi2ZW/gTF+cXLm15mX179JhzuGtqVRwc9Wu359PR0wsPDPfl9witM8x4zZgyvvfYaAwYM4JNPPuHll18mODiYPn36YDKZeOedd5g5cyY+Pj5s27aNrKwsPv30U7744gvWr1/P4MGDmT9/PgDffPMNL774IlJKLrvsMl5++WWgZqmwT0VycjKXXHIJgwcPZsuWLSxbtoyXXnqpyhTcFZ/H39+fe++9l59//hkfHx+WLFlCVFRUXb/mJkHzMx+VZB8fKWRlK3+CQlEPXHzxxaSmptK5c2fuvPNO1qxZc1KdY8eO8dxzz7Fhwwb++usv9u2rrLjy8/NZv349r7/+OhMnTuT+++9n9+7d7Ny5k4SEBI4dO8ajjz7KypUrSUhIYPPmzSxevLhSG6dKhX06EhMTufPOO9m9ezft2rWrUQrukpIShgwZwvbt2xk1ahQfffRRje/XVGleIwWXS1MKfuXJ8HLwadevkYVSKOqXU73RNxT+/v5s2bKFtWvXsmrVKqZNm8ZLL73EzJkzPXU2bdrE6NGjCXX78K6++moOHDjgOX/FFVcghKBXr15ERUXRq1cvAHr06EFycjIpKSmMGTOG8nXar7vuOv7880/PWg1w6lTYp6Ndu3YMGTLEc1yTFNxeXl5cfvnlgJYS+48//qjx/ZoqzUsplOWDywH+kUgpceTkqBgFhaKe0Ov1jBkzhjFjxtCrVy8+//zzSkrhdJSbnnQ6nWe//NjhcGA0Gutb5EpUTLxXnoJ78+bNhISEMHPmzCpTZxuNRk+G5aaeErumNC/zUYVoZpfZjLRaVYoLhaIe2L9/P4mJiZ7jhIQE2rVrV6nOwIEDWbNmDfn5+TgcDhYtWlSrewwaNIg1a9aQk5OD0+nkm2++OSk19alSYdeG2qbgPp9oXiMFT96jSLXimkJRj5jNZu6++24KCgowGAx07NiRDz/8sFKdVq1a8dhjjzFo0CBCQ0Pp2rUrQUFBNb5HixYteOmllxg7dqzH0Txp0qRKdSqmwo6MjKyUCrs2VEzB3aZNm9Om4D6faF6ps3d+D4tuhlmbKEkq5MiNN9J2/mf4VbAjKhTnIudK6myz2Yy/vz8Oh4PJkyfzz3/+k8mTJze2WOcdKnV2TamQIdUTzazMRwrFWWPu3LnExcXRs2dPYmNjKzmJFU2D5mU+KskCnRF8QnCWJ8NT5iOF4qxxYnSxounR/EYKfhGeFBfCaEQXGNjYUikUCkWTofkphYorrkWEe6aTKRQKhaK5KYWSCkpBxSgoFArFSTSoUhBCjBdC7BdCHBRCzD5FvSlCCCmEOK1n/IwwV4hmzlYpLhQKheJEGkwpCCH0wDxgAtAdmCGE6F5FvQDgXmBjQ8kCgJSV8x7l5KiZRwpFA/Hpp5/Sq1cvevfuTc+ePVmyZAkATz31FMuXL2/Qe1eX2nr+/PncddddlcqSk5Np3bo1LperUnnF1N8nkpycTM+ePQGIj4/nnnvuqbJeTEwMOe4JLdXx4osvVjoeNmzYKeufDRpy9tEg4KCUMglACLEAmASc+Gs9B7wMPNyAsrhTXNjBLxJpt+PMz1dKQaFoANLS0njhhRfYunUrQUFBmM1mst3Bos8++2yD3782qa1jYmJo27Yta9eu9URH79u3j+LiYgYPHnza6wcMGMCAAXU3cLz44os89thjnuO///67zm3VFw2pFFoBqRWO04BK37IQoh/QRkr5f0KIapWCEOI24DaAtm3b1k2aEvfazP6ROPLyQUplPlKcl2S8+CLWvfWbOtvUrSvRFTqvU5GVlUVAQAD+/v6AliyvfH/mzJlcfvnlTJ06lWXLlvHAAw/g5+fH8OHDSUpK4ueff2bu3LkcPnyYpKQkjhw5wuuvv86GDRv45ZdfaNWqFT/99BNGo5EVK1bw0EMP4XA4GDhwIO+99x4mk6lSauvPPvuMf//735VSdZ/IjBkzWLBggUcpLFiwgOnTp5OcnMz1119PSUkJAO+8885Jb/KrV6/mtdde4+effyY3N5cZM2Zw9OhRhg4dSsXA4CuvvJLU1FQsFgv33nsvt912G7Nnz6asrIy4uDh69OjBV199hb+/P2azGSkljzzyCL/88gtCCJ544gmmTZvG6tWrmTt3LuHh4ezatYv+/fvzv//9r14nzDSao1kIoQP+Czx4urpSyg+llAOklAMi6tqRe9ZmrpjiQo0UFIr6pk+fPkRFRREbG8tNN91UZf4hi8XCv/71L3755Re2bNniGUmUc+jQIVauXMnSpUv5xz/+wdixY9m5cyc+Pj783//9HxaLhZkzZ7Jw4UJ27tyJw+Hgvffeq9RGeno6Tz/9NH/99Rfr1q2rdrW0a665hsWLF3uS2S1cuJAZM2YQGRnJH3/8wdatW1m4cGG1ZqJynnnmGUaMGMHu3buZPHkyR44c8Zz79NNP2bJlC/Hx8bz11lvk5uby0ksv4ePjQ0JCAl999VWltn744QcSEhLYvn07y5cv5+GHHyY9PR2Abdu28cYbb7Bnzx6SkpL466+/TilXbWnIkcJRoE2F49busnICgJ7AareWiwaWCiEmSinrmMfiFFTMe5SSAahoZsX5SU3f6BsKvV7Pr7/+yubNm1mxYgX3338/W7ZsYe7cuZ46+/bto3379sTGxgLa23rFXEkTJkzAaDTSq1cvnE4n48ePB6BXr14kJyezf/9+YmNj6dy5MwA33ngj8+bN47777vO0sXHjxkqptqdNm1YpVXc5UVFR9OzZkxUrVhAVFYXBYKBnz54UFhZy1113kZCQgF6vr/Laivz555/88MMPAFx22WWEhIR4zr311lv8+OOPAKSmppKYmEhYWFi1ba1bt44ZM2ag1+uJiopi9OjRbN68mcDAQAYNGkTr1q0BzfeRnJzMiBEjTilbbWhIpbAZ6CSEiEVTBtOBa8tPSikLAU+vLIRYDTzUIAoBKpmPnDm7AKUUFIqGQgjBoEGDGDRoEBdddBE33XRTJaVwOiqm0a6Ynro8jXZ9U25CioqKYsaMGQC8/vrrREVFsX37dlwuF97e3nVqe/Xq1Sxfvpz169fj6+vLmDFjqkzDXVMqmsAaIl13g5mPpJQO4C7gN2Av8K2UcrcQ4lkhRM1XvqgvIrvBgJvBO9hjPtIrn4JCUe8cO3aMrVu3eo6rSqPdpUsXkpKSSE5OBjSTTW3o0qULycnJHDx4EIAvv/zypDTagwcPZs2aNeTm5mK32/nuu++qbe+qq65i2bJlLFy4kOnTpwNQWFhIixYt0Ol0fPnllzidzlPKNGrUKL7++msAfvnlF/Lz8z3thISE4Ovry759+9iwYYPnGqPRiN1uP6mtkSNHsnDhQpxOJ9nZ2fz5558MGjSoBt/MmdOguY+klMuAZSeUPVVN3TENKQvtx2gftGhmXVAQOi+vBr2lQtEcsdvtPPTQQxw7dgxvb28iIiJ4//33K9Xx8fHh3XffZfz48fj5+dU6xbW3tzefffYZV199tcfRfPvtt1eq06JFC+bOncvQoUMJDg4mLi6u2vaCg4MZOnQoGRkZtG/fHoA777yTKVOm8MUXX3jkPBVPP/00M2bMoEePHgwbNswzKWb8+PG8//77dOvWjS5dulRa3e22226jd+/e9OvXr5JfYfLkyaxfv54+ffoghOCVV14hOjr6pCVMG4LmlTrbTdo992I9dIgO//dzPUmlUDQu50rq7IqUp9GWUjJr1iw6derE/fff39hinReo1Nm1xJGTo6ajKhSNzEcffeSZjllYWMi//vWvxhZJQXNLne3GkZ2NT58+jS2GQtGsuf/++9XIoAnS7EYKUkqV4kKhUCiqodkpBVdJKbKsTAWuKRQKRRU0O6XgLF+GU/kUFAqF4iSanVLwpLhQ5iOFQqE4ieanFNypbPVKKSgU9UZubi5xcXHExcURHR1Nq1atPMc2m61GbaxevZrLL7/8lHVmzZpFXFwc3bt3x8fHx3OP77//vkb3uPTSSykoKKhR3eZKs5t95MjWlIIyHykU9UdYWBgJCQkAzJ07F39/fx566KF6v8+8efMAbU2Dyy+/3HPPchwOBwZD9d3asmXLqj2n0GiGSiEbjEb0QUGNLYpC0SCs/fYAOanmem0zvI0/I6/pXKtrPvroIz788ENsNhsdO3bkyy+/xNfXl5kzZxIYGEh8fDwZGRm88sorTJ06FdAC2qZOnVqrtNCrV6/mySefJCQkhH379nHgwIEqU1WDtn5CfHw8ZrOZCRMmMGLECP7++29atWrFkiVL8PHxqdsXdB7RLM1HhrAwhK7ZPbpCcVa56qqr2Lx5M9u3b6dbt2588sknnnPp6emsW7eOn3/+mdmzj6/UW9e00Fu3buXNN9/0ZDKtKlX1iSQmJjJr1ix2795NcHAwixYtOsMnPj9ofiMFFaOgOM+p7Rt9Q7Fr1y6eeOIJCgoKMJvNXHLJJZ5zV155JTqdju7du5OZmekpr2ta6EGDBnnScEPNUlXHxsZ68iH179/fk5yvudMslYIxOrqxxVAozntmzpzJ4sWL6dOnD/Pnz2f16tWecxXTP1fMv1bXtNAVk9XVNFX1ifcqKyur0b3Od5qdDcWRna1GCgrFWaC4uJgWLVpgt9tPWlmsITlVqmrF6WlWSkE6nTjz8lQ0s0JxFnjuuecYPHgww4cPp2vXrmftvuPHj8fhcNCtWzdmz55dKVW14vQ0q9TZjuxsEkeOIuqpJwm99trTX6BQnCOci6mzFQ2HSp1dQ8oD11SMgkKhUFRN81IKKsWFQqFQnJJmphTUSEGhUChORfNSCuXmIzVSUCgUiippXkohOxtdQAA6b+/GFkWhUCiaJM1LKahoZoVCoTglzUwpqMA1haKhGTx4MHFxcbRt25aIiAhPeuvapJFITk6mZ8+ep6yzZs0ahg4dWqnM4XAQFRXFsWPHqrymYnrupUuX8tJLL1VZz9/f/5T3Ligo4N133/UcHzt2zJPU71ynWaW5cGbn4N2jR2OLoVCc12zcuBGA+fPnEx8fzzvvvNMg9xk5ciRpaWmkpKTQrl07AJYvX06PHj1o2bLlaa+fOHEiEydOrNO9y5XCnXfeCUDLli1rvKZDU6dZKQVHdraKZlac96ya/yFZKUn12mZku/aMnXlbna//6aefeP7557HZbISFhfHVV18RFRXF3LlzOXLkCElJSRw5coT77ruPe+65BwCn08mtt95abWprnU7HNddcw4IFC3j00UcBWLBgATNmzGDTpk3ce++9WCwWfHx8+Oyzz+jSpUslmSoqrcOHD3PttddiNpuZNGmSp075cX5+Pna7neeff55JkyYxe/ZsDh06RFxcHBdddBGzZs3i8ssvZ9euXVgsFu644w7i4+MxGAz897//ZezYscyfP5+lS5dSWlrKoUOHmDx5Mq+88kqdv9OGokHNR0KI8UKI/UKIg0KI2VWcv10IsVMIkSCEWCeE6N5QsrhKSnCVlqoV1xSKRmDEiBFs2LCBbdu2MX369Eqd4b59+/jtt9/YtGkTzzzzDHa7HahZausZM2awYMECAKxWK8uWLWPKlCl07dqVtWvXsm3bNp599lkee+yxU8p37733cscdd7Bz505atGjhKff29ubHH39k69atrFq1igcffBApJS+99BIdOnQgISGBV199tVJb8+bNQwjBzp07+eabb7jxxhs9CfkSEhJYuHAhO3fuZOHChaSmptbtC21AGmykIITQA/OAi4A0YLMQYqmUck+Fal9LKd93158I/BcY3xDyONz51FWMguJ850ze6BuKtLQ0pk2bRnp6OjabrVKa68suuwyTyYTJZCIyMtKTSrsmqa0HDBiA2Wxm//797N27l8GDBxMaGkpqaio33ngjiYmJCCE8iqY6/vrrL4/Suf766z0jDykljz32GH/++Sc6nY6jR49WSvVdFevWrePuu+8GoGvXrrRr186zzsO4ceMIci/w1b17d1JSUmjTps1pvr2zS0OOFAYBB6WUSVJKG7AAmFSxgpSyqMKhH9BgiZiORzMrpaBQnG3uvvtu7rrrLnbu3MkHH3xQKZV1demya5pGu3y0UG46AnjyyScZO3Ysu3bt4qeffqoydfaJVLXC21dffUV2djZbtmwhISGBqKioGrVVHXVNDX42aUil0AqoODZKc5dVQggxSwhxCHgFuKeqhoQQtwkh4oUQ8dnuzr22HI9mVuYjheJsU1hYSKtW2r//559/Xq9tz5gxg//973+sXLnS4w+oeL/58+efto3hw4d7zFAV03wXFhYSGRmJ0Whk1apVpKSkABAQEEBxcXGVbY0cOdLTxoEDBzhy5MhJ/oymTKNPSZVSzpNSdgAeBZ6ops6HUsoBUsoBEXU0/6hoZoWi8Zg7dy5XX301/fv3J7ye/we7deuGn58fF1xwgWexnUceeYQ5c+bQt2/fGr2Nv/nmm8ybN49evXpx9OhRT/l1111HfHw8vXr14osvvvCkAA8LC2P48OH07NmThx9+uFJbd955Jy6Xi169ejFt2jTmz59faYTQ1Gmw1NlCiKHAXCnlJe7jOQBSyn9XU18H5Espg07Vbl1TZxevWEHBjz/S+q231PrMivMOlTpbUZEzSZ3dkFNSNwOdhBCxwFFgOlBpEQMhRCcpZaL78DIgkQYiYNw4AsaNa6jmFQqF4rygwZSClNIhhLgL+A3QA59KKXcLIZ4F4qWUS4G7hBAXAnYgH7ixoeRRKBQKxelp0OA1KeUyYNkJZU9V2L+3Ie+vUDQnpJRVzqBRNC/O1CWgjOsKxXmAt7c3ubm5Z9whKM5tpJTk5ubifQaZoJtVmguF4nyldevWpKWlUdcp24rzB29vb1q3bl3n65VSUCjOA4xGY6UoYYWirijzkUKhUCg8KKWgUCgUCg9KKSgUCoXCQ4NFNDcUQohsIKWOl4cDOfUozrlGc37+5vzs0LyfXz27Rjsp5WnzBJ1zSuFMEELE1yTM+3ylOT9/c352aN7Pr569ds+uzEcKhUKh8KCUgkKhUCg8NDel8GFjC9DINOfnb87PDs37+dWz14Jm5VNQKBQKxalpbiMFhUKhUJwCpRQUCoVC4aHZKAUhxHghxH4hxEEhxOzGludsIoRIFkLsFEIkCCFqv2zdOYYQ4lMhRJYQYleFslAhxB9CiET3NqQxZWwoqnn2uUKIo+7fP0EIcWljythQCCHaCCFWCSH2CCF2CyHudZc3l9++uuev1e/fLHwKQgg9cAC4CEhDWxVuhpRyT6MKdpYQQiQDA6SUzSKARwgxCjADX0gpe7rLXgHypJQvuV8KQqSUjzamnA1BNc8+FzBLKV9rTNkaGiFEC6CFlHKrECIA2AJcCcykefz21T3/NdTi928uI4VBwEEpZZKU0gYsACY1skyKBkJK+SeQd0LxJOBz9/7naP8s5x3VPHuzQEqZLqXc6t4vBvYCrWg+v311z18rmotSaAWkVjhOow5f1jmMBH4XQmwRQtzW2MI0ElFSynT3fgYQ1ZjCNAJ3CSF2uM1L56X5pCJCiBigL7CRZvjbn/D8UIvfv7kohebOCCllP2ACMMttYmi2SM1mev7bTY/zHtABiAPSgf80qjQNjBDCH1gE3CelLKp4rjn89lU8f61+/+aiFI4CbSoct3aXNQuklEfd2yzgRzRzWnMj021zLbe9ZjWyPGcNKWWmlNIppXQBH3Ee//5CCCNah/iVlPIHd3Gz+e2rev7a/v7NRSlsBjoJIWKFEF7AdGBpI8t0VhBC+LmdTggh/ICLgV2nvuq8ZClwo3v/RmBJI8pyVinvEN1M5jz9/YUQAvgE2Cul/G+FU83it6/u+Wv7+zeL2UcA7mlYbwB64FMp5QuNK9HZQQjRHm10ANryq1+f788uhPgGGIOWNjgTeBpYDHwLtEVLvX6NlPK8c8hW8+xj0EwHEkgG/lXBxn7eIIQYAawFdgIud/FjaHb15vDbV/f8M6jF799slIJCoVAoTk9zMR8pFAqFogYopaBQKBQKD0opKBQKhcKDUgoKhUKh8KCUgkKhUCg8KKWgULgRQjgrZJJMqM9sukKImIqZSxWKpoqhsQVQKJoQZVLKuMYWQqFoTNRIQaE4De71KF5xr0mxSQjR0V0eI4RY6U40tkII0dZdHiWE+FEIsd39GeZuSi+E+Mid6/53IYSPu/497hz4O4QQCxrpMRUKQCkFhaIiPieYj6ZVOFcopewFvIMWGQ/wNvC5lLI38BXwlrv8LWCNlLIP0A/Y7S7vBMyTUvYACoAp7vLZQF93O7c3zKMpFDVDRTQrFG6EEGYppX8V5cnABVLKJHfCsQwpZZgQIgdtURO7uzxdShkuhMgGWksprRXaiAH+kFJ2ch8/ChillM8LIX5FWxhnMbBYSmlu4EdVKKpFjRQUipohq9mvDdYK+06O+/QuA+ahjSo2CyGUr0/RaCiloFDUjGkVtuvd+3+jZdwFuA4tGRnACuAO0JaCFUIEVdeoEEIHtJFSrgIeBYKAk0YrCsXZQr2RKBTH8RFCJFQ4/lVKWT4tNUQIsQPtbX+Gu+xu4DMhxMNANnCTu/xe4EMhxM1oI4I70BY3qQo98D+34hDAW1LKgnp6HoWi1iifgkJxGtw+hQFSypzGlkWhaGiU+UihUCgUHtRIQaFQKBQe1EhBoVAoFB6UUlAoFAqFB6UUFAqFQuFBKQWFQqFQeFBKQaFQKBQe/h8ZTYeGwxRMdwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 404.71777868270874 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "plt.plot(history.history['accuracy'])\n",
+    "plt.plot(history.history['val_accuracy'])\n",
+    "plt.plot(history_sig.history['accuracy'])\n",
+    "plt.plot(history_sig.history['val_accuracy'])\n",
+    "plt.plot(history_tan.history['accuracy'])\n",
+    "plt.plot(history_tan.history['val_accuracy'])\n",
+    "plt.title(\"Model Accuracy\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Accuracy')\n",
+    "plt.legend(['Relu Train', ' Relu Validation', 'Sigmoid Train', ' Sigmoid Validation', 'Tanh Train', ' Tanh Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "attempted-apollo",
+   "metadata": {
+    "papermill": {
+     "duration": 0.108235,
+     "end_time": "2021-04-25T14:34:31.239863",
+     "exception": false,
+     "start_time": "2021-04-25T14:34:31.131628",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6.5 Model 2 ( Resnet )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "german-context",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:34:31.474424Z",
+     "iopub.status.busy": "2021-04-25T14:34:31.473519Z",
+     "iopub.status.idle": "2021-04-25T14:34:31.848959Z",
+     "shell.execute_reply": "2021-04-25T14:34:31.848244Z"
+    },
+    "papermill": {
+     "duration": 0.499209,
+     "end_time": "2021-04-25T14:34:31.849140",
+     "exception": false,
+     "start_time": "2021-04-25T14:34:31.349931",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: \"model\"\n",
+      "__________________________________________________________________________________________________\n",
+      "Layer (type)                    Output Shape         Param #     Connected to                     \n",
+      "==================================================================================================\n",
+      "input_1 (InputLayer)            [(None, 28, 28, 1)]  0                                            \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_12 (Conv2D)              (None, 14, 14, 64)   3200        input_1[0][0]                    \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_15 (BatchNo (None, 14, 14, 64)   256         conv2d_12[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation (Activation)         (None, 14, 14, 64)   0           batch_normalization_15[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_13 (Conv2D)              (None, 14, 14, 64)   36928       activation[0][0]                 \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_16 (BatchNo (None, 14, 14, 64)   256         conv2d_13[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_1 (Activation)       (None, 14, 14, 64)   0           batch_normalization_16[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_14 (Conv2D)              (None, 14, 14, 64)   36928       activation_1[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_17 (BatchNo (None, 14, 14, 64)   256         conv2d_14[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add (Add)                       (None, 14, 14, 64)   0           activation[0][0]                 \n",
+      "                                                                 batch_normalization_17[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_2 (Activation)       (None, 14, 14, 64)   0           add[0][0]                        \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_15 (Conv2D)              (None, 14, 14, 64)   36928       activation_2[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_18 (BatchNo (None, 14, 14, 64)   256         conv2d_15[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_3 (Activation)       (None, 14, 14, 64)   0           batch_normalization_18[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_16 (Conv2D)              (None, 14, 14, 64)   36928       activation_3[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_19 (BatchNo (None, 14, 14, 64)   256         conv2d_16[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_1 (Add)                     (None, 14, 14, 64)   0           activation_2[0][0]               \n",
+      "                                                                 batch_normalization_19[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_4 (Activation)       (None, 14, 14, 64)   0           add_1[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_17 (Conv2D)              (None, 7, 7, 128)    73856       activation_4[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_20 (BatchNo (None, 7, 7, 128)    512         conv2d_17[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_5 (Activation)       (None, 7, 7, 128)    0           batch_normalization_20[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_18 (Conv2D)              (None, 7, 7, 128)    147584      activation_5[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_19 (Conv2D)              (None, 7, 7, 128)    8320        activation_4[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_21 (BatchNo (None, 7, 7, 128)    512         conv2d_18[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_2 (Add)                     (None, 7, 7, 128)    0           conv2d_19[0][0]                  \n",
+      "                                                                 batch_normalization_21[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_6 (Activation)       (None, 7, 7, 128)    0           add_2[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_20 (Conv2D)              (None, 7, 7, 128)    147584      activation_6[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_22 (BatchNo (None, 7, 7, 128)    512         conv2d_20[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_7 (Activation)       (None, 7, 7, 128)    0           batch_normalization_22[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_21 (Conv2D)              (None, 7, 7, 128)    147584      activation_7[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_23 (BatchNo (None, 7, 7, 128)    512         conv2d_21[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_3 (Add)                     (None, 7, 7, 128)    0           activation_6[0][0]               \n",
+      "                                                                 batch_normalization_23[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_8 (Activation)       (None, 7, 7, 128)    0           add_3[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_22 (Conv2D)              (None, 4, 4, 256)    295168      activation_8[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_24 (BatchNo (None, 4, 4, 256)    1024        conv2d_22[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_9 (Activation)       (None, 4, 4, 256)    0           batch_normalization_24[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_23 (Conv2D)              (None, 4, 4, 256)    590080      activation_9[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_24 (Conv2D)              (None, 4, 4, 256)    33024       activation_8[0][0]               \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_25 (BatchNo (None, 4, 4, 256)    1024        conv2d_23[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_4 (Add)                     (None, 4, 4, 256)    0           conv2d_24[0][0]                  \n",
+      "                                                                 batch_normalization_25[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_10 (Activation)      (None, 4, 4, 256)    0           add_4[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_25 (Conv2D)              (None, 4, 4, 256)    590080      activation_10[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_26 (BatchNo (None, 4, 4, 256)    1024        conv2d_25[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_11 (Activation)      (None, 4, 4, 256)    0           batch_normalization_26[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_26 (Conv2D)              (None, 4, 4, 256)    590080      activation_11[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_27 (BatchNo (None, 4, 4, 256)    1024        conv2d_26[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_5 (Add)                     (None, 4, 4, 256)    0           activation_10[0][0]              \n",
+      "                                                                 batch_normalization_27[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_12 (Activation)      (None, 4, 4, 256)    0           add_5[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_27 (Conv2D)              (None, 2, 2, 512)    1180160     activation_12[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_28 (BatchNo (None, 2, 2, 512)    2048        conv2d_27[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_13 (Activation)      (None, 2, 2, 512)    0           batch_normalization_28[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_28 (Conv2D)              (None, 2, 2, 512)    2359808     activation_13[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_29 (Conv2D)              (None, 2, 2, 512)    131584      activation_12[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_29 (BatchNo (None, 2, 2, 512)    2048        conv2d_28[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_6 (Add)                     (None, 2, 2, 512)    0           conv2d_29[0][0]                  \n",
+      "                                                                 batch_normalization_29[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_14 (Activation)      (None, 2, 2, 512)    0           add_6[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_30 (Conv2D)              (None, 2, 2, 512)    2359808     activation_14[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_30 (BatchNo (None, 2, 2, 512)    2048        conv2d_30[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_15 (Activation)      (None, 2, 2, 512)    0           batch_normalization_30[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "conv2d_31 (Conv2D)              (None, 2, 2, 512)    2359808     activation_15[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "batch_normalization_31 (BatchNo (None, 2, 2, 512)    2048        conv2d_31[0][0]                  \n",
+      "__________________________________________________________________________________________________\n",
+      "add_7 (Add)                     (None, 2, 2, 512)    0           activation_14[0][0]              \n",
+      "                                                                 batch_normalization_31[0][0]     \n",
+      "__________________________________________________________________________________________________\n",
+      "activation_16 (Activation)      (None, 2, 2, 512)    0           add_7[0][0]                      \n",
+      "__________________________________________________________________________________________________\n",
+      "average_pooling2d (AveragePooli (None, 1, 1, 512)    0           activation_16[0][0]              \n",
+      "__________________________________________________________________________________________________\n",
+      "flatten_3 (Flatten)             (None, 512)          0           average_pooling2d[0][0]          \n",
+      "__________________________________________________________________________________________________\n",
+      "dense_9 (Dense)                 (None, 5)            2565        flatten_3[0][0]                  \n",
+      "==================================================================================================\n",
+      "Total params: 11,183,621\n",
+      "Trainable params: 11,175,813\n",
+      "Non-trainable params: 7,808\n",
+      "__________________________________________________________________________________________________\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_size = (28, 28,1)\n",
+    "num_filters = 64\n",
+    "use_max_pool = False\n",
+    "num_blocks = 4\n",
+    "num_sub_blocks = 2\n",
+    "num_classes = 5\n",
+    "inputs = Input(shape=input_size)\n",
+    "con_x = Conv2D(num_filters, padding='same', \n",
+    "           kernel_initializer='he_normal', \n",
+    "           kernel_size=7, strides=2,\n",
+    "           kernel_regularizer=l2(1e-4))(inputs)\n",
+    "con_x = BatchNormalization()(con_x)\n",
+    "con_x = Activation('relu')(con_x)\n",
+    "\n",
+    "#Check by applying max pooling later (setting it false as size of image is small i.e. 28x28)\n",
+    "if use_max_pool:\n",
+    "    con_x = MaxPooling2D(pool_size=3,padding='same', strides=2)(con_x)\n",
+    "    num_blocks =3\n",
+    "#Creating Conv base stack \n",
+    "\n",
+    "# Instantiate convolutional base (stack of blocks).\n",
+    "for i in range(num_blocks):\n",
+    "    for j in range(num_sub_blocks):\n",
+    "        strides = 1\n",
+    "        is_first_layer_but_not_first_block = j == 0 and i > 0\n",
+    "        if is_first_layer_but_not_first_block:\n",
+    "            strides = 2\n",
+    "        #Creating residual mapping using y\n",
+    "        con_y = Conv2D(num_filters,\n",
+    "                   kernel_size=3,\n",
+    "                   padding='same',\n",
+    "                   strides=strides,\n",
+    "                   kernel_initializer='he_normal',\n",
+    "                   kernel_regularizer=l2(1e-4))(con_x)\n",
+    "        con_y = BatchNormalization()(con_y)\n",
+    "        con_y = Activation('relu')(con_y)\n",
+    "        con_y = Conv2D(num_filters,\n",
+    "                   kernel_size=3,\n",
+    "                   padding='same',\n",
+    "                   kernel_initializer='he_normal',\n",
+    "                   kernel_regularizer=l2(1e-4))(con_y)\n",
+    "        con_y = BatchNormalization()(con_y)\n",
+    "        if is_first_layer_but_not_first_block:\n",
+    "            con_x = Conv2D(num_filters,\n",
+    "                       kernel_size=1,\n",
+    "                       padding='same',\n",
+    "                       strides=2,\n",
+    "                       kernel_initializer='he_normal',\n",
+    "                       kernel_regularizer=l2(1e-4))(con_x)\n",
+    "        #Adding back residual mapping\n",
+    "        con_x = keras.layers.add([con_x, con_y])\n",
+    "        con_x = Activation('relu')(con_x)\n",
+    "\n",
+    "    num_filters = 2 * num_filters\n",
+    "\n",
+    "# Add classifier on top.\n",
+    "con_x = AveragePooling2D()(con_x)\n",
+    "con_y = Flatten()(con_x)\n",
+    "outputs = Dense(num_classes,\n",
+    "                activation='softmax',\n",
+    "                kernel_initializer='he_normal')(con_y)\n",
+    "\n",
+    "# Instantiate and compile model.\n",
+    "resmodel = Model(inputs=inputs, outputs=outputs)\n",
+    "resmodel.compile(loss='categorical_crossentropy',\n",
+    "              optimizer='adam',\n",
+    "              metrics=['accuracy'])\n",
+    "resmodel.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "signal-fever",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:34:32.101821Z",
+     "iopub.status.busy": "2021-04-25T14:34:32.100694Z",
+     "iopub.status.idle": "2021-04-25T14:34:32.108654Z",
+     "shell.execute_reply": "2021-04-25T14:34:32.107751Z"
+    },
+    "papermill": {
+     "duration": 0.141571,
+     "end_time": "2021-04-25T14:34:32.108854",
+     "exception": false,
+     "start_time": "2021-04-25T14:34:31.967283",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/kaggle/working/saved_model/fmnist_resnet_model.h5\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "save_dir = os.path.join(os.getcwd(), 'saved_model')\n",
+    "model_name = 'fmnist_resnet_model.h5'\n",
+    "if not os.path.isdir(save_dir):\n",
+    "    os.makedirs(save_dir)\n",
+    "filepath = os.path.join(save_dir,model_name)\n",
+    "print(filepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "liberal-antigua",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:34:32.353371Z",
+     "iopub.status.busy": "2021-04-25T14:34:32.351415Z",
+     "iopub.status.idle": "2021-04-25T14:34:32.353914Z",
+     "shell.execute_reply": "2021-04-25T14:34:32.354333Z"
+    },
+    "papermill": {
+     "duration": 0.121115,
+     "end_time": "2021-04-25T14:34:32.354461",
+     "exception": false,
+     "start_time": "2021-04-25T14:34:32.233346",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from keras.callbacks import ModelCheckpoint, ReduceLROnPlateau\n",
+    "checkpoint = ModelCheckpoint(filepath=filepath,\n",
+    "                             verbose=1,\n",
+    "                             save_best_only=True)\n",
+    "lr_reducer = ReduceLROnPlateau(factor=np.sqrt(0.1),\n",
+    "                               cooldown=0,\n",
+    "                               patience=5,\n",
+    "                               min_lr=0.5e-6)\n",
+    "callbacks = [checkpoint, reduce_lr]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "confident-chancellor",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:34:32.592421Z",
+     "iopub.status.busy": "2021-04-25T14:34:32.590988Z",
+     "iopub.status.idle": "2021-04-25T14:39:27.573179Z",
+     "shell.execute_reply": "2021-04-25T14:39:27.573756Z"
+    },
+    "papermill": {
+     "duration": 295.1048,
+     "end_time": "2021-04-25T14:39:27.573981",
+     "exception": false,
+     "start_time": "2021-04-25T14:34:32.469181",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/25\n",
+      "375/375 [==============================] - 15s 32ms/step - loss: 1.6851 - accuracy: 0.7568 - val_loss: 1.1325 - val_accuracy: 0.8332\n",
+      "\n",
+      "Epoch 00001: val_loss improved from inf to 1.13249, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 2/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.9646 - accuracy: 0.8758 - val_loss: 0.8490 - val_accuracy: 0.8770\n",
+      "\n",
+      "Epoch 00002: val_loss improved from 1.13249 to 0.84898, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 3/25\n",
+      "375/375 [==============================] - 11s 31ms/step - loss: 0.7581 - accuracy: 0.8982 - val_loss: 0.8651 - val_accuracy: 0.8385\n",
+      "\n",
+      "Epoch 00003: val_loss did not improve from 0.84898\n",
+      "Epoch 4/25\n",
+      "375/375 [==============================] - 12s 31ms/step - loss: 0.6444 - accuracy: 0.9091 - val_loss: 0.7495 - val_accuracy: 0.8553\n",
+      "\n",
+      "Epoch 00004: val_loss improved from 0.84898 to 0.74947, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 5/25\n",
+      "375/375 [==============================] - 11s 31ms/step - loss: 0.5589 - accuracy: 0.9180 - val_loss: 0.6890 - val_accuracy: 0.8667\n",
+      "\n",
+      "Epoch 00005: val_loss improved from 0.74947 to 0.68900, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 6/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.4809 - accuracy: 0.9343 - val_loss: 0.5812 - val_accuracy: 0.8937\n",
+      "\n",
+      "Epoch 00006: val_loss improved from 0.68900 to 0.58117, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 7/25\n",
+      "375/375 [==============================] - 11s 31ms/step - loss: 0.4292 - accuracy: 0.9447 - val_loss: 0.5465 - val_accuracy: 0.9047\n",
+      "\n",
+      "Epoch 00007: val_loss improved from 0.58117 to 0.54649, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 8/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.3873 - accuracy: 0.9546 - val_loss: 0.5461 - val_accuracy: 0.8992\n",
+      "\n",
+      "Epoch 00008: val_loss improved from 0.54649 to 0.54610, saving model to /kaggle/working/saved_model/fmnist_resnet_model.h5\n",
+      "Epoch 9/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.3457 - accuracy: 0.9640 - val_loss: 0.6492 - val_accuracy: 0.8790\n",
+      "\n",
+      "Epoch 00009: val_loss did not improve from 0.54610\n",
+      "Epoch 10/25\n",
+      "375/375 [==============================] - 12s 31ms/step - loss: 0.3366 - accuracy: 0.9621 - val_loss: 0.5793 - val_accuracy: 0.8928\n",
+      "\n",
+      "Epoch 00010: val_loss did not improve from 0.54610\n",
+      "Epoch 11/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.3069 - accuracy: 0.9688 - val_loss: 0.6016 - val_accuracy: 0.8933\n",
+      "\n",
+      "Epoch 00011: val_loss did not improve from 0.54610\n",
+      "Epoch 12/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.2733 - accuracy: 0.9791 - val_loss: 0.6696 - val_accuracy: 0.8785\n",
+      "\n",
+      "Epoch 00012: val_loss did not improve from 0.54610\n",
+      "Epoch 13/25\n",
+      "375/375 [==============================] - 11s 31ms/step - loss: 0.2599 - accuracy: 0.9798 - val_loss: 0.6064 - val_accuracy: 0.8887\n",
+      "\n",
+      "Epoch 00013: val_loss did not improve from 0.54610\n",
+      "Epoch 14/25\n",
+      "375/375 [==============================] - 11s 31ms/step - loss: 0.2396 - accuracy: 0.9857 - val_loss: 0.6087 - val_accuracy: 0.9007\n",
+      "\n",
+      "Epoch 00014: val_loss did not improve from 0.54610\n",
+      "Epoch 15/25\n",
+      "375/375 [==============================] - 12s 31ms/step - loss: 0.2269 - accuracy: 0.9869 - val_loss: 0.6088 - val_accuracy: 0.8995\n",
+      "\n",
+      "Epoch 00015: val_loss did not improve from 0.54610\n",
+      "Epoch 16/25\n",
+      "375/375 [==============================] - 11s 31ms/step - loss: 0.2136 - accuracy: 0.9911 - val_loss: 0.6401 - val_accuracy: 0.8975\n",
+      "\n",
+      "Epoch 00016: val_loss did not improve from 0.54610\n",
+      "Epoch 17/25\n",
+      "375/375 [==============================] - 11s 30ms/step - loss: 0.2046 - accuracy: 0.9918 - val_loss: 0.7109 - val_accuracy: 0.8920\n",
+      "\n",
+      "Epoch 00017: val_loss did not improve from 0.54610\n",
+      "Epoch 18/25\n",
+      "375/375 [==============================] - 12s 31ms/step - loss: 0.1994 - accuracy: 0.9905 - val_loss: 0.6740 - val_accuracy: 0.8963\n",
+      "\n",
+      "Epoch 00018: val_loss did not improve from 0.54610\n",
+      "Epoch 19/25\n",
+      "375/375 [==============================] - 12s 31ms/step - loss: 0.1852 - accuracy: 0.9954 - val_loss: 0.6066 - val_accuracy: 0.9022\n",
+      "\n",
+      "Epoch 00019: val_loss did not improve from 0.54610\n",
+      "Epoch 20/25\n",
+      "375/375 [==============================] - 11s 31ms/step - loss: 0.1806 - accuracy: 0.9949 - val_loss: 0.6464 - val_accuracy: 0.8997\n",
+      "\n",
+      "Epoch 00020: val_loss did not improve from 0.54610\n",
+      "Epoch 21/25\n",
+      "375/375 [==============================] - 12s 31ms/step - loss: 0.1717 - accuracy: 0.9966 - val_loss: 0.6862 - val_accuracy: 0.9000\n",
+      "\n",
+      "Epoch 00021: val_loss did not improve from 0.54610\n",
+      "Epoch 22/25\n",
+      "375/375 [==============================] - 12s 31ms/step - loss: 0.1670 - accuracy: 0.9972 - val_loss: 0.6623 - val_accuracy: 0.9013\n",
+      "\n",
+      "Epoch 00022: val_loss did not improve from 0.54610\n",
+      "Epoch 23/25\n",
+      "375/375 [==============================] - 12s 31ms/step - loss: 0.1619 - accuracy: 0.9975 - val_loss: 0.6955 - val_accuracy: 0.9038\n",
+      "\n",
+      "Epoch 00023: val_loss did not improve from 0.54610\n",
+      "Epoch 24/25\n",
+      "375/375 [==============================] - 12s 31ms/step - loss: 0.1569 - accuracy: 0.9983 - val_loss: 0.7591 - val_accuracy: 0.8922\n",
+      "\n",
+      "Epoch 00024: val_loss did not improve from 0.54610\n",
+      "Epoch 25/25\n",
+      "375/375 [==============================] - 12s 31ms/step - loss: 0.1530 - accuracy: 0.9987 - val_loss: 0.6858 - val_accuracy: 0.8977\n",
+      "\n",
+      "Epoch 00025: val_loss did not improve from 0.54610\n",
+      "--- 294.9793691635132 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "history2 =resmodel.fit(x_train, y_train, batch_size=batch_size,\n",
+    "              epochs=epochs,\n",
+    "              validation_data=(x_val, y_val),\n",
+    "              shuffle=True,\n",
+    "              callbacks=callbacks)\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "theoretical-regard",
+   "metadata": {
+    "papermill": {
+     "duration": 1.513189,
+     "end_time": "2021-04-25T14:39:30.543615",
+     "exception": false,
+     "start_time": "2021-04-25T14:39:29.030426",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Model 2 Evaluation "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "thirty-teddy",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:39:33.702591Z",
+     "iopub.status.busy": "2021-04-25T14:39:33.701399Z",
+     "iopub.status.idle": "2021-04-25T14:39:35.420777Z",
+     "shell.execute_reply": "2021-04-25T14:39:35.422505Z"
+    },
+    "papermill": {
+     "duration": 3.380054,
+     "end_time": "2021-04-25T14:39:35.422703",
+     "exception": false,
+     "start_time": "2021-04-25T14:39:32.042649",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "188/188 [==============================] - 2s 9ms/step - loss: 0.6858 - accuracy: 0.8977\n",
+      "Loss: 0.6858\n",
+      "Accuracy: 0.8977\n",
+      "--- 1.7169296741485596 seconds ---\n",
+      "---Total time in Model 2 : 1.7170186042785645 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "score = resmodel.evaluate(x_val, y_val)\n",
+    "\n",
+    "print('Loss: {:.4f}'.format(score[0]))\n",
+    "print('Accuracy: {:.4f}'.format(score[1]))\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))\n",
+    "print(\"---Total time in Model 2 : %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "written-egyptian",
+   "metadata": {
+    "papermill": {
+     "duration": 1.383407,
+     "end_time": "2021-04-25T14:39:38.248490",
+     "exception": false,
+     "start_time": "2021-04-25T14:39:36.865083",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Model 2 loss vs no. of epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "similar-marshall",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:39:41.085328Z",
+     "iopub.status.busy": "2021-04-25T14:39:41.078503Z",
+     "iopub.status.idle": "2021-04-25T14:39:41.202020Z",
+     "shell.execute_reply": "2021-04-25T14:39:41.202563Z"
+    },
+    "papermill": {
+     "duration": 1.537278,
+     "end_time": "2021-04-25T14:39:41.202770",
+     "exception": false,
+     "start_time": "2021-04-25T14:39:39.665492",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAEWCAYAAABi5jCmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAA7yElEQVR4nO3deXxU5fX48c/JvgeyACEJhEAwIDvIElS2UnFDRVApIihKtVVb+611+Vlr7WZrtWqlVdxQRFBULFZFqgIuLAISlH1NIKxJICH7+vz+eCYxiQlkm0ySOe/Xi9fM3Llz51wG5sx9lvOIMQallFKqgoerA1BKKdW6aGJQSilVjSYGpZRS1WhiUEopVY0mBqWUUtVoYlBKKVWNJgalzkFE4kTEiIhXPfadLSJftkRcSjmLJgbVrohIiogUi0hEje1bHF/ucS4KrUEJRilX0sSg2qODwPSKByLSHwhwXThKtS2aGFR7tBC4qcrjWcBrVXcQkVAReU1E0kUkVUQeEhEPx3OeIvJ3EckQkQPA5bW89iUROSYiR0TkjyLi2ZSARaSriCwXkVMisk9Ebqvy3HAR2SQiZ0TkhIg86djuJyKvi0imiGSJyEYR6dyUOJQCTQyqfVoPhIhIH8cX9g3A6zX2+ScQCsQDY7CJ5GbHc7cBVwCDgWHA1BqvXQCUAr0c+/wYuLWJMS8B0oCujvf7s4iMdzz3NPC0MSYE6Am85dg+y3EOsUA4cDtQ0MQ4lNLEoNqtiquGicBO4EjFE1WSxQPGmBxjTArwBDDTsct1wFPGmMPGmFPAX6q8tjNwGfBLY0yeMeYk8A/H8RpFRGKB0cB9xphCY0wy8CLfX/WUAL1EJMIYk2uMWV9lezjQyxhTZozZbIw509g4lKqgiUG1VwuBnwCzqdGMBEQA3kBqlW2pQLTjflfgcI3nKnR3vPaYo/kmC3ge6NSEWLsCp4wxOXXEMwfoDexyNBdd4di+EPgYWCIiR0XkbyLi3YQ4lAI0Mah2yhiTiu2Evgx4t8bTGdhf292rbOvG91cVx7DNM1Wfq3AYKAIijDEdHH9CjDHnNyHco0CYiATXFo8xZq8xZjo2+fwVeFtEAo0xJcaY3xtj+gJJ2Oavm1CqiTQxqPZsDjDeGJNXdaMxpgzbTv8nEQkWke7Ar/i+H+It4G4RiRGRjsD9VV57DFgJPCEiISLiISI9RWRMA+LydXQc+4mIHzYBrAX+4tg2wBH76wAicqOIRBpjyoEsxzHKRWSciPR3NI2dwSa78gbEoVStNDGodssYs98Ys6mOp+8C8oADwJfAG8DLjudewDbRbAW+4YdXHDcBPsAO4DTwNhDVgNBysZ3EFX/GY4fXxmGvHpYBvzPGfOLYfxKwXURysR3RNxhjCoAujvc+g+1HWYNtXlKqSUQX6lFKKVWVXjEopZSqRhODUkqpajQxKKWUqkYTg1JKqWraXJXHiIgIExcX5+owlFKqTdm8eXOGMSayPvu2ucQQFxfHpk11jUBUSilVGxFJPfdeljYlKaWUqkYTg1JKqWo0MSillKqmzfUxKKUap6SkhLS0NAoLC10dinIiPz8/YmJi8PZufKFdTQxKuYm0tDSCg4OJi4tDRFwdjnICYwyZmZmkpaXRo0ePRh9Hm5KUchOFhYWEh4drUmjHRITw8PAmXxVqYlDKjWhSaP+a4zN2m8Sw+3gOf/lwJ7lFpa4ORSmlWjW3SQyHT+Xz/OcH2H1cl8RVylU8PT0ZNGgQ/fr148orryQrK6tF3vepp54iPz//B9uvueYaBg0aRK9evQgNDWXQoEEMGjSItWvX1uu4SUlJzR1qq+A2iaFP1xAAdh7LOceeSiln8ff3Jzk5mW3bthEWFsa8efNa5H3rSgzLli0jOTmZF198kYsuuojk5GSSk5Mrv/BLS8/ewlDfBNLWuE1i6BrqR4ifFzuP6RWDUq3BqFGjOHLELrO9f/9+Jk2axNChQ7nooovYtWsXAEuXLqVfv34MHDiQiy++GIAFCxYwZcoUJk2aREJCAr/5zW8qj7ly5UpGjRrFkCFDmDZtGrm5uTzzzDMcPXqUcePGMW7cuHPGtWDBAiZPnsz48eOZMGECubm5TJgwgSFDhtC/f3/+85//VO4bFBQEwOrVqxk7dixTp04lMTGRGTNm0JYXQXOb4aoiQmJUiCYGpYDfv7+dHUeb9/9C364h/O7K8+u1b1lZGZ9++ilz5swBYO7cuTz33HMkJCSwYcMGfvazn/HZZ5/x6KOP8vHHHxMdHV2t2Sk5OZktW7bg6+vLeeedx1133YW/vz9//OMf+eSTTwgMDOSvf/0rTz75JA8//DBPPvkkq1atIiIiol7xffPNN3z77beEhYVRWlrKsmXLCAkJISMjg5EjRzJ58uQfdPJu2bKF7du307VrV0aPHs1XX33FhRdeWL+/vFbGbRIDQN+oEJZuOkx5ucHDQ0dnKNXSCgoKGDRoEEeOHKFPnz5MnDiR3Nxc1q5dy7Rp0yr3KyoqAmD06NHMnj2b6667jilTplQ+P2HCBEJDQwHo27cvqampZGVlsWPHDkaPHg1AcXExo0aNalScEydOJCwsDLBzAx588EE+//xzPDw8OHLkCCdOnKBLly7VXjN8+HBiYmIAGDRoECkpKZoY2oI+UcHkFZdx+HQ+3cMDXR2OUi5T31/2za2ijyE/P59LLrmEefPmMXv2bDp06EBycvIP9n/uuefYsGEDH3zwAUOHDmXz5s0A+Pr6Vu7j6elJaWkpxhgmTpzI4sWLmxxnYOD33w+LFi0iPT2dzZs34+3tTVxcXK3zBGqLqa1ymz4GgD5RFR3Q2pyklCsFBATwzDPP8MQTTxAQEECPHj1YunQpYH+hb926FbB9DyNGjODRRx8lMjKSw4cP13nMkSNH8tVXX7Fv3z4A8vLy2LNnDwDBwcHk5DRu4El2djadOnXC29ubVatWkZpa7+rVbZZbJYbenYPxENihI5OUcrnBgwczYMAAFi9ezKJFi3jppZcYOHAg559/fmUH77333kv//v3p168fSUlJDBw4sM7jRUZGsmDBAqZPn86AAQMYNWpUZSf23LlzmTRpUr06n2uaMWMGmzZton///rz22mskJiY27oTbEGlrPefDhg0zTVmoZ8ITq+kZGcT8m4Y1Y1RKtX47d+6kT58+rg5DtYDaPmsR2WyMqdcXn1tdMYBtTtqpk9yUUqpObpkYDp8qIKewxNWhKKVUq+SGiSEYgF3HtZ9BKaVq44aJwY5M2qUjk5RSqlZulxi6hPjRIcBbRyYppVQd3C4xiAiJXYJ1LoNSStXB7RID2Oak3cdzKC9vW0N1lWrrWlvZ7d///vc88MAD1bYlJyefdVjvI488wt///ncAHn74YT755JMf7LN69WquuOKKs8aUnJzMhx9+WPl4+fLlPPbYY2d9TUtx28RQUFJG6qkf/kNRSjlPayu7PX36dN58881q25YsWcL06dPrddxHH32UH/3oR42KqWZimDx5Mvfff3+jjtXc3DMxdNHSGEq5Wmsou927d286duzIhg0bKre99dZbTJ8+nRdeeIELLriAgQMHcu2119aaWGbPns3bb78NwIoVK0hMTGTIkCG8++67lft8/fXXjBo1isGDB5OUlMTu3bspLi7m4Ycf5s0332TQoEG8+eabLFiwgDvvvBOAlJQUxo8fz4ABA5gwYQKHDh2qfL+7776bpKQk4uPjK9+7ublVEb0KCZ2D8PQQdh47w2X9o1wdjlIt76P74fh3zXvMLv3h0vo1hbSmstvTp09nyZIljBgxgvXr1xMWFkZCQgJhYWHcdtttADz00EO89NJL3HXXXbWeT2FhIbfddhufffYZvXr14vrrr698LjExkS+++AIvLy8++eQTHnzwQd555x0effRRNm3axLPPPgvYhFfhrrvuYtasWcyaNYuXX36Zu+++m/feew+AY8eO8eWXX7Jr1y4mT57M1KlT6/V33hBumRj8vD2JjwjU1dyUamGtsez29ddfT1JSEk888US1ZqRt27bx0EMPkZWVRW5uLpdcckmdx9i1axc9evQgISEBgBtvvJH58+cDtgjfrFmz2Lt3LyJCScm5J9euW7eu8qpj5syZ1a6Krr76ajw8POjbty8nTpw457Eaw2mJQUReBq4AThpj+tXy/AzgPkCAHOAOY8xWZ8VTU2JUCN+knm6pt1OqdannL/vm1hrLbsfGxtKjRw/WrFnDO++8w7p16wDbbPPee+8xcOBAFixYwOrVqxt1zr/97W8ZN24cy5YtIyUlhbFjxzbqOBWqnruzat05s49hATDpLM8fBMYYY/oDfwDmOzGWH+gTFcyRrAKyC7Q0hlItrbWV3Z4+fTr33HMP8fHxlYvt5OTkEBUVRUlJCYsWLTrr+SQmJpKSksL+/fsBqiWn7OxsoqOjgerNRWeLKSkpiSVLlgB2PYiLLrrorO/f3JyWGIwxnwOnzvL8WmNMxU/29UCMs2KpTcUM6N1aGkMpl2hNZbenTZvG9u3bq41G+sMf/sCIESMYPXr0OUtt+/n5MX/+fC6//HKGDBlCp06dKp/7zW9+wwMPPMDgwYOrLd4zbtw4duzYUdn5XNU///lPXnnlFQYMGMDChQt5+umnz/r+zc2pZbdFJA74b21NSTX2+zWQaIy5tY7n5wJzAbp16za0ORbKOHGmkBF//pTfTz6fWUlxTT6eUq2dlt12H22+7LaIjAPmYPsbamWMmW+MGWaMGRYZGdks79sp2JeOAd46ZFUppWpw6agkERkAvAhcaozJbOH3tmszaGJQSqlqXHbFICLdgHeBmcaYPa6IoU9UCLtP5FCmpTGUm2hrKzaqhmuOz9iZw1UXA2OBCBFJA34HeAMYY54DHgbCgX+JCEBpfdu/mktil2AKS8pJycyjZ2RQS761Ui3Oz8+PzMxMwsPDcfyfU+2MMYbMzEz8/PyadBynJQZjzFmLjTg6mmvtbG4pFSOTdh47o4lBtXsxMTGkpaWRnp7u6lCUE/n5+VUOuW0st5z5XCGhcxBejtIYVwzo6upwlHIqb29vevTo4eowVBvg8lFJruTr5UnPyCB2aWkMpZSq5NaJASAxShftUUqpqtw+MfSJCuFodiFZ+cWuDkUppVoF90kM6bvhfw9DSWG1zRUd0Lu0NIZSSgHulBhOHYSvnobDG6pt7tMlGNBFe5RSqoL7JIa40eDhBQdWV9scGexLeKCPJgallHJwn8TgGwwxF8CBVdU2f18aQ5uSlFIK3CkxAMSPhaPJkF+9GnifqGD2nMihtKzcJWEppVRr4maJYRxgIOWLapsTu4RQVGpLYyillLtzr8QQPQR8gmF/9eakipFJO7Q5SSml3CwxeHpD3IU/6IDu1cmWxtilHdBKKeVmiQGg5zg4fRBOp1Ru8vHyoFenIB2ZpJRSuGNiiB9rb2tcNejIJKWUstwvMUT0huCutfQzBHP8TCGn87Q0hlLKvblfYhCxVw0H10D598NTK9dmOK7NSUop9+Z+iQFsYig4Dce/rdyU2KVi0R5tTlJKuTf3TQxQbRZ0ZLAvEUG+2gGtlHJ77pkYgjtDp761dEDr2gxKKeWeiQHsLOjUdVBSULmpT1QIe0/kamkMpZRbc+PEMBbKiuDQ+spNfaKCKS4r50CGlsZQSrkv900M3ZPAw7tac1LlyCRtTlJKuTH3TQy+QRA7vFoHdHxEEN6eoiOTlFJuzX0TA9jmpGPfQl4mUFEaQzuglVLuzWmJQUReFpGTIrKtjudFRJ4RkX0i8q2IDHFWLHWqKMN9cE3lJh2ZpJRyd868YlgATDrL85cCCY4/c4F/OzGW2nUdDL6h1foZ+kaFcDKniMzcohYPRymlWgOnJQZjzOfAqbPschXwmrHWAx1EJMpZ8dTK0wt6XFQtMVTMgN51XPsZlFLuyZV9DNHA4SqP0xzbfkBE5orIJhHZlJ6e3rxRxI+FrFQ4dQCwTUmgI5OUUu6rTXQ+G2PmG2OGGWOGRUZGNu/Ba5ThDg/ypVOwLzs0MSil3JQrE8MRILbK4xjHtpYV3gtCYqqV4U6MCmGXDllVSrkpVyaG5cBNjtFJI4FsY8yxFo+isgz351BeBtjmpH0ncynR0hhKKTfkzOGqi4F1wHkikiYic0TkdhG53bHLh8ABYB/wAvAzZ8VyTj3HQWEWHNsK2JFJxWXl7E/PdVlISinlKl7OOrAxZvo5njfAz531/g3S42J7e2AVRA+pVhqjYpSSUkq5izbR+ex0QZ2gc7/KDugeEYH4eHpoP4NSyi1pYqgQP9ZWWi3Ox9vTg4TOQToySSnlljQxVIgfB2XFcGgdYCutajE9pZQ70sRQofso8PSprLaa2CWYjNwi0nO0NIZSyr1oYqjgEwixIyr7GfpGVZTG0OYkpZR70cRQVfwYOP4d5GXooj1KKbeliaGq+PH29sBqOgb60CXET/sZlFJuRxNDVV0Hgd/3ZbgTo4LZejgLO+VCKaXcgyaGqjw87WS3A6vBGH7ctwsHMvLYmHLa1ZEppVSL0cRQU/xYyD4Mpw5w9eCuhPp78+raFFdHpZRSLUYTQ03x4+ztgVUE+Hhx/QWxrNh+nKNZBa6NSymlWogmhprC4iG0W2UZ7pkju2OMYdGGVBcHppRSLUMTQ00idtjqwS+gvIzYsAAm9OnM4q8PU1hS5urolFLK6TQx1KbnOCjKhqNbAJidFMepvGLe33rUxYEppZTzaWKoTY8x9tZRHiOpZzgJnYJYsDZFh64qpdo9TQy1CYyALgPgwBoARIRZSXFsP3qGzak6dFUp1b5pYqhLZRnuPACmDIkm2M+LBbUNXS3Isp3Vn/8d3roJ9n7SkpEqpVSzctoKbm1e/FhY+wykroOEH9mhq8NieX3tPjJ2FxOR/R0c2Wz/ZOz5/nXegZDyFfx8g73yUEqpNkYTQ126J4GnL2x/FwpOw5HN3Jv2Nfd6f4vv4hK7T2AkRA+DAddB9FDoOhjOHIPnL4aP7oOpL7n2HJRSqhE0MdTF2x+6jYTkRfaPdwC+UYP4OPRqPsuN5fc/m4VfeHc7vLUq/45w8b2w+s/Q71pIvMw18SulVCNpYjibyx6HwxvslUBkH/D0InBvBm++tIHhqV5cGyG1v+7Ce2DncvjvPfbKw79Di4atlFJNoZ3PZxN5Hgy5Cbr0B0+bQ0f3CqfXuYauevnAVc9CXjqs/H8tGLBSSjWdJoYGEhFmjerOd0ey+eZQVt07dh0Mo38BW16HfZ+2WHxKKdVUmhgaYcqQGIJ9vc5ddXXMfRDRG97/JRTpgj9KqbZBE0MjBPp6MW1YLB9+d4wTZwrr3tHbDyY/a8t4f/L7lgtQKaWawKmJQUQmichuEdknIvfX8nw3EVklIltE5FsRaTNDeG4a1Z0yY1i04dDZd+w2AkbeARtfsPMblFKqlXNaYhART2AecCnQF5guIn1r7PYQ8JYxZjBwA/AvZ8XT3OIiAhl3Xife2JBKUek5qq6Ofwg6xsHyO6E4v0XiU0qpxnLmFcNwYJ8x5oAxphhYAlxVYx8DhDjuhwJtqnzp7KQ4MnKL+fC7Y2ff0ScQrnwGTh2w8xuUUqoVc2ZiiAYOV3mc5thW1SPAjSKSBnwI3FXbgURkrohsEpFN6enpzoi1US7sFUF8ZCALvko5987xY2DozbBuHqRtdnpsSinVWPVKDCISKCIejvu9RWSyiHg3w/tPBxYYY2KAy4CFFe9TlTFmvjFmmDFmWGRkZDO8bfPw8BBmJ8WxNS2bLYfqUXV14qMQHAX/+TmUFjk/QKWUaoT6XjF8DviJSDSwEpgJLDjHa44AsVUexzi2VTUHeAvAGLMO8APaVOW5KUNiCKrP0FUAvxC48mlI32krsSqlVCtU38Qgxph8YArwL2PMNOD8c7xmI5AgIj1ExAfbuby8xj6HgAkAItIHmxhaT1tRPQT5ejF1aAwffHeMkzlnGbpaIWEiDJwOXz4Jx751foBKKdVA9U4MIjIKmAF84NjmebYXGGNKgTuBj4Gd2NFH20XkURGZ7Njt/4DbRGQrsBiYbdrgEmmzkuIoKTO8ca6hqxUu+TP4h9kmpbIS5wanlFINVN/E8EvgAWCZ48s9Hlh1rhcZYz40xvQ2xvQ0xvzJse1hY8xyx/0dxpjRxpiBxphBxpiVjTwPl+oREcjY8yJZtOEQxaXl535BQBhc/gQc/9au+aCUUq1IvRKDMWaNMWayMeavjs7hDGPM3U6OrU2ZnRRHek4RH207x9DVCn0nQ9+rYfVjkL7bqbEppVqRohx4cya8+CPIbZ0t5/UdlfSGiISISCCwDdghIvc6N7S25eKESHpEBPJKfYauVrjscfAJcjQplTotNqVUK3E6FV76Mez6AI5/Bwsut4t7tTL1bUrqa4w5A1wNfAT0wI5MUg4eHrbqavLhLJIPZ9XvRUGdbHJI2wgLr4a8DGeGqJRypUMb4IXxcOYI3PiO/XPmCCy4DLLTXB1dNfVNDN6OeQtXA8uNMSXYWcuqimuH2qqrf1uxi/Lyev719J8KVz9nk8P8sXA02ZkhKqVcYeub8OoVdsj6rZ9Cz3EQdyHMXGZ/EL5yKZxOcXWUleqbGJ4HUoBA4HMR6Q6ccVZQbVWwnzcPXNaHtfszWfR1PUcoAQyaDressPdfvgS2LnFOgEqpllVeDp8+CsvmQuwImxQiEr5/PnY4zFoOhWfg5UshY5/rYq2ivp3Pzxhjoo0xlxkrFRjn5NjapOnDY7koIYK/fLiTw6caUDCv62CYuxpiLoBlP4WP7tOhrEq1ZcV5sPQm+OIJGDILbnzXjkisqetgmP0BlBXbK4eTO1s+1hrq2/kcKiJPVtQrEpEnsFcPqgYR4bFrB+Ahwr1vb61/kxJAYATMfA9G/hw2PAevXd1qRy0opc7izFH7Jb/rA7jkL7bigZdP3ft36Qc3fwjiYTukXTz5tb5NSS8DOcB1jj9ngFecFVRbF93Bn4cu78P6A6d4fUNqw17s6QWT/gxTXoAjm2D+GDjyjXMCVUo1vyPfwPxxkHkApi+BUT8DkXO/LvI8mxy8/OHVK+GI64pt1jcx9DTG/M5RQvuAMeb3QLwzA2vrrr8glot7R/KXD3dxKLMRazAMuA7mrATxhJcnwZZFzR+kUrXZ+CLMGwnrn4OSAldH07ZsXwavXGavDuashN6XNOz14T1tcvALtS0Gh9Y7JcxzqW9iKBCRCyseiMhoQP/FnIWI8NiU/nh5CL9uaJNShaiBtt+h2wj4z8/gw3u130E5jzGw5nH44P+gMAtW3AdPDYCvnoaiXFdH17oZA2v+Bktn2/+3t34GnWuuS1ZPHbvDzR9BYCQsnAIHv2jWUOujvonhdmCeiKSISArwLPBTp0XVTnTt4M9vr+jL1wdP8dq6lMYdJDAcblwGo+6Er+fDq5Mh92SzxqkUxsDH/w9W/dEWefzlNpj9of1y+9/D8FQ/mzQKs10daetTcBrevQ1W/QkG3GBHGQU1cXmA0Gh75dAhFhZNhX2fNE+s9SQNqVknIiEAxpgzIvJLY8xTzgqsLsOGDTObNm1q6bdtNGMMNy/YyIYDp1jxy4voHt6EPvvv3ob/3An+HeH61yFmaPMFqtxXWSm8/wtIfh1G3G47Sz2q/GY8vBE+fxz2fgy+oTBiLoz8We0jbNxJxj47SCT5DSjJgwkPw4W/ql9/Qn3lZdgmpYzdcN1rcN6ljT6UiGw2xgyr176NLWYqIoeMMd0a9eImaGuJAeBYdgE//sfn9IkKYcltI/HwaMI/nGPfwpszoCAL7vgKOrT4R6Dak9IieGcO7HwfxtwPY++v+4vt2FabIHa+D96BcMEcSLrLzuBvjc4chS//AbknoPeltr2/qcnMGDi4Btb/G/asAE8f6D8NRt4BXfo3T9w15Z+C16+1RTenvgx9a66QXD8tlRgOG2Niz71n82qLiQHgrU2H+c3b3/K7K/ty8+geTTvY6VT492iIGgCz3gePs1ZAV6p2Rbnw5o1wYBVMesx+udXHyZ12bP62d+wX49DZkHS3bf5oDfJP2fVOvn4ByssgIBxyj9uBHHEXQp8r4bzLGhZvSSF8t9QmhJPbISACLrjVJseWSIyF2fDG9baZb+isRh1CrxhaIWMMtyzYyLoDmXz0i4vpEdHEaSDJi+G92+FHj8CF9zRLjKoKY5q3SaC1KTgNi6bZIZGTn4XBMxp+jIx99hf5t0vs+PtRP4fxD1dvhmpJRTmw7l+w9p+2aWfADTD2PujQHY5+Azv/C7v+Cxl77P5dh0CfKyDxSojsXfsxc07Appdg40uQnwGdzrfDT/tNBW+/ljs3sEmuCT8Cmy0xiEgOtddEEsDfGOPVuBAbr60mBoDj2YVM/McaErsE8+bcUU1rUjLGjoDY9QHc+gl0HdRcYarsNFh8AwR1tvNJ2ltbes4JWHgNZO61TRN9rmza8U6nwuq/wNbFtpT8Nc+37JdmSaH98v7iCcjPtOcz7iHolFj7/ul7YNf7NlEcdcwRiugNiVfYRNF1iK18uv7fsO1tOxKw9yR7RdXj4jb7g6FFrhhcpS0nBoC3N6fx66Vb+e0VfZlzYROblPJPwb+TwDcY5q4Bn4DmCdKdndxphwgW5UBZEYTGwk/egohero6seZxOhdeusiPbblhki7k1l7XPwsr/B91H22P7d2y+Y9emrBSSF8Gav9oqpfHjYMJvIboBgzKyj9gfV7v+CylfgimzqysWnALvABg0wyaE8J7OO48WoomhFTPGMOfVTazdn8GHd19EfGRQ0w64f5Ut2T18ri3hrRovda29UvDyhxvftrVulsyA8hKY9mrzfom6wsld9t9KSYEt+RxTr++IhvnubVh2O4T3sn+HoTHN/x7l5bBjGXz2Jzi139YXm/Cw/TXfFPmnYM/HsP8zW6JiyE3OT24tSBNDK3fiTCETn1xDQudg3vrpKDyb0qQEsOJBWD8PZrwNCRObJ8iWsmWR7QSMH+vaOHYsh3dutaO8bnzHTjIC+wt78Q12lb1L/wrDb3NtnI11ZDO8PtV2Fs9c1vjJV/VxYI3t1PYJssmh8/nNc1xjYO//4LNHbVNPp74w/rd2CGcbbd5pSQ1JDC7qJXJvnUP8+N2V57M59TSvfHWw6Qec8LD9T/Kfn7etxX52/tfO6F44xXamu8rGF+Gtm+worzkrv08KYO/PWWkT7oe/hg9+3fZW2zv4hZ0Y6RsMt3zk3KQAED/GztzF2HIuzTFzN3WtLUr3xjQ7mmrKi3D7l5B4mSYFJ9DE4CJThkTzoz6dePzj3exPb2K5AW8/20lacNpOVGoLV4FZh20iixpkhxC+dzusm9eyMRgDn/3RloDofQnctLz2jmbfYLjhDTskc+MLdiZqwemWjbWhjLFfyG/Nss1HoTFwy8cQ1kIlzrr0gzn/g5Cu8PoUO7S1MY5ttWP4X7kUTh2Ey5+EOzfCgGk6TNuJNDG4iIjw52v64+ftyb1Lt1LWmFpKVXXpBxN+ZzvRtixsniCdpazUNtuUl8G0V2DGUugzGT5+0C5q0hKJrawUlt9pJ2wNngnXLzp7572HJ/z4D3DVPNtJ+eKPIHO/8+NsqMJs2PA8zBthVww7uMbOZr75IwiJatlYOsTa940eBm/f0rDEn7HXJrXnL7bNYBP/AL9ItvMGPL2dFrKytI/Bxd7bcoRfvpnM9cNieeza/khTLovLy2HhVZC2Ge74suV+HTbUp3+AL/4O175klzYFmyT+ew988yoMvRkuf8J5vwiL8+Htm+3M1Yt/A+MebFhzROpa2yltym2ZgvgxzomzIY59a4dsfvsWlOTbkTkX3ArnXwPe/q6NraTQrmC24z+25tfEP9Q91yHrsB1llPwGePnZuRFJd9pqo6pJGtLH0OLzEFR1Vw+OZt/JXJ5dtY/QAG8euDSx8cnBw8OuH/3vUfDuXLh5hV3foTU5sNqONx888/ukADYJXPm0bcr58h+2qWbKfPDybd73z8uExddD2iabfC64teHH6J4Et31mO6Vfn2JHgw27pXnjrI+SQvtlu/FFSPvafpH2nwrD5kD0kJaPpy7efjD1FVjxAKx71paquOa56p9tbrr9d7HpJft4xE9t3aGmFqNTjeLUbw0RmQQ8DXgCLxpjHqtln+uAR7AT6bYaY37izJhao//7cW/OFJYw//MDhPp78/NxTRgzHxoNV/zDXrp/8YSd+dla5KbbhBXR247wqUnEzuQOCIeVD9lmketfB98mDumtcDrVtldnHbK/9PtObvyxwnrYNvR35tgrnZO74JI/t0wiPp0Cm16xTYb5mRDW0xa+GzS99Q6v9PC0n3lotK3WmpduP1sRO1N53b+gtMDOGxhzn22GUi7jtH/FIuIJzAMmAmnARhFZbozZUWWfBOABYLQx5rSItNJqXM4lIjxy5fmcKSjh8Y93E+LvzcyR3c/9wrr0u9aOx17zV+g1wTnj1RuqvNx2MBdk2eGSPmcpCZJ0l/2CW36XnYw1Y2nTZx8f/84O1ywtgJves7/6m8ovxK7QtfK3drhwxm7oOcFOjCstgtLCKrfFNR47bivX13A06VY27db1uNy2v4vYej8X3Ao9xriuDEVDiMDoX0BwV3jvDnhhvJ1IVnDazpge/xBEJLg6SoVzrxiGA/uMMQcARGQJcBWwo8o+twHzjDGnAYwxbrvQgIeH8Pi0geQWlfLwf7YR4ufFVYOaUJTsssdtW/i7t8FPv2i+X92Nte5ZW1P+8ifrN6598I3g18Fe+bxyqU0mIV0b/r4Z+2DPR3YRFd9gOzKnU5+GH6cuHp52KdbI8+xw1gOrHU+Ibdv38gVPX3vr5Vf9NiDMzivA0XRYswmx8nGN58+/xk6+csbksZYwYJptInprlv3RMv63WtKllXFa57OITAUmGWNudTyeCYwwxtxZZZ/3gD3AaGxz0yPGmBW1HGsuMBegW7duQ1NTG7iOchtSWFLGrJe/ZlPqaebPHMqEPp0bf7CUr+zC4kNugsnPNF+QDZW2CV6+xP7Cve61hnX0HvwCFjuaSGYuO3dpitJiSP3KXjHt/RhOHbDbYy6AaQuc+2VanG9LKnj5gYeXjq8/l/LytnGl0060ipnP9UwM/wVKgOuAGOBzoL8xJquu47a3UUm1ySksYcaLG9h9PIdXbxnOyPjwxh/sk0dsZ+4Nb0Di5c0WY70VZMHzF9mWkNs/b1wb+NFk2zcAMPNdu3RiVTknYO9Kmwj2r4LiXPsrvcfFdn5Cwo+rT1pTyg21llFJR4CqPUgxjm1VpQEbjDElwEER2QMkABudGFerF+znzYKbh3P98+u49dVNvHHbCAbEdGjcwcY+CPs+te310UMhuEuzxnpWxtgJd9lH4JYVje8Y7TrINgEtvBpeuRymL7ZzDvY4ksHRLXa/4K520ZTel9ikcLZ+DKVUnZx5xeCFbSaagE0IG4GfGGO2V9lnEjDdGDNLRCKALcAgY0xmXcd1hyuGCsezC5n63FryikpZevsoenUKbtyB0nfbiUJefrazcsRPW2Zxkc0LbGKY8Du46FdNP172EVsuOmO3Y4PYJqLel9g/nftp841SdWgVTUmOQC4DnsL2H7xsjPmTiDwKbDLGLBc7YP8JYBJQBvzJGLPkbMd0p8QAkJKRx9Tn1uHlISy9fRSxYY0srX002U4q2/lf2+E58AY7+sdZo0BO7oT5Y6HbSLhxWfO1JeefsuvshvWEXj+CwCY0synlRlpNYnAGd0sMADuPneH659fRMdCHpbePolNwExZBydhnRwglvwFlxbbfIelu6Dai+QIuzrdDEfMz4PavILgJHehKqWah1VXbmT5RIbxy83BOninippe+Jju/5NwvqktEL7jyKbhnG1z8a1v35+Ufw0s/tlcT5eVND/jjByB9p525rElBqTZHE0MbMbR7R+bfNJQD6XncvOBr8oubWPo5qJOdUPSrHXDp3yDnGLw5A+ZdYGfVlhQ27rjb3rV9CxfeAz3HNy1GpZRLaFNSG7Ni2zF+tugbknpG8MJNw/D3aaZCc2WlsOM9WPuMLXUcGGmL2YV0tQu9iwBS477jccX98lL48F472evmj7QKplKtiPYxtHPvbE7j3re3Mqx7GC/NHkawXzN+ARsDBz+Hr56G/Z82/PX+He360zpvQKlWpbXMY1BOcu3QGHy9PfjlkmRmvLiBV28eTsdAn+Y5uIgtIx0/xo4AKi209XmMAUyN++aH24O7gH+H5olFKeUSmhjaqCsGdMXf25M7Fn3DDfPXs/DW4U0brVSbphauU0q1Sdr53IZN6NOZBbMv4PDpfK57bh1pp/NdHZJSqh3QxNDGJfWKYOGcEWTmFXPdc+s4mJHn6pCUUm2cJoZ2YGj3jiyZO5Ki0nKmPbeOXcfPuDokpVQbpomhnTi/ayhv/nQUXh7CDfPXs/VwlqtDUkq1UZoY2pFenYJYevsogv28mPHiBjYcqLMWoVJK1UkTQzsTGxbA0p8m0TnEl1mvfM2aPemuDkkp1cZoYmiHuoT68dZPRxEfEcStr25kxbZjrg5JKdWGaGJop8KDfFk8dyT9o0P5+RtbWLYlzdUhKaXaCE0M7ViovzcL54xgRI8wfvXWVv7xvz0UlpS5OiylVCuniaGdC/T14uXZF3DVwK48/eleJjyxhve3HqWt1chSSrUcTQxuwM/bk6duGMySuSMJ9ffmrsVbuO75dXyXlu3q0JRSrZAmBjcyMj6c9++6kMem9OdgRh6T533JvUu3cjKnkWsvKKXaJU0MbsbTQ7hheDc++/VYbrsonveSjzDu8dX8a/U+7X9QSgGaGNxWiJ83D17Wh5X3jGFUzwj+tmI3E/+xhhXbjmn/g1JuThODm+sREciLs4bx+pwR+Ht7cvvr3zD9hfXsOKr1lpRyV5oYFAAXJkTw4d0X8Yerzmf38Ryu+OcXPPDud6TnFLk6NKVUC9PEoCp5eXowc1Qcq389jllJcSzddJixj6/imU/3kl9c6urwlFItRBOD+oHQAG9+d+X5rLznYi5KiOTJ/+1h7OOrWfL1IUrLyl0dnlLKyTQxqDrFRwbx3MyhvH37KGI6+nP/u99x2TNf8NmuE9pBrVQ75tTEICKTRGS3iOwTkfvPst+1ImJEZJgz41GNMywujHfuSOK5G4dQUma4ZcEmfvLCBp0gp1Q75bTEICKewDzgUqAvMF1E+tayXzDwC2CDs2JRTSciTOoXxcp7LubRq85n94kcrnz2S36xZAuHT+la00q1J868YhgO7DPGHDDGFANLgKtq2e8PwF8BnX7bBnh7enDTqDjW3DuWO8f14uPtx5nwxBr+9MEOsvKLXR2eUqoZODMxRAOHqzxOc2yrJCJDgFhjzAdnO5CIzBWRTSKyKT1dF55pDYL9vPn1Jeex6tdjuXpwV1788iBjHl/N/M/36wxqpdo4l3U+i4gH8CTwf+fa1xgz3xgzzBgzLDIy0vnBqXqLCvXnb1MH8tEvLmJQbAf+/OEuxv99NW9tOkxZuXZQK9UWOTMxHAFiqzyOcWyrEAz0A1aLSAowEliuHdBtU2KXEF69ZThv3DaCyBA/fvP2t0x66nNWbj+uI5iUamOcmRg2Agki0kNEfIAbgOUVTxpjso0xEcaYOGNMHLAemGyM2eTEmJSTJfWM4L2fJfHvGUMoKzfMXbiZqc+tY2PKKVeHppSqJ6clBmNMKXAn8DGwE3jLGLNdRB4VkcnOel/leiLCpf3tCKa/TOlP2ul8pj23jjkLNrLruNZgUqq1k7Z2mT9s2DCzaZNeVLQlBcVlLFibwr9W7yO3qJRrBkfzq4m9iekY4OrQlHIbIrLZGFOvpnpNDKrFZOUX8+/V+3llbQoYuHFkd+4c34uwQB9Xh6ZUu6eJQbVqx7ILeOp/e1m6+TABPl5cMSCKod07MqR7R+IjAhERV4eoVLujiUG1CftO5vDUJ3v5fE86Zwpt9daOAd4M7taRod07MrhbBwbFdiDAx8vFkSrV9jUkMej/OOUyvToF8+xPhlBebtifnsvm1NN8c+g0m1NP89muk4BdirRPVDBDHMliSLeOxHT016sKpZxIrxhUq5SVX8yWQ1mViSL5cBb5xXZGdadgX64eHM2NI7rTLVw7sJWqD21KUu1OaVk5u0/k8M2hLL7Yk86nu05SbgzjzuvEzFHdGZMQiYeHXkUoVRdNDKrdO5ZdwOINh3jj68Nk5BbRPTyAG0d0Z9qwGDoE6CgnpWrSxKDcRnFpOSu2H2fhuhQ2ppzG18uDqwZ15aZRcfSLDnV1eEq1GpoYlFvacfQMC9en8t6WIxSUlDG4WwdmjYrj0v5d8PXydHV4SrmUJgbl1rILSnh7cxqvr0/lYEYe4YE+TBsWy+X9o+gXHaIjmpRb0sSgFFBebvhyXwavrUtl1e6TlJUbojv4M6lfFy7t14Uh3Tpqh7VyG5oYlKrhVF4xn+w4wYrtx/lybwbFZeVEBvtyyfmdmXR+FCPiw/D2dNnyJEo5nSYGpc7iTGEJq3adZMW246zenU5BSRkdAryZ2Kczk/p14cKECO2TUO2OJgal6qmguIw1e9L5ePtxPtl5gpzCUoJ8vRiX2ImLEiLoHx1KQqcgvPRqQrVxWhJDqXry9/FkUr8uTOrXheLSctbuz2DFtuOs3HGC97ceBcDXy4M+USH0jw6lf3Qo/aJDSegcpE1Pqt3SKwalalFebjiYmce2I9l8l5bNd0ey2X70DLlFttifr5cHiVEh9I8OYUB0B00WqtXTpiSlnKA+yWJkfDgT+nRifGInXYhItSqaGJRqIeXlhpTMPL47ks2WQ1ms3n2SlMx8ABK7BDuSRGcGxXbAU4fGKhfSxKCUC+1Pz+WznSf5ZOcJNqWepqzcEB7ow9jzOjGhj+3UDvbzdnWYys1oYlCqlcjOL2HN3nQ+3XmC1bvTyS4owdtTGNEjnPGJnbi4dyTdwwO0b0I5nSYGpVqh0rJyvjmUxac7T/DprpPsO5kLgJeHENPRn7iIQOLCA4kLDyAuIpAeEYFEd/DXobKqWWhiUKoNSM3M4+uDp0jJzCMlM5+UjDxSMvLIcyxIBDZpxIYFEBceQPdwmyzO6xLMgJhQXfJUNYjOY1CqDegeHkj38MBq24wxpOcWkZqZz0FHokjJzCMlI58NB09VrmLn6SEkdrFLng7u1oEh3TrSPTxACwSqZqGJQalWREToFOxHp2A/LogLq/acMYb0nCK2Hc2uXPZ02ZYjLFyfCkBYoA+DYztUJooBsR0I8tX/4qrhnPqvRkQmAU8DnsCLxpjHajz/K+BWoBRIB24xxqQ6Myal2ioRoVOIH+ND/Bif2BmAsnLD3pM5NlGknmbL4Sw+3XUSAA+B3p2DGdytA7FhAUQG+RIR7EtkkC+dgn0JC/TR/gtVK6f1MYiIJ7AHmAikARuB6caYHVX2GQdsMMbki8gdwFhjzPVnO672MSh1dtn5JSSnfZ8oth7OIrug5Af7iUBYgA+Rwb72T5XEERnsS+cQP6JC/egS6oeftxYVbOtaSx/DcGCfMeaAI6glwFVAZWIwxqyqsv964EYnxqOUWwgN8GZM70jG9I6s3FZQXEZGbhEnc4pIzykiPbeIDMdtumPbwYw80nOKKCot/+Ex/b2JCvWrTBadQ2zC6BLqRxfHtlB/b+3jaCecmRiigcNVHqcBI86y/xzgo9qeEJG5wFyAbt26NVd8SrkNfx9PYsMCiA07e5kOYww5RaWcPFPEiTOFHM8u5Ljj9lh2ISfOFLLj2Bkycouo2dgQ5OtFz8hA4iOD6BkZSM/IIOIjg+geHqBXHG1Mq+iZEpEbgWHAmNqeN8bMB+aDbUpqwdCUcisiQoifNyF+3vTqFFTnfiVl5ZzMKeJ4dgHHs4s4ll3A4VP57E/PY8OBTJZtOVK5r4dATMeAasmiIoGEB/roKnqtkDMTwxEgtsrjGMe2akTkR8D/A8YYY4qcGI9Sqpl4e3oQ3cGf6A7+tT6fX1zKgfQ89qfnVt7uT89j3YFMCku+b6ry9BA6+HvTMdCHsAAfOgZ60zHAp8pjHzoGfP98WJAPwb5e2mTlZM5MDBuBBBHpgU0INwA/qbqDiAwGngcmGWNOOjEWpVQLCvDxop9j7YqqyssNR7MLOJCex4H0XDLzijmVV8zpfHubmpnPlkNZnM4vpqSs9sYBf2/PWvs5qnaWRwT5atHCJnBaYjDGlIrIncDH2OGqLxtjtovIo8AmY8xy4HEgCFjq+AVwyBgz2VkxKaVcy8NDiOkYQEzHAC6u0jlekzGG3KJSsvJLOJVXzKn8Yk7nFZOZW2z7PM4UciK7kK8PnuJkTuEPkoinh9DJMbKqc4gv4UG+hAf62D9BvoQH+RDh2NYhwEeTSA1aEkMp1aaVlxtO5RfbjvIqneUVt+k5RWTmFXEqr5jyWr7uPMRODgwL9CE80CaNYD9vAn08CfD1qn7r40mAjxeBvo5bHy8CfD0J8vVq9R3srWW4qlJKOZ2HhxAR5EtEkO8Pmq6qKis3ZDmarDJyi8nMKyIzt5jM3CIy8uxtZm4xO46eIaeolPyi0mp1q87F18uDDgG2j6TqbYcA209ibyue8ybI1xtvT8HbywNvDw+8PQVPD2kV/SeaGJRSbsHTQxzNSL4kdK7fa8rLDYWlZeQVlZFfXPr9bXFZZeLILy4lp7CU7IISTucVk1VQQlZ+MXtP5pKVb++X1napUgcfTw+8PAVvTw/HH3vfy1P4yfBu3HpRfCP/BupPE4NSStXBw0MI8PFyVLL1bdQxqvaXZOWXcDrfJo/cwlJKy8spKTOUlJVTUlpOSfn390vLDcU17kcENS6GhtLEoJRSTiQiBPt5E+znTWzYufdvDbSCllJKqWo0MSillKpGE4NSSqlqNDEopZSqRhODUkqpajQxKKWUqkYTg1JKqWo0MSillKqmzRXRE5F0ILWRL48AMpoxnLbGnc/fnc8d3Pv89dyt7saYukvaVtHmEkNTiMim+lYXbI/c+fzd+dzBvc9fz73h565NSUopparRxKCUUqoad0sM810dgIu58/m787mDe5+/nnsDuVUfg1JKqXNztysGpZRS56CJQSmlVDVukxhEZJKI7BaRfSJyv6vjaUkikiIi34lIsohscnU8ziYiL4vISRHZVmVbmIj8T0T2Om47ujJGZ6nj3B8RkSOOzz9ZRC5zZYzOIiKxIrJKRHaIyHYR+YVju7t89nWdf4M/f7foYxART2APMBFIAzYC040xO1waWAsRkRRgmDHGLSb5iMjFQC7wmjGmn2Pb34BTxpjHHD8MOhpj7nNlnM5Qx7k/AuQaY/7uyticTUSigChjzDciEgxsBq4GZuMen31d538dDfz83eWKYTiwzxhzwBhTDCwBrnJxTMpJjDGfA6dqbL4KeNVx/1Xsf5h2p45zdwvGmGPGmG8c93OAnUA07vPZ13X+DeYuiSEaOFzlcRqN/AtrowywUkQ2i8hcVwfjIp2NMccc948DnV0ZjAvcKSLfOpqa2mVTSlUiEgcMBjbghp99jfOHBn7+7pIY3N2FxpghwKXAzx3NDW7L2PbT9t+G+r1/Az2BQcAx4AmXRuNkIhIEvAP80hhzpupz7vDZ13L+Df783SUxHAFiqzyOcWxzC8aYI47bk8AybNOauznhaIOtaIs96eJ4Wowx5oQxpswYUw68QDv+/EXEG/uluMgY865js9t89rWdf2M+f3dJDBuBBBHpISI+wA3AchfH1CJEJNDREYWIBAI/Brad/VXt0nJgluP+LOA/LoylRVV8KTpcQzv9/EVEgJeAncaYJ6s85RaffV3n35jP3y1GJQE4hmg9BXgCLxtj/uTaiFqGiMRjrxIAvIA32vu5i8hiYCy25PAJ4HfAe8BbQDds2fbrjDHtrpO2jnMfi21GMEAK8NMqbe7thohcCHwBfAeUOzY/iG1nd4fPvq7zn04DP3+3SQxKKaXqx12akpRSStWTJgallFLVaGJQSilVjSYGpZRS1WhiUEopVY0mBqUcRKSsSgXK5OaswisicVUrnirVmnm5OgClWpECY8wgVwehlKvpFYNS5+BYz+JvjjUtvhaRXo7tcSLymaM42aci0s2xvbOILBORrY4/SY5DeYrIC45a+StFxN+x/92OGvrfisgSF52mUpU0MSj1Pf8aTUnXV3ku2xjTH3gWO4Me4J/Aq8aYAcAi4BnH9meANcaYgcAQYLtjewIwzxhzPpAFXOvYfj8w2HGc251zakrVn858VspBRHKNMUG1bE8BxhtjDjiKlB03xoSLSAZ2YZQSx/ZjxpgIEUkHYowxRVWOEQf8zxiT4Hh8H+BtjPmjiKzALq7zHvCeMSbXyaeq1FnpFYNS9WPquN8QRVXul/F9H9/lwDzs1cVGEdG+P+VSmhiUqp/rq9yuc9xfi63UCzADW8AM4FPgDrDLyopIaF0HFREPINYYswq4DwgFfnDVolRL0l8mSn3PX0SSqzxeYYypGLLaUUS+xf7qn+7YdhfwiojcC6QDNzu2/wKYLyJzsFcGd2AXSKmNJ/C6I3kI8IwxJquZzkepRtE+BqXOwdHHMMwYk+HqWJRqCdqUpJRSqhq9YlBKKVWNXjEopZSqRhODUkqpajQxKKWUqkYTg1JKqWo0MSillKrm/wNEYcxCmNWXfgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.14998102188110352 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "plt.plot(history2.history['loss'])\n",
+    "plt.plot(history2.history['val_loss'])\n",
+    "plt.title(\"Model Loss\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Loss')\n",
+    "plt.legend(['Resnet Train', 'Resnet Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "executed-preservation",
+   "metadata": {
+    "papermill": {
+     "duration": 1.625232,
+     "end_time": "2021-04-25T14:39:44.218509",
+     "exception": false,
+     "start_time": "2021-04-25T14:39:42.593277",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Model 2 Accuracy vs no. of epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "alike-confusion",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:39:47.082896Z",
+     "iopub.status.busy": "2021-04-25T14:39:47.081975Z",
+     "iopub.status.idle": "2021-04-25T14:39:47.233248Z",
+     "shell.execute_reply": "2021-04-25T14:39:47.232605Z"
+    },
+    "papermill": {
+     "duration": 1.58841,
+     "end_time": "2021-04-25T14:39:47.233411",
+     "exception": false,
+     "start_time": "2021-04-25T14:39:45.645001",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZIAAAEWCAYAAABMoxE0AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAABHnElEQVR4nO3dd3xUZfb48c9JIxA6Cb2FDgKhRKoFrIgF7GID15W16+7qWtZ1lXV/rn7Vtetiw44VxF5BVEQMVQg1FEkBQg0hpJ/fH89NGEIaSSaTct6v17xm5rY5lyFz7lPu84iqYowxxlRUUKADMMYYU7tZIjHGGFMplkiMMcZUiiUSY4wxlWKJxBhjTKVYIjHGGFMplkiMKYGIdBURFZGQcmw7RUR+rI64jKlpLJGYOkFENotItohEFlm+1EsGXQMUmm8sjUUkXUQ+D3QsxlQlSySmLtkETCp4IyIDgEaBC+cI5wNZwKki0rY6P7g8pSpjKsoSialLXgeu9Hk/GXjNdwMRaSYir4lIqohsEZF7RCTIWxcsIo+IyE4R2QicWcy+L4lIiogkicgDIhJ8FPFNBp4HVgCXFzn2cSKyQET2ishWEZniLW8oIo96se4TkR+9ZWNEJLHIMTaLyCne6/tE5H0ReUNE0oApIjJMRH72PiNFRJ4WkTCf/Y8Rka9FZLeIbBeRu0WkrYhkiEgrn+2GeP9+oUdx7qYOs0Ri6pKFQFMR6ev9wF8CvFFkm6eAZkA34ERc4rnKW3cNcBYwGIgFLiiy7wwgF+jhbXMa8MfyBCYiXYAxwJve48oi6z73YosCBgHLvNWPAEOBUUBL4G9Afnk+E5gAvA809z4zD/gzEAmMBE4GrvdiaAJ8A3wBtPfO8VtV3QbMAy7yOe4VwExVzSlnHKaOs0Ri6pqCUsmpwGogqWCFT3K5S1X3q+pm4FHcDyO4H8vHVXWrqu4GHvTZtw0wHrhVVQ+o6g7gv97xyuMKYIWqxgMzgWNEZLC37lLgG1V9W1VzVHWXqi7zSkp/AG5R1SRVzVPVBaqaVc7P/FlVZ6tqvqoeVNXFqrpQVXO9c/8fLpmCS6DbVPVRVc30/n1+8da9ileC8v4NJ+H+nY0BwOpNTV3zOjAfiKZItRbuSjwU2OKzbAvQwXvdHthaZF2BLt6+KSJSsCyoyPaluRJ4AUBVk0Tke1xV11KgE5BQzD6RQHgJ68rjsNhEpBfwGK601Qj397/YW11SDAAfAc+LSDTQG9inqosqGJOpg6xEYuoUVd2Ca3QfD3xYZPVOIAeXFAp05lCpJQX3g+q7rsBWXEN5pKo29x5NVfWYsmISkVFAT+AuEdkmItuA4cClXiP4VqB7MbvuBDJLWHcAn44EXkkhqsg2RYf2fg5YA/RU1abA3UBBVtyKq+47gqpmAu/iSiVXYKURU4QlElMXXQ2cpKoHfBeqah7uB/HfItLEa5v4C4faUd4FbhaRjiLSArjTZ98U4CvgURFpKiJBItJdRE6kbJOBr4F+uPaPQUB/oCFwBq794hQRuUhEQkSklYgMUtV84GXgMRFp73UGGCkiDYB1QLiInOk1et8DNCgjjiZAGpAuIn2A63zWfQK0E5FbRaSB9+8z3Gf9a8AU4BwskZgiLJGYOkdVE1Q1roTVN+Gu5jcCPwJv4X6swVU9fQksB5ZwZInmSiAMiAf24Bqy25UWi4iE49penlLVbT6PTbgf5Mmq+juuBPVXYDeuoT3GO8RtwG/Ar966h4AgVd2Hayh/EVeiOgAc1ourGLfh2mP2e+f6TsEKVd2Pa1c6G9gGrAfG+qz/CdfIv8Qr9RlTSGxiK2NMeYjId8BbqvpioGMxNYslEmNMmUTkWFz1XCev9GJMIavaMsaUSkRexd1jcqslEVMcK5EYY4ypFCuRGGOMqZR6cUNiZGSkdu3aNdBhGGNMrbJ48eKdqlr0/qQj1ItE0rVrV+LiSuoNaowxpjgiUq6u3la1ZYwxplIskRhjjKkUSyTGGGMqxa9tJCLyMm546h2q2r+Y9QI8gRseIgOYoqpLvHWTceMHATygqq96y4fi5oVoCHyGG2L7qPsw5+TkkJiYSGZm5lGfl6k9wsPD6dixI6GhNgeTMf7i78b2GcDTHDmcd4EzcKOi9sSNhvocMFxEWgL/xA13rcBiEZmjqnu8ba4BfsElknG4SYGOSmJiIk2aNKFr1674DAtu6hBVZdeuXSQmJhIdHR3ocIyps/xataWq83EDzZVkAvCaOguB5iLSDjgd+FpVd3vJ42tgnLeuqTc5j+IS1MSKxJaZmUmrVq0sidRhIkKrVq2s1GmMnwW6jaQDh0++k+gtK215YjHLjyAiU0UkTkTiUlNTi/1wSyJ1n33Hxvhfnb2PRFWnA9MBYmNjbRwYY0ytkJOXz56MbHYfOPTYcyCbPRk5ADQICaJBSBBhIcHudWgQDUKCCfOWu8eh922bhRMa7N8yQ6ATSRKHz0jX0VuWBIwpsnyet7xjMdvXSsHBwQwYMIDc3Fyio6N5/fXXad68ud8/9/HHH2fq1Kk0atTosOXnnnsumzZtIj09ndTU1MJ2hWeffZZRo0aVedxRo0axYMECv8RsTE2Qn6/sOpDNtn2ZpOw7yPa0TFL2ZbL7QDYirgQcLEKQ9zpIhOAgCBJx63xeZ+XkuSSRkc0uL1nsOpDN/szcKo35m7+cQI/WTar0mEUFOpHMAW4UkZm4xvZ9qpoiIl8C/8+bpQ7gNOAuVd0tImkiMgLX2H4l8FRAIq8CDRs2ZNmyZQBMnjyZZ555hr///e9+/9zHH3+cyy+//IhEMmvWLADmzZvHI488wieffHLY+tzcXEJCSv4vY0nE1GbZufns2J9ZmBy2eY+UtEy273PLduzPJCfv8AqOkCChRUQYAuQr5Ku6R74e/l7xlrnXYcFBtIwIK3x0atGIlhFhtGgURsvGYbRsFEaLiFBaRTSgRUQoLRq5z8jKzfceeWQXvM7JJzsvj6yc/MPWZ+Xm07ppuN//7fzd/fdtXMkiUkQScT2xQgFU9Xlcr6vxwAZc99+rvHW7ReRfuFnhAKapakGj/fUc6v77ORXosVUTjRw5khUrVgCQkJDADTfcQGpqKo0aNeKFF16gT58+vPfee9x///0EBwfTrFkz5s+fz4wZM5gzZw4ZGRkkJCRw7rnn8vDDDwPw1Vdf8c9//pOsrCy6d+/OK6+8wssvv0xycjJjx44lMjKSuXPnlhrXjBkz+PDDD0lPTycvL49PP/2UCRMmsGfPHnJycnjggQeYMGECAI0bNyY9PZ158+Zx3333ERkZycqVKxk6dChvvPGGtVeYgFBV9mflFiaDbV5i2Jbmksa2NJcwdqZnH7FveGgQ7Zo1pG3TcIZFt6Rts3DaNQunTVP33LZZOJERDQgKOvr/26paob+JkOAgIsqaVLma+TWRqOqkMtYrcEMJ617m0BSovsvjcPNdV5n7P15FfHJaVR6Sfu2b8s+zjynXtnl5eXz77bdcffXVAEydOpXnn3+enj178ssvv3D99dfz3XffMW3aNL788ks6dOjA3r17C/dftmwZS5cupUGDBvTu3ZubbrqJhg0b8sADD/DNN98QERHBQw89xGOPPca9997LY489xty5c4mMjCxXfEuWLGHFihW0bNmS3NxcZs2aRdOmTdm5cycjRozgnHPOOeIPYunSpaxatYr27dszevRofvrpJ4477rjy/eMZU8TW3RnMX5/KyqQ0snLzyMlTcnLzyc3PJ9t7nZPnHtl5Wvg6JzefvQdzyMjOO+KYLRqF0qapSwb92zejbbNw2jYNp42XLNo1bUjThiF+uwCqSxdWga7aqtcOHjzIoEGDSEpKom/fvpx66qmkp6ezYMECLrzwwsLtsrKyABg9ejRTpkzhoosu4rzzzitcf/LJJ9OsWTMA+vXrx5YtW9i7dy/x8fGMHj0agOzsbEaOHFmhOE899VRatmwJuKuou+++m/nz5xMUFERSUhLbt2+nbdu2h+0zbNgwOnZ0zVmDBg1i8+bNlkhMuWVk57Jw4y7mr9vJ/HWpbNx5AHA//hENQggLDiIkWAgNDiI0OIiwYNfo3Dg8xFt2aF2T8JDCUkRbL3G0aRpOeGhwgM+y7rBEAuUuOVS1gjaSjIwMTj/9dJ555hmmTJlC8+bNC9tOfD3//PP88ssvfPrppwwdOpTFixcD0KDBoXJucHAwubm5qCqnnnoqb7/9dqXjjIiIKHz95ptvkpqayuLFiwkNDaVr167F3qdRXEzGlERVWbNtP/PXpfL9ulTiNu8hOy+f8NAgRnRrxeUjunBCryi6R0XUqSv5usISSQ3QqFEjnnzySSZOnMj1119PdHQ07733HhdeeCGqyooVK4iJiSEhIYHhw4czfPhwPv/8c7Zu3VriMUeMGMENN9zAhg0b6NGjBwcOHCApKYlevXrRpEkT9u/fX+6qLV/79u2jdevWhIaGMnfuXLZsKdco08YUys9XsnLzScvMKSx1/LA+lR37Xcm7d5smTBndlRN6RhHbtYWVHGoBSyQ1xODBgxk4cCBvv/02b775Jtdddx0PPPAAOTk5XHLJJcTExHD77bezfv16VJWTTz6ZmJiYYksuAFFRUcyYMYNJkyYVVo098MAD9OrVi6lTpzJu3Djat29fZmN7UZdddhlnn302AwYMIDY2lj59+lT21E0Nl5+v7M/MZe/BbPZm5LDvYA57D7rnfRmHlh3IziUzx/UW8n3OzHG9hzJz8rzeRfmHHb95o1CO6xHJCb2iOKFnFG2b+b+Xkala9WLO9tjYWC06sdXq1avp27dvgCIy1cm+6/JRVVYmpTFneRKLNu1m78Ec9mbkkJaZQ2k/E43CgmnWMJTGDUJoEBpEeEhw4XN4aMFNc+45PDSYcO8GukZhwcR0as6ADs0IrkCvJ+N/IrJYVWPL2s5KJMbUcxt2pDNneTIfL09m084DhAYLsV1a0jUygmYNQ2neMJRmjcIKXzdv5B5NG4bSrGEoDUKs6qm+s0RiTD2UvPcgHy9PZs7yZFYlpyECI6Jb8acTujGuf1uaNwoLdIimFrFEYkw9sftANp/+lsLHy5JZtNnd3xvTqTn/OKsfZw1sR5tquAPa1E2WSIypo9Kzctm88wDxKWl89lsKP67fSW6+0qN1Y/56ai/OjmlP18iIsg9kTBkskRhTi2Xn5vP77gw27TzApp3pbNp5gI2pB9i080Bhd1qADs0b8sfju3FOTHv6tmti92KYKmWJxJhaIjcvny9XbWfxlj2FSWPrnoPk5R/qUtUyIoxukRGc2CuK6KgIukVG0C2qMT2iGldoPChjysMSSQDVtGHk77//fjIzM3nwwQcLly1btoxJkyaxevXqYo9133330bhxY2677TbuvfdeTjjhBE455ZTDtilpNGFfy5YtIzk5mfHjxwMwZ84c4uPjufPOOyt6mnVGVm4eHy5J4vnvE9iyK4OGocFER0ZwTIdmnB3TnujIiMKHNZKbQLBEEkA1bRj5SZMmMW7cuMMSycyZM5k0qdSxNwtNmzatwjEtW7aMuLi4wkRyzjnncM4551T4eHVBRnYuby/aygvzN7ItLZOBHZvxvyuGcmrfNla6MDVKoKfaNZ6RI0eSlOTm6EpISGDcuHEMHTqU448/njVr1gDw3nvv0b9/f2JiYjjhhBMAN8z7eeedx7hx4+jZsyd/+9vfCo/51VdfMXLkSIYMGcKFF15Ieno6Tz75ZOEw8mPHjj0shl69etGiRQt++eWXwmXvvvsukyZN4oUXXuDYY48lJiaG888/n4yMjCPOYcqUKbz//vsAfPHFF/Tp04chQ4bw4YcfFm6zaNEiRo4cyeDBgxk1ahRr164lOzube++9l3feeYdBgwbxzjvvMGPGDG688UYANm/ezEknncTAgQM5+eST+f333ws/7+abb2bUqFF069at8LNru30Hc3j6u/Uc99Bc/vVJPF1aNeL1q4fx0Q2jOf2YtpZETI1jJRKAz++Ebb9V7THbDoAz/lOuTWvSMPKTJk1i5syZDB8+nIULF9KyZUt69uxJy5YtueaaawC45557eOmll7jpppuKPZ/MzEyuueYavvvuO3r06MHFF19cuK5Pnz788MMPhISE8M0333D33XfzwQcfMG3aNOLi4nj66acBlyAL3HTTTUyePJnJkyfz8ssvc/PNNzN79mwAUlJS+PHHH1mzZg3nnHMOF1xwQbn+zWuinelZvPzjJl7/eQv7s3IZ2zuKG8b2ILZry0CHZkypLJEEUE0cRv7iiy9m1KhRPProo4dVa61cuZJ77rmHvXv3kp6ezumnn17iMdasWUN0dDQ9e/YE4PLLL2f69OmAG/Rx8uTJrF+/HhEhJyenzJh+/vnnwlLNFVdccVipa+LEiQQFBdGvXz+2b99e5rFqouS9B5k+fyMzf/2drNx8xg9ox/VjunNM+2aBDs2YcrFEAuUuOVS1mjiMfKdOnYiOjub777/ngw8+4OeffwZcNdLs2bOJiYlhxowZzJs3r0Ln/I9//IOxY8cya9YsNm/ezJgxYyp0nAK+516bxo3LzMlj+da9fLAkkVlLk1CFcwd34Nox3eke1TjQ4RlzVKyNpAYoGEb+0UcfpVGjRoXDyIP7cVy+fDlA4TDy06ZNIyoqqsxh5H/66Sc2bNgAwIEDB1i3bh1A4TDyJZk0aRJ//vOf6datW+HkVPv376ddu3bk5OTw5ptvlno+ffr0YfPmzSQkJAAclsz27dtHhw4dgMOrr0qLadSoUcycORNw86Ecf/zxpX5+TZSRncuP63fy6Fdrueh/PzPw/q+4ePpCPlqWzKXDOvP938byfxfGWBIxtZJfE4mIjBORtSKyQUSO6McpIl1E5FsRWSEi80Sko7d8rIgs83lkishEb90MEdnks26QP8+huhQdRv6ll14iJiaGY445ho8++giA22+/nQEDBtC/f39GjRpFTExMicfzHUZ+4MCBjBw5srDRvmAY+aKN7QUuvPBCVq1adVhvrX/9618MHz6c0aNHlzl0fHh4ONOnT+fMM89kyJAhtG7dunDd3/72N+666y4GDx582GRXY8eOJT4+vrCx3ddTTz3FK6+8wsCBA3n99dd54oknSv38miAtM4e5a3bw4OerOffZnxh431dc/tIvPDsvgaycPCaP7MKLV8ay6O+ncP+E/nRo3jDQIRtTYX4bRl5EgoF1wKlAIvArMElV4322eQ/4RFVfFZGTgKtU9Yoix2kJbAA6qmqGiMzw9il3Fx0bRr5+q47vOjcvn3lrU1mQsItFm3cRn5xGvkJosDCwY3OGR7dkeLdWDO3SgsYNrEbZ1A41YRj5YcAGVd3oBTQTmADE+2zTD/iL93ouMLuY41wAfK6qR/Y3NSbAVJUvVm7jka/WkpB6gAYhQQzu3JybTurJ8OiWDO7cgoZhNsy6qdv8mUg6AL6V+InA8CLbLAfOA54AzgWaiEgrVd3ls80lwGNF9vu3iNwLfAvcqapZRdYjIlOBqQCdO3euzHkYU6wf1+/k4S/XsCJxH92jInjm0iGc0q+1zc9h6p1Al7FvA54WkSnAfCAJyCtYKSLtgAHAlz773AVsA8KA6cAdwBG3VKvqdG89sbGxxdbfqaoNXlfH+aPqdunve/i/L9eyIGEXHZo35OELBnLe4A6EBFvfFVM/+TORJAGdfN539JYVUtVkXIkEEWkMnK+qe302uQiYpao5PvukeC+zROQVXDI6auHh4ezatYtWrVpZMqmjVJVdu3YRHl4182ys276fR75cy1fx22kVEca9Z/XjshGdrQRi6j1/JpJfgZ4iEo1LIJcAl/puICKRwG5VzceVNF4ucoxJ3nLffdqpaoq4X/+JwMqKBNexY0cSExNJTU2tyO6mlggPDy/swlxRW3dn8N9v1jFraRIRYSH8+ZReXH18tDWaG+Px21+CquaKyI24aqlg4GVVXSUi04A4VZ0DjAEeFBHFVW3dULC/iHTFlWi+L3LoN0UkChBgGXBtReILDQ0lOjq6IruaeiJ1fxZPf7eetxb9jojwx+OiuW5MD1pG2Ai7xvjyW/ffmqS47r/GlCQzJ49n5yXwwvyNZOflc1FsR24+uSftmtm9HqZ+qQndf42pdX7dvJs7PljBxtQDnDmwHX89tRfd7G5zY0plicQYYH9mDg9/sZbXF26hY4uGvPaHYZzQKyrQYRlTK1giMfXe3DU7+Pus30hJy+Sq0V257bTeRFhDujHlZn8tpt7afSCbaR+vYvayZHq2bsz7145iaJcWgQ7LmFrHEompd1SVOcuTuf/jePZn5nDLyT25fmx3ux/EmAqyRGLqlZR9B7ln1kq+XbODmE7Nefj8gfRu2yTQYRlTq1kiMfVCfr7y1qLf+c/na8jLV+45sy9XjY4m2OY/N6bSLJGYOktV2ZaWSXxyGv+bv5FFm3YzukcrHjx3IJ1bNQp0eMbUGZZITJ2Qk5fPhh3pxCensToljXjvsTfDDdPWNDyEhy8YyIVDO9rYasZUMUskptbZl5FTmChWp6QRn5zGhh3pZOflA9AgJIg+7ZpyRv+29GvXlL7tmtKvfVMahdl/d2P8wf6yTK2hqrz04yYe9No5AKKaNKBvu6ac0CuKfu2b0q9dE7q2irAh3Y2pRpZITK2QnZvPPbN/4924RE4/pg2XDu9C33ZNaN2kaoaIN8ZUnCUSU+PtPpDNtW8sZtGm3dx8Ug9uPaUXQdbbypgawxKJqdHWb9/P1a/GsS0tkycuGcSEQR0CHZIxpghLJKbGmrt2Bze/tZQGocG8M3UEgzvb8CXG1ESWSEyNo6q88tNmHvg0nt5tm/Li5Fg6NLe5QIypqSyRmBolJy+fez9axduLfue0fm3478WDbCReY2o4+ws1NcbejGyue2MJP2/cxfVjunPbab2tUd2YWsCvne1FZJyIrBWRDSJyZzHru4jItyKyQkTmiUhHn3V5IrLMe8zxWR4tIr94x3xHRGwC7Tpgw450Jj7zE4u37OGxi2L427g+lkSMqSX8lkhEJBh4BjgD6AdMEpF+RTZ7BHhNVQcC04AHfdYdVNVB3uMcn+UPAf9V1R7AHuBqf52DqR4/rE/l3Gd/Yn9mLm9dM5zzhnQseydjTI3hzxLJMGCDqm5U1WxgJjChyDb9gO+813OLWX8YcYMknQS87y16FZhYVQGb6vf6z5uZ8sqvdGjekNk3jCa2a8tAh2SMOUr+TCQdgK0+7xO9Zb6WA+d5r88FmohIK+99uIjEichCEZnoLWsF7FXV3FKOCYCITPX2j0tNTa3kqZiqlp+vPPjZav7x0SrG9Iri/etG0amljchrTG0U6AGJbgNOFJGlwIlAEpDnreuiqrHApcDjItL9aA6sqtNVNVZVY6Oioqo0aFM5Wbl53PLOMv43fyNXjOjC9CtjaWw9s4yptfz515sEdPJ539FbVkhVk/FKJCLSGDhfVfd665K8540iMg8YDHwANBeREK9UcsQxTc2272AOf3o9joUbd3PHuD5ce2I3G9bdmFrOnyWSX4GeXi+rMOASYI7vBiISKSIFMdwFvOwtbyEiDQq2AUYD8aqquLaUC7x9JgMf+fEcTBVK3nuQi57/mcVb9vDfi2O4bkx3SyLG1AF+SyReieFG4EtgNfCuqq4SkWkiUtALawywVkTWAW2Af3vL+wJxIrIclzj+o6rx3ro7gL+IyAZcm8lL/joHU3XWbEvjvGcXkLT3IDOuGsa5g61nljF1hbiL/LotNjZW4+LiAh1GvbUgYSd/em0xjRoE88qUYfRr3zTQIRljykFEFntt1aWyFk7jVx8tS+K295bTtVUEM/4wzMbMMqYOskRi/EJVmT5/Iw9+vobh0S2ZfkUszRqFBjosY4wfWCIxVS4vX/nXJ/HMWLCZMwe247GLYmgQEhzosIwxfmKJxFSpzJw8bp25jC9WbeOPx0Vz9/i+NmaWMXWcJRJTZfYcyOaa1+JY/Pse/nFWP64+LjrQIRljqoElElNpmTl5vLFwC0/P3UBGdh5PTxrCmQPbBTosY0w1sURiKiwvX5m9NInHvl5H0t6DHN8zkrvO6Gvde42pZyyRmKOmqsxdu4OHPl/L2u37GdChGQ9fMJDRPSIDHZoxJgAskZijsuT3Pfzn8zUs2rSbrq0a8fSlgxnfv501qBtTj1kiMeWyYUc6//flGr5ctZ3Ixg3418T+XHJsJ0KDAz2AtDEm0CyRmFJt25fJE9+u4924RMJDgvjLqb24+rhoImzYd2OMx34NTLGycvN44pv1vPzTJvLylStHduHGsT1o1bhBoEMzxtQwlkjMEVSVe2at5L3FiUwc1J6/ntbbZi80xpTIEok5wtuLtvLe4kRuPqkHfzmtd6DDMcbUcNZSag6zbOte7puzihN7RXHLKb0CHY4xphawRGIK7UrP4vo3FtO6aQOeuGQQwdal1xhTDla1ZQDIzcvnpreXsutANh9cN4rmjcICHZIxppawRGIAeOSrdSxI2MX/XTCQ/h2aBTocY0wt4teqLREZJyJrRWSDiNxZzPouIvKtiKwQkXki0tFbPkhEfhaRVd66i332mSEim0RkmfcY5M9zqA++WJnC898ncNnwzlwY2ynQ4Rhjahm/JRIRCQaeAc4A+gGTRKRfkc0eAV5T1YHANOBBb3kGcKWqHgOMAx4XkeY++92uqoO8xzJ/nUN9sGFHOre9t4JBnZpz79lFvx5jjCmbP0skw4ANqrpRVbOBmcCEItv0A77zXs8tWK+q61R1vfc6GdgBRPkx1nopPSuXa99YTIOQIJ67fIjNYmiMqZAyE4mInC0iFUk4HYCtPu8TvWW+lgPnea/PBZqISKsinz8MCAMSfBb/26vy+q+IFHurtYhMFZE4EYlLTU2tQPh1m6pyx/sr2JiazlOTBtOuWcNAh2SMqaXKkyAuBtaLyMMi0qeKP/824EQRWQqcCCQBeQUrRaQd8Dpwlarme4vvAvoAxwItgTuKO7CqTlfVWFWNjYqywkxRL/6wiU9/S+GOcX0YZcO/G2MqocxEoqqXA4NxJYIZXiP4VBFpUsauSYBvy21Hb5nvsZNV9TxVHQz83Vu2F0BEmgKfAn9X1YU++6SokwW8gqtCM0fh54Rd/OeLNZzRvy1TT+gW6HCMMbVcuaqsVDUNeB/XztEOVw21RERuKmW3X4GeIhItImHAJcAc3w1EJNKn2uwu4GVveRgwC9cQ/36Rfdp5zwJMBFaW5xyMk7LvIDe9vYSurRrxfxfG4P4ZjTGm4srTRnKOiMwC5gGhwDBVPQOIAf5a0n6qmgvcCHwJrAbeVdVVIjJNRM7xNhsDrBWRdUAb4N/e8ouAE4ApxXTzfVNEfgN+AyKBB47ifOu17Nx8rn9zCQez8/jfFUNpbEPBG2OqgKhq6RuIvAq8pKrzi1l3sqp+66/gqkpsbKzGxcUFOoyA+8fslby+cAvPXjaE8QPaBTocY0wNJyKLVTW2rO3Kc0l6H5Dic+CGQBtV3VwbkohxPlicyOsLtzD1hG6WRIwxVao8bSTvAfk+7/O8ZaaW+Oy3FO768DdGdGvJ3063YeGNMVWrPIkkxLuhEADvtY3oV0u8vnALN7y1hAEdm/H85UMJsTnWjTFVrDy/Kqk+jeOIyARgp/9CMlVBVXns63X8Y/ZKTurdmjeuHm4j+hpj/KI8bSTX4npKPQ0I7m71K/0alamUvHzlntkreXvR71w4tCMPnjfASiLGGL8pM5GoagIwQkQae+/T/R6VqbDMnDxumbmUL1dt5/ox3bn99N52r4gxxq/KdSOBiJwJHAOEF/woqeo0P8ZlKmDfwRyueS2ORZt2c+9Z/fjDcdGBDskYUw+UmUhE5HmgETAWeBG4AFjk57jMUdqRlsmVLy8iITWdJy4ZxIRBRcfHNMYY/yhPxfkoVb0S2KOq9wMjgV7+DcscjY2p6Zz33AJ+353By1OOtSRijKlW5anayvSeM0SkPbALN96WqQGWb93LVTN+BWDm1BEM7Ng8sAEZY+qd8iSSj73ZCf8PWAIo8II/gzLl88P6VP70+mJaRoTx2h+G0S2qcaBDMsbUQ6UmEm9k3m+9od0/EJFPgHBV3VcdwZmSfbQsidveW073qMa89odhtG4aHuiQjDH1VKltJN5kUs/4vM+yJBJ4byzcwi0zlzGkcwvevXakJRFjTECVp7H9WxE5X+xmhBrh899S+MdHKzmlb2te/cMwmoaHBjokY0w9V55E8ifcII1ZIpImIvtFJM3PcZlixG3eza3vLGNwp+Y8fekQwkODAx2SMcaU6872sqbUNdUgITWdP74WR/vmDXlx8rE1M4ms/QKSl0LsVdCkbaCjMcZUk/LckHhCccuLm+jK+Efq/iymvLKIYBFmXHUsLSNq4OCLS16Dj28BzYcfH4NBl8Kom6FV90BHZkzNkJsN23+DpCWQtBgie8Fxf4Y60GpQnu6/t/u8DgeGAYuBk/wSkTnMgaxc/jDjV3buz2bm1BF0aRUR6JCOtOBp+Orv0P0kOPVfEPcSLH0TFr8K/SbAcbdC+8GBjtKY6qMKuze6hJEY5563rYA8b0aO8Oaw/G3YlwjjH4Gg2j2oanmqts72fS8inYDHy3NwERkHPAEEAy+q6n+KrO8CvAxEAbuBy1U10Vs3GbjH2/QBVX3VWz4UmAE0BD4DbtGy5guupXLz8rnxrSWsSt7HC1fGEtOpeaBDOpwqzP03zP8/lzDOewFCGsBZ/4UT74RfnoNfX4L42dBtrEso0SfWiSswU812b4QfHoWN86FNP+gQCx2GuEfDFoGODtJTIXnJoaSRtBgy97p1oY3chdTwa6HDUOgYC007wDf3wU+Pu1L8mY/V6mRS5pztR+zgem+tUtV+ZWwXDKwDTgUSgV+BSaoa77PNe8AnqvqqiJwEXKWqV4hISyAOiMXdALkYGKqqe0RkEXAz8AsukTypqp+XFkttnLNdVbl71m+8vWgr/z63P5cN7xLokA6Xnw9f3AGLpsPgK+DsJyComHabzH0Q9wosfBbSt7s/qOP+DH3OKn57U7rdm2DPZmjSDpq0cVe2dTkx70qA+Y/AincgOBR6nAI718POdbifBqBVD/cD3SHWPbft7y5oqkp2BqQlQ1oi7EuCtCRXkkhLOvQ+y+t/JEHQ+hgvyXlJI7I3BBdzza4K305zVcFDJsNZj9e4ZFJlc7aLyFMUfmMEAYNwd7iXZRiwQVU3eseZCUwA4n226Qf8xXs9F5jtvT4d+FpVd3v7fg2ME5F5QFNVXegtfw2YCJSaSGqjZ+Zu4O1FW7l+TPeal0TycuCjG9wf98gb4bQHSv4xC2/mSiLDr4UVM+GnJ+DdK6Fldxh9C8RcUrV/9HXZph/gzQsh9+ChZSHh0LjNocTSuK3r6FDwKHjfqGXg4q6InRtcSfe3dyG4gfv/M/rmQ504Mve5jh1Ji12bw8bv3f9HgOAwaDvgUHJp2s61T+RmQl6We13wfMSyLLds//ZDiePg7iPji4iCZh1dG2C3E6F5Z3eR1C4GwspZ/SwCJ9/rks8Pj7iSydlP1rhkUh7laSPxvZTPBd5W1Z/KsV8H3CRYBRKB4UW2WQ6ch6v+OhdoIiKtSti3g/dILGb5EURkKjAVoHPnzuUIt+b4YHEij3y1jnMHd+D2mjbHek4mvH8VrP0MTroHjr+tfFfEoeEwdIorvayeAz8+Dh/fDHP/H0x8xl1pmpJtWQBvXQQtusC4ByFjN+zfBvtTXElv/zbYHg8Jcw9dHftqFAmt+7pHVB9o3Q9a96kZ1UK+Ute5BLLyfZckR1zvLjgatz58u/Bm0G2Me4C7uk9LhqS4Q8ll6ZuuxFwu4i5oghu458atXfVTx2Pdc7OO3nMH91xVFz8i7u9IgmD+w+48znmy1pXWy5NI3gcyVTUPXJWViDRS1Ywq+PzbgKdFZAowH0gC8qrguKjqdGA6uKqtqjhmdfhhfSp3fLCCUd1b8dD5A2vWpFRZ+2HmpbBpvmsgHHbN0R8jKBiOORf6TYSN8+Dzv8HsG+CmOGhgPc2L9fsvriTStANcOceVPEqTfcAllvTtLtGkJUPqWkhdA8vegmyfuematDs8sbTuB1G9q/+72LHG/ZCu/NC1KYy6CUbeBI2jyre/iPuRb9bBtdcB5Oe5887Y5ZJSSNihRFGYNLxlwaGBqyIUgZP+7pLJ9/9xJZMJT1dNMtmVUC09J8uTSL4FTgEK/vc1BL4CRpWxXxLQyed9R29ZIVVNxpVI8GZgPF9V94pIEjCmyL7zvP07lnbM2iw+OY3r3lhCj9aNef6KoYSF1KAibsZuePMCSF4G5/7PVUlVhgh0HwsTnoWXTnENqafcVxWR1i2Ji+GN81311eSPy04i4KpWWnUv/gdE1dXv71gNqavd847VEPfy4VVmkb1h+FQYdBmENqy68ylqe7xLIKtmu7iPu9VVl0ZEVv7YQcGuYb62GHuXSybz/p9LJhOfrVgyUYWNc+HH/7qLvut/cRcJflSeRBLuO72uqqaLSKNy7Pcr0FNEonE/9pcAl/puICKRwG5vTK+7cD24AL4E/p+IFJS7TwPuUtXd3t31I3CN7VcCT5Ujlhovee9BrpqxiMYNQnjlqmNr1tAnaSnw+rmu58zFr0OfM6vu2J2OhZhJ8PMzrtrL7js5JHmp+3ePaOWSSNMqmL1BBJp3co9epx1anp8He7ccSixrP4NP/wrz/gMjroPYq6Fh88p/fsFnbZwLi2fA6o8hrDEc/xcYcYM71/pszB0umcx9wCWTc58vfzLJz4P4j1wC2bbClTZP/ZcrpflZeRLJAREZoqpLoLD77cEy9kFVc0XkRlxSCAZeVtVVIjINiFPVObhSx4MioriqrRu8fXeLyL9wyQhgWkHDO3A9h7r/fk4daGjfdzCHKa8sIiMrj/euG0m7Zn68AjxauzfB6xPhwE64/H2ILvb+1Mo55T73g/Ll3+HSmVV//NooZQW8NtG1BUz+2P8/BkHB0LKbe/Q5E47/K2z+0f0ofTsNfvivG7FgxPUVT2jb4929EyvehfRtrsfZCbe7Y9a2zgD+dOLtLuF/9y8vmfyv+F5fBXIyYflb8NOTsGeT68V2zlMw8OJq68hSZvdfETkWmAkkAwK0BS5W1cX+D69q1OTuv1m5eUx5+VfituxmxlXDGN2jCor0VWXHavdjlpcFl30AHYf677N+fBy++af7nJ71vOF9+yqYcZZrK7jqU2jRNbDxpCx3ve1WzYKgEFeCHH1L+UqP6anw23sugWxb4fbvebqrGu11uvXYK80Pj8G398Mx57l7tIomk8x9rkry52fhwA5oP8TrWn9mlTXWl7f7b7nuIxGRUKCg+9BaVc2pZHzVqiYnkn9/Gs8LP2zisYtiOG9Ix7J3qC67N8ILJ7mGyCtnu94+/pSbBc+OAAmG6xa4RlB/ycuFnAPu/oCcDNc47fucc9A9epxSLdUCh9mxBmac6Rp/p3xas6r6dm+EBU+53lB52dDvHBh9q7tnwldOJqz7HJbPhPVfg+a5rrExk6D/+VXT/lFfFFxg9ZsI57/o/l/s3wYLn3NJJCvNjSgx+lZXW1DFHQaq8j6SG4A3VXWl976FiExS1WerIM56beHGXbz44yYuG965ZiURcMXknINwzXeuusPfQhrAuP+4Lq6LpsOoG6vu2Aufc8O4ZO93ySO/nNdBzTvD1O+rr9pl53p49Wx3NTn5k5qVRMD9PygcteB5+PVFVycffaK7Eg5t5Eoeqz50V8tN2rveVzGT/N7YW2cdd6trM/n6H5Cf65Lwsrfd/+F+E1wCaT8owEGWr2prmaoOKrJsqarWmsGTamKJZH9mDmc88QPBQcJnNx9PRIPyNFdVk4zd8Fg/GHihq2utTm9cAFt/gZsWH3nvQEWs/ADe/wN0GQ1t+rseSGER7kcvrBGERnjPjQ5flpboutx2GQ2Xf+D/fv27ElxJJD/XlUSiatj9Q8UpOmoBuH/Dvue4qqvoE2rd/RA1VsF4dsENvAFRb6qWC40qK5EAwSIiBeNZeUOf1MDhZ2uXBz5ZTfLeg7z7p5E1K4kALHnVdQUdfm31f/a4B10V17f3w4Rnyt6+NFsXwazroPMouGLW0dXHR/aAMx+FOTe5xuZT769cLKXZvcmVRPKyXUmkNiQROHzUglWz3LK+Z9n9QP4w6kZ3c2SLLjVyioby/IJ9AbwjIv/z3v+JOtBTKpC+id/OO3FbuW5Md2K71rDeKnk5sOgFV13R5pjq//zInq676YKnXZfTovXv5bVnC7w9CZq2h4vfqFij7pAr3R3SPz3u6viPmVixWEqz93eXRHIyXO+s2nTfQ4HQcBg0KdBR1H2diw4MUnOU5463O4DvgGu9x2+4rremAnalZ3Hnhyvo07YJt57SM9DhHGn1x24QuhHXBS6GE/7mxjL6/A43OOTRytwHb13s6pEve69y9yac8ZC7Epx9vevFVpX2JbreWVlpcMVsNz6UMbVQmYnEu1nwF2AzbiDGk4Aq/ouqH1SVv89aSdrBXP578SAahNTA+uOFz0GLaNdFM1DCm7p7SxIXuUH7jkZeLrw3BXatdyWRyEom65AGcNHrrl1l5mVwcG/ljlcgZQW8eAoc3OOq3WpAg6kxFVViIhGRXiLyTxFZg7t7/HcAVR2rqk9XV4B1yexlSXyxaht/Oa0Xfds1DXQ4R0pc7H68h18b+BFIYya50Vu//qcb46s8VOHz2yHhO9e7qKpunmzaDi56zd35PetPFSsl+Vr/NbxyhuuNc9Xn7jyNqcVK+7VYgyt9nKWqx6nqU1TRgIr1UfLeg9z70Spiu7TgmuOroTttRfzyHDRoCoMvC3QkLpGd8bC7A/qHR8u3T0Hf+tG3uvaNqtRlJJz+IKz7wo0NVVG/vuSq3Vp2gz9+6+bOMKaWKy2RnAekAHNF5AURORl3Z7s5Svn5yu3vLycvX3n0ohiCg2rgP2Naiut5M/jymtPrpmMsxFzqxuHalVD6tms/hy/vhr5nw8n/9E88w65xJaV5D8LaL45u3/x8+Ooe+PQv7kbHqz6vmrGzjKkBSkwkqjpbVS8B+uAmnboVaC0iz4nIaSXtZ4702s+b+WnDLu45s1/NnHMd3M1l+XkwbGqgIzncKf90ExV9+feSt0lZAe9f7doZzp3uv2o5EVdl1i4GPpxadnIrkHMQ3pvs7go/9o9wyVvQoLF/YjQmAMrT2H5AVd/y5m7vCCzF9eQy5bBhRzoPfr6GMb2jmDSsU9k7BELOQVcl1Hs8tIwOdDSHa9LWDey37nNY/82R69NSXFVRw+Ywaaa7odCfQhu6RvygYDc3S1ntN+mprnvv6o/htH+7eVxKG4DPmFroqC7dVHWPqk5X1ZP9FVBdkpuXz1/fXUbDsGAermmTVPn67T03nWggu/yWZsR1bmreL+50U6IWyD4Ab1/ius9e+k713ajVvDNc+IqbN/yjG1wjf3FS18GLJ8O2lW74/VE31u351U29VYNmTqp7np2XwPLEfTwwsT+tm4YHOpziqbpG6jYDoOtxgY6meCEN3B3vu9Yfmjo1P99VL21bARe8XP33YHQbA6fc78aa+unxI9dv/tFN2JWT4YY86Xt29cZnTDWyROInvyXu48lv13NOTHvOGtg+0OGUbNN82BEPI66t2VfLvU6HnqfB9w9B+g43IuqaT1xPql4Buudl1E1uiO9vp7kuxwWWv+OG32/cBv74jX+H3zemBrBE4geZOXn8+d1ltGocxrQJARhm5GgsfA4aRUL/CwIdSdlOf9C157w2ARY86Rquh/8pcPGIuLm1o/q4gSH3bIZ5D8GsqdB5BFz9VeDnEjGmGlgi8YNHvlzLhh3pPHxBDM0b1eDxLXcluPsiYv/gxkuq6SJ7uJLTjnjXhXbcQ4EvRYVFuMZ3zYfnj3fzbQ+8BC7/EBq2KHt/Y+oA6z5SxX5O2MVLP23i8hGdObFXVKDDKd2i6W7GumOvDnQk5TfmLmjexU0jWlN6P7XqDue9CO9e6eI78Y7AJzhjqpFfSyQiMk5E1orIBhG5s5j1nUVkrogsFZEVIjLeW36ZiCzzeeSLyCBv3TzvmAXrqmDSiqqRl5tL2ltXcXazTdw93s8zClZW5j5Y+gb0P69GDktdorAId2NgeA0bYqbXaXBXIoy505KIqXf8dknnzVvyDHAqkAj8KiJzVDXeZ7N7gHdV9TkR6Qd8BnRV1TeBN73jDABmq+oyn/0uU9WaNVMVkLzmF07P+55jokJpFFaFM/z5w9I3ITu95nb5rY1qSgnJmGrmzxLJMGCDqm5U1WxgJjChyDYKFFxaNgOSiznOJG/fGm9//FcAtN+5wM1bXVPl57mpUjuNcPNsGGNMJfgzkXQAtvq8T/SW+boPuFxEEnGlkZuKOc7FwNtFlr3iVWv9Q0q4y09EpopInIjEpaamVugEjlajxB/I1hCCcjNct9qaat0XbiRbK40YY6pAoHttTQJmqGpHYDzwuogUxiQiw4EMVV3ps89lqjoAON57XFHcgb078GNVNTYqqhoavbMz6JC2gi/DT4ewxrD2M/9/ZkUtfA6adYI+ZwU6EmNMHeDPRJIE+A4u1dFb5utq4F0AVf0ZCAcifdZfQpHSiKomec/7gbdwVWgBp1sWEEoO29uOgR4nu6v+ys5b4Q8pK2DzD67B2ur0jTFVwJ+J5Fegp4hEi0gYLinMKbLN78DJACLSF5dIUr33QcBF+LSPiEiIiER6r0OBs4CV1AAZa74hS0MI736cG/xwfwqkLAt0WEf65X8Q2qjq5+swxtRbfrskVdVcEbkR+BIIBl5W1VUiMg2IU9U5wF+BF0Tkz7iG9ymqhSPgnQBsVdWNPodtAHzpJZFg4BvgBX+dw9HIT5jLkvxe9O7cFlq3dbPfrf0MOgwJdGiHpKe6qWsHX2E3yxljqoxf6zZU9TNcI7rvsnt9XscDo0vYdx4wosiyA0DNG7gofQdN9q7hh/yLuK5tEwgPhc4j3WRLJ90T6OgOWfwK5GW7qXSNMaaKBLqxvW7Y+D0ACU2OpUl4qFvWezxsXwl7tgQwMB+5WW7yqh6nQFSvQEdjjKlDLJFUhY3zSKMxIR0HHVrW+wz3vO4op2T1l1WzIH27dfk1xlQ5SySVpUp+wnf8mNePvu192h1adYfI3rDm08DFViA3C35+GiJ7QXebk8wYU7UskVTWzvUE7U/mx/wBHNO+2eHrep8BW36Cg3sDEhrghl2feSls+83GgTLG+IUlksraOBeAH/L70699kYEE+5wJ+bmwoZi5xqtDVjq8eSFs+BbOfhL6nx+YOIwxdZolksraOI9doe04GNGJ1k0aHL6uw1CIiHK9t6pb5j5443zYsgDOmw5DJ1d/DMaYesESSWXk5cCmH1gUFEPfdk05YtivoGA3Dez6r9221SVjt5tFMCkOLnwFBl5UfZ9tjKl3LJFURtJiyN7PZwf6HNk+UqD3eMja59pKqkN6Krx6NmxfBRe/Cf2KDrhsjDFVyxJJZWychyLMz+13ZPtIgW5jICS8eqq30lJgxng3he6l70Dvcf7/TGNMvWeJpDIS5rKnWT/20Zh+7UpIJGER0G2sGy6lcPQXP9j7O7xyBqQlw+UfQPeT/PdZxhjjwxJJRWWmQeKvrGo4lIahwURHRpS8be8z3A/9jviSt6mM3RvhlfGubeSK2dC12FFnjDHGLyyRVNTmH0Hz+C77GPq0a0JwUCn3Z/TyqpjW+GGOktS18PIZkH0AJs+BTsdW/WcYY0wpLJFU1MZ5aEhDPtrVkWNKah8p0KQNdIit+smutq10JRHNhymfQvtBVXt8Y4wpB0skFbVxLpnth7M7S+jXroQeW776jIfkJa5BvCokLYFXz4LgMLjqM2jTr2qOa4wxR8kSSUXsS4Kd69jS3E3OWGaJBFw3YKiaQRy3/uruE2nQxCWRyJ6VP6YxxlSQJZKK2DgPgEUSQ5BA77ZNyt4nqg+06Fr56q2M3fDO5dCoFVz1ObSMrtzxjDGmkiyRVMTGuRARxfy9UXSPakx4aHDZ+4i4UsnG790YWBWhCp/cChm74KJXoVnHih3HGGOqkCWSo5Wf70ok3cawalt6+aq1CvQeD3lZhQM9HrXlMyH+Ixh7N7SLqdgxjDGmivk1kYjIOBFZKyIbROTOYtZ3FpG5IrJURFaIyHhveVcROSgiy7zH8z77DBWR37xjPilHDHDlZzvi4UAq6R2PJ2VfZsl3tBen8wgIb16xu9z3bIHPbofOo2D0LUe/vzHG+InfEomIBAPPAGcA/YBJIlK0a9E9wLuqOhi4BHjWZ12Cqg7yHr6TjD8HXAP09B7VOw6IV5qIDx8CUPIYW8UJDoWep7kG9/y88u+XnwezvZkNz33eDQZpjDE1hD9LJMOADaq6UVWzgZlA0REEFSi4pG8GJJd2QBFpBzRV1YWqqsBrwMQqjbosCXMhshfL9jUCKHlolJL0PsO1cWxdVP59FjzlBn0c/zC06HJ0n2eMMX7mz0TSAdjq8z7RW+brPuByEUkEPgNu8lkX7VV5fS8ix/scM7GMYwIgIlNFJE5E4lJTUytxGj5yMt38Ht3Gsio5jfbNwmkREXZ0x+hxCgSFlr/3VsoK+O4B6HsOxEw6+piNMcbPAt3YPgmYoaodgfHA6yISBKQAnb0qr78Ab4nIUV36q+p0VY1V1dioqKiqiTZxEeQehO5jiU9OO7r2kQLhTSH6+PK1k+RkwodTXVffs5+waXKNMTWSPxNJEtDJ531Hb5mvq4F3AVT1ZyAciFTVLFXd5S1fDCQAvbz9ffu8FndM/0mYCxLMwfYjSEhNP/pqrQK9x8Ou9bBzfenbfXs/pK6Gic9Ao5YV+yxjjPEzfyaSX4GeIhItImG4xvQ5Rbb5HTgZQET64hJJqohEeY31iEg3XKP6RlVNAdJEZITXW+tK4CM/nsPhNs6Fjseydq+Qr9DvaBrafRUM4lha9VbCXFj4LBx7jasOM8aYGspviURVc4EbgS+B1bjeWatEZJqInONt9lfgGhFZDrwNTPEa0U8AVojIMuB94FpV3e3tcz3wIrABV1KpngnRM3ZD8rLCai0o59AoxWneCdoOKLl6K2M3zL4eInvBqdMq9hnGGFNNQvx5cFX9DNeI7rvsXp/X8cARk2eo6gfAByUcMw7oX7WRlsOm+YC6GxEX76NJeAgdWzSs+PF6nwnzH4YDOyEi8vB1n90GB3bApLcgrFGlwjbGGH8LdGN77bFxLoQ1gQ5DiU9Jo1+7plTqXsjeZ7jh39d/dfjyFe/Byg9gzJ3QfnDlYjbGmGpgiaS8EuZC9PHkSQhrUvYf3Y2IxWkXA03aw5pPDy3buxU+/St0Gg6j/1y54xtjTDWxRFIeuzfB3i3QbSybdh7gYE5exbr++hJxpZKE71w33/x8d/e65sG5/4Ngv9Y6GmNMlbFEUh4Fgyx2G8Oq5H1ABe5oL06f8ZCT4dpfFj4Dm3+Acf+xoeGNMbWKXfaWR8JcaNoBInsSH7eGsOAgerRuXPnjdj0ewhrDgidh6y/Q5ywYfHnlj2uMMdXISiRlyc9zJYZuY0GE+OQ0erZpTFhIFfzThTSAHie7kkh4c7t73RhTK1kiKUvKMsjcC93GoKrEJ6dV/P6R4vSbCAhMePrIbsDGGFMLWNVWWRIOtY/s2J/FrgPZVdM+UuCYc908JU3bV90xjTGmGlmJpCwb50GbAdA4qrCh/ZgOlez660vEkogxplazRFKa7AzXCN59DEDh0Ch92jYJYFDGGFOzWCIpzZYFkJcN3cYAsCo5ja6tGtEkPDSwcRljTA1iiaQ0G+dCcJibJx3c0ChV2dBujDF1gCWS0uz93TWEhzVif2YOW3ZlVG1DuzHG1AHWa6s0F7/uhi8BVqfsB6j8GFvGGFPHWImkLKHhAMQXDI1iVVvGGHMYSyTltCo5jcjGYbRu0iDQoRhjTI1iiaSc4lPS6FvZOUiMMaYOskRSDtm5+azbXgVzkBhjTB3k10QiIuNEZK2IbBCRO4tZ31lE5orIUhFZISLjveWnishiEfnNez7JZ5953jGXeY/W/jwHgA070snJU2sfMcaYYvit15aIBAPPAKcCicCvIjLHm6e9wD3Au6r6nIj0w83v3hXYCZytqski0h/4Eujgs99l3tzt1SI+xd3Rbl1/jTHmSP4skQwDNqjqRlXNBmYCE4pso0DBr3MzIBlAVZeqarK3fBXQUEQC1sq9KnkfDUODiY6MCFQIxhhTY/kzkXQAtvq8T+TwUgXAfcDlIpKIK43cVMxxzgeWqGqWz7JXvGqtf0gJrd8iMlVE4kQkLjU1tcInAW6MrT7tmhAcZA3txhhTVKAb2ycBM1S1IzAeeF1ECmMSkWOAh4A/+exzmaoOAI73HlcUd2BVna6qsaoaGxUVVeEAVZX4lCqeg8QYY+oQfyaSJKCTz/uO3jJfVwPvAqjqz0A4EAkgIh2BWcCVqppQsIOqJnnP+4G3cFVofpO45yD7M3Pp1856bBljTHH8mUh+BXqKSLSIhAGXAHOKbPM7cDKAiPTFJZJUEWkOfArcqao/FWwsIiEiUpBoQoGzgJV+PIdDc5BYicQYY4rlt0SiqrnAjbgeV6txvbNWicg0ETnH2+yvwDUishx4G5iiqurt1wO4t0g33wbAlyKyAliGK+G84K9zANc+EiTQ2+YgMcaYYvl10EZV/QzXiO677F6f1/HA6GL2ewB4oITDDq3KGMsSn5JG96jGhIcGV+fHGmNMrRHoxvYab1WyNbQbY0xpLJGUYveBbFL2Zdod7cYYUwpLJKUomKPdxtgyxpiSWSIpRXyKNweJDY1ijDElskRSilXJabRvFk6LiLBAh2KMMTWWTbVbil5tmtCuWcNAh2GMMTWaJZJS3DC2R6BDMMaYGs+qtowxxlSKJRJjjDGVYonEGGNMpVgiMcYYUymWSIwxxlSKJRJjjDGVYonEGGNMpVgiMcYYUyni5pGq20QkFdhSwd0jgZ1VGE5tUp/PHer3+dfnc4f6ff6+595FVaPK2qFeJJLKEJE4VY0NdByBUJ/PHer3+dfnc4f6ff4VOXer2jLGGFMplkiMMcZUiiWSsk0PdAABVJ/PHer3+dfnc4f6ff5Hfe7WRmKMMaZSrERijDGmUiyRGGOMqRRLJKUQkXEislZENojInYGOpzqJyGYR+U1ElolIXKDj8TcReVlEdojISp9lLUXkaxFZ7z23CGSM/lLCud8nIkne979MRMYHMkZ/EZFOIjJXROJFZJWI3OItr/PffSnnftTfvbWRlEBEgoF1wKlAIvArMElV4wMaWDURkc1ArKrWi5uyROQEIB14TVX7e8seBnar6n+8C4kWqnpHIOP0hxLO/T4gXVUfCWRs/iYi7YB2qrpERJoAi4GJwBTq+HdfyrlfxFF+91YiKdkwYIOqblTVbGAmMCHAMRk/UdX5wO4iiycAr3qvX8X9kdU5JZx7vaCqKaq6xHu9H1gNdKAefPelnPtRs0RSsg7AVp/3iVTwH7mWUuArEVksIlMDHUyAtFHVFO/1NqBNIIMJgBtFZIVX9VXnqnaKEpGuwGDgF+rZd1/k3OEov3tLJKYkx6nqEOAM4Aav+qPeUlcHXJ/qgZ8DugODgBTg0YBG42ci0hj4ALhVVdN819X1776Ycz/q794SScmSgE4+7zt6y+oFVU3ynncAs3BVffXNdq8euaA+eUeA46k2qrpdVfNUNR94gTr8/YtIKO6H9E1V/dBbXC++++LOvSLfvSWSkv0K9BSRaBEJAy4B5gQ4pmohIhFe4xsiEgGcBqwsfa86aQ4w2Xs9GfgogLFUq4IfUc+51NHvX0QEeAlYraqP+ayq8999Sedeke/eem2Vwuv29jgQDLysqv8ObETVQ0S64UohACHAW3X93EXkbWAMbgjt7cA/gdnAu0Bn3DQEF6lqnWuULuHcx+CqNhTYDPzJp82gzhCR44AfgN+AfG/x3bi2gjr93Zdy7pM4yu/eEokxxphKsaotY4wxlWKJxBhjTKVYIjHGGFMplkiMMcZUiiUSY4wxlWKJxJgKEpE8nxFSl1XlCNEi0tV3NF5jarKQQAdgTC12UFUHBToIYwLNSiTGVDFvLpeHvflcFolID295VxH5zhsM71sR6ewtbyMis0RkufcY5R0qWERe8OaK+EpEGnrb3+zNIbFCRGYG6DSNKWSJxJiKa1ikautin3X7VHUA8DRudASAp4BXVXUg8CbwpLf8SeB7VY0BhgCrvOU9gWdU9RhgL3C+t/xOYLB3nGv9c2rGlJ/d2W5MBYlIuqo2Lmb5ZuAkVd3oDYq3TVVbichO3ERCOd7yFFWNFJFUoKOqZvkcoyvwtar29N7fAYSq6gMi8gVuIqrZwGxVTffzqRpTKiuRGOMfWsLro5Hl8zqPQ22aZwLP4Eovv4qItXWagLJEYox/XOzz/LP3egFuFGmAy3AD5gF8C1wHbopnEWlW0kFFJAjopKpzgTuAZsARpSJjqpNdyRhTcQ1FZJnP+y9UtaALcAsRWYErVUzylt0EvCIitwOpwFXe8luA6SJyNa7kcR1uQqHiBANveMlGgCdVdW8VnY8xFWJtJMZUMa+NJFZVdwY6FmOqg1VtGWOMqRQrkRhjjKkUK5EYY4ypFEskxhhjKsUSiTHGmEqxRGKMMaZSLJEYY4yplP8P6KWpRGxiuvIAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.15931320190429688 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time()\n",
+    "plt.plot(history2.history['accuracy'])\n",
+    "plt.plot(history2.history['val_accuracy'])\n",
+    "plt.title(\"Model Accuracy\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Accuracy')\n",
+    "plt.legend(['Resnet Train', 'Resnet Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ethical-tobago",
+   "metadata": {
+    "papermill": {
+     "duration": 1.373886,
+     "end_time": "2021-04-25T14:39:49.989960",
+     "exception": false,
+     "start_time": "2021-04-25T14:39:48.616074",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6.6 Model 1 (CNN) vs Model 2 (Resnet)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sufficient-insulin",
+   "metadata": {
+    "papermill": {
+     "duration": 1.426784,
+     "end_time": "2021-04-25T14:39:52.799013",
+     "exception": false,
+     "start_time": "2021-04-25T14:39:51.372229",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Loss vs no. of epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "contrary-paragraph",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:39:56.221584Z",
+     "iopub.status.busy": "2021-04-25T14:39:56.214830Z",
+     "iopub.status.idle": "2021-04-25T14:39:56.381275Z",
+     "shell.execute_reply": "2021-04-25T14:39:56.380589Z"
+    },
+    "papermill": {
+     "duration": 1.968325,
+     "end_time": "2021-04-25T14:39:56.381493",
+     "exception": false,
+     "start_time": "2021-04-25T14:39:54.413168",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAEWCAYAAABi5jCmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAABcrUlEQVR4nO3dd3hUVfrA8e+Zkt4rpBGqtIRQpVcpAmIHsYEFrFh+qyiufXXX3VVXUSyIigUFpSiKoNKkd0LvkEAKCem9zMz5/XEnIYGE1ElC5nyeZ57M3Hvn3nMJmXdOe4+QUqIoiqIoJXSNXQBFURSlaVGBQVEURSlHBQZFURSlHBUYFEVRlHJUYFAURVHKUYFBURRFKUcFBkWpghAiXAghhRCGahw7VQixqSHKpSi2ogKD0qwIIWKEEEVCCL9Ltu+1friHN1LRahRgFKUxqcCgNEdngMklL4QQEYBL4xVHUa4uKjAozdE3wL1lXk8Bvi57gBDCUwjxtRDighAiVgjxohBCZ92nF0K8LYRIEUKcBsZV8N7PhRCJQoh4IcQbQgh9XQoshAgSQiwXQqQJIU4KIaaV2ddHCLFLCJElhEgSQrxr3e4khPhWCJEqhMgQQuwUQgTWpRyKAiowKM3TNsBDCNHJ+oF9B/DtJcd8AHgCbYAhaIHkPuu+acB4oDvQC7jtkvfOB0xAO+sxo4AH61jmhUAcEGS93j+FEMOt+94H3pdSegBtgR+s26dY7yEU8AUeBvLrWA5FUYFBabZKag0jgSNAfMmOMsFilpQyW0oZA7wD3GM9ZCLwnpTynJQyDfhXmfcGAmOBp6SUuVLKZOB/1vPVihAiFBgAPCelLJBSRgPzuFjrKQbaCSH8pJQ5UsptZbb7Au2klGYp5W4pZVZty6EoJVRgUJqrb4A7galc0owE+AFGILbMtlgg2Po8CDh3yb4SrazvTbQ232QAnwIBdShrEJAmpcyupDwPAB2Ao9bmovHW7d8AvwMLhRAJQoj/CCGMdSiHogAqMCjNlJQyFq0Teiyw9JLdKWjftluV2RbGxVpFIlrzTNl9Jc4BhYCflNLL+vCQUnapQ3ETAB8hhHtF5ZFSnpBSTkYLPv8GFgshXKWUxVLK16SUnYH+aM1f96IodaQCg9KcPQAMl1Lmlt0opTSjtdO/KYRwF0K0Av6Pi/0QPwBPCCFChBDewPNl3psI/AG8I4TwEELohBBthRBDalAuR2vHsZMQwgktAGwB/mXdFmkt+7cAQoi7hRD+UkoLkGE9h0UIMUwIEWFtGstCC3aWGpRDUSqkAoPSbEkpT0kpd1WyewaQC5wGNgHfAV9Y932G1kSzD9jD5TWOewEH4DCQDiwGWtagaDloncQlj+Fow2vD0WoPy4BXpJSrrcePAQ4JIXLQOqLvkFLmAy2s185C60f5C615SVHqRKiFehRFUZSyVI1BURRFKUcFBkVRFKUcFRgURVGUclRgUBRFUcq56rI8+vn5yfDw8MYuhqIoylVl9+7dKVJK/+oce9UFhvDwcHbtqmwEoqIoilIRIURs1UdpVFOSoiiKUo4KDIqiKEo5KjAoiqIo5Vx1fQyKotRMcXExcXFxFBQUNHZRlAbg5ORESEgIRmPtE+2qwKAozVxcXBzu7u6Eh4cjhGjs4ig2JKUkNTWVuLg4WrduXevzqKYkRWnmCgoK8PX1VUHBDggh8PX1rXPtUAUGRbEDKijYj/r4XdtNYCg4fpzk997DlJ7e2EVRFEVp0uwmMBTFxpL6yaeYEhMbuyiKYnf0ej1RUVF07dqVG264gYyMjAa57nvvvUdeXt5l22+++WaioqJo164dnp6eREVFERUVxZYtW6p13v79+9d3UZsUuwkMBl9fAEypaY1cEkWxP87OzkRHR3Pw4EF8fHyYM2dOg1y3ssCwbNkyoqOjmTdvHoMGDSI6Opro6OjSD3yTyXTF81Y3gFytbBYYhBBfCCGShRAHqziutxDCJIS4zVZlATD4+ABgTku15WUURalCv379iI/Xltc+deoUY8aMoWfPngwaNIijR48C8OOPP9K1a1e6devG4MGDAZg/fz633HILY8aMoX379sycObP0nH/88Qf9+vWjR48e3H777eTk5DB79mwSEhIYNmwYw4YNq7Jc8+fPZ8KECQwfPpwRI0aQk5PDiBEj6NGjBxEREfz888+lx7q5uQGwfv16hg4dym233UbHjh256667aA6Ln9lyuOp84EPg68oOsK5V+2+0NXRtSq9qDIrCa78c4nBCVr2es3OQB6/c0KVax5rNZtasWcMDDzwAwPTp0/nkk09o374927dv59FHH2Xt2rW8/vrr/P777wQHB5drdoqOjmbv3r04OjpyzTXXMGPGDJydnXnjjTdYvXo1rq6u/Pvf/+bdd9/l5Zdf5t1332XdunX4+flVq3x79uxh//79+Pj4YDKZWLZsGR4eHqSkpNC3b18mTJhwWefu3r17OXToEEFBQQwYMIDNmzczcODA6v3jNVE2CwxSyg1CiPAqDpsBLAF626ocJXRubgijUdUYFKUR5OfnExUVRXx8PJ06dWLkyJHk5OSwZcsWbr/99tLjCgsLARgwYABTp05l4sSJ3HLLLaX7R4wYgaenJwCdO3cmNjaWjIwMDh8+zIABAwAoKiqiX79+tSrnyJEj8bG2LkgpeeGFF9iwYQM6nY74+HiSkpJo0aJFuff06dOHkJAQAKKiooiJiVGBobaEEMHAzcAwqggMQojpwHSAsLCw2l4Pva+vqjEodq263+zrW0kfQ15eHqNHj2bOnDlMnToVLy8voqOjLzv+k08+Yfv27axYsYKePXuye/duABwdHUuP0ev1mEwmpJSMHDmS77//vs7ldHV1LX2+YMECLly4wO7duzEajYSHh1c4P6CiMl3tGrPz+T3gOSmlpaoDpZRzpZS9pJS9/P2rlU68QgZfX0yqxqAojcbFxYXZs2fzzjvv4OLiQuvWrfnxxx8B7Rv6vn37AK3v4dprr+X111/H39+fc+fOVXrOvn37snnzZk6ePAlAbm4ux48fB8Dd3Z3s7OxalTUzM5OAgACMRiPr1q0jNrbaWauveo0ZGHoBC4UQMcBtwEdCiJtseUG9rw9mVWNQlEbVvXt3IiMj+f7771mwYAGff/453bp1o0uXLqUdvM8++ywRERF07dqV/v37061bt0rP5+/vz/z585k8eTKRkZH069evtBN7+vTpjBkzplqdz5e666672LVrFxEREXz99dd07Nixdjd8FRK27EG39jH8KqXsWsVx863HLa7qnL169ZK1Xagn4flZ5G7fTvt1a2v1fkW5Gh05coROnTo1djGUBlTR71wIsVtK2as677dZH4MQ4ntgKOAnhIgDXgGMAFLKT2x13SvRagypSClVigBFUZRK2HJU0uQaHDvVVuUoy+DjiywqwpKbi946DllRFEUpz25mPoNWYwAwp6oOaEVRlMrYVWBQaTEURVGqZleBQa/SYiiKolTJbgLD5pMpPPTraUDVGBRFUa7EbgKDTgi2pmhz6VSNQVEaVlNLu/3aa68xa9asctuio6OvOKz31Vdf5e233wbg5ZdfZvXq1Zcds379esaPH3/FMkVHR/Pbb7+Vvl6+fDlvvfXWFd/T0OwmMHQJ9qBYb6DY2VXVGBSlgTW1tNuTJ09m0aJF5bYtXLiQyZOrN5jy9ddf57rrrqtVmS4NDBMmTOD555+v1blsxW4Cg4eTkXBfF3Kc3VWNQVEaUVNIu92hQwe8vb3Zvn176bYffviByZMn89lnn9G7d2+6devGrbfeWmFgmTp1KosXa/NxV61aRceOHenRowdLly4tPWbHjh3069eP7t27079/f44dO0ZRUREvv/wyixYtIioqikWLFjF//nwef/xxAGJiYhg+fDiRkZGMGDGCs2fPll7viSeeoH///rRp06b02rbSaEn0GkPXYE9SDC4EqxqDYq9WPg/nD9TvOVtEwPXVawppSmm3J0+ezMKFC7n22mvZtm0bPj4+tG/fHh8fH6ZNmwbAiy++yOeff86MGTMqvJ+CggKmTZvG2rVradeuHZMmTSrd17FjRzZu3IjBYGD16tW88MILLFmyhNdff51du3bx4YcfAlrAKzFjxgymTJnClClT+OKLL3jiiSf46aefAEhMTGTTpk0cPXqUCRMmcNtttlvCxu4CQ7LehaKUlMYuiqLYlaaYdnvSpEn079+fd955p1wz0sGDB3nxxRfJyMggJyeH0aNHV3qOo0eP0rp1a9q3bw/A3Xffzdy5cwEtCd+UKVM4ceIEQgiKi4urLNPWrVtLax333HNPuVrRTTfdhE6no3PnziQlJVV5rrqwq8AQEezJVkc3ilLiGrsoitI4qvnNvr41xbTboaGhtG7dmr/++oslS5awdetWQGu2+emnn+jWrRvz589n/fr1tbrnl156iWHDhrFs2TJiYmIYOnRorc5Touy923qVOLvpYwDoEuRBpqMbIisTaTY3dnEUxe40tbTbkydP5umnn6ZNmzali+1kZ2fTsmVLiouLWbBgwRXvp2PHjsTExHDq1CmAcsEpMzOT4OBgoHxz0ZXK1L9/fxYuXAho60EMGjToite3FbsKDF4uDuDtg5AScwMNl1MUpbymlHb79ttv59ChQ+VGI/3jH//g2muvZcCAAVWm2nZycmLu3LmMGzeOHj16EBAQULpv5syZzJo1i+7du5dbvGfYsGEcPny4tPO5rA8++IAvv/ySyMhIvvnmG95///0rXt9WbJp22xbqknYb4J0XPmLs0g9ovfxnnDp0qMeSKUrTpNJu25+6pt22qxoDQItWLQHISrRt542iKMrVyu4CQ6t2Wjvi2ZPxjVwSRVGUpsnuAsM114QBkHQ2sZFLoiiK0jTZXWDwC/LHLHRkJKimJEVRlIrYXWAQOh35Lu7kJ6tJboqiKBWxu8AAIL280WVmkFNoqvpgRVEUO2OXgcHBzxevwhwOJ2Q1dlEUxS4IIbj77rtLX5tMJvz9/atMUX2p8PBwUqpIaVP2mPvvv5+AgAC6du1a4bFvvvkmUVFRREVFlaYGj4qKYvbs2dUqz4MPPsjhw4drdA9XA7sMDO4tAvAqzOFgfGZjF0VR7IKrqysHDx4kPz8fgD///LN0VrAtTZ06lVWrVlW6/+9//zvR0dFER0eXpu2Ijo7miSeeALTZ2BaLpdL3z5s3j86dO9d7uRubXQYGtxb+eBWpwKAoDWns2LGsWLEC0FJHlJ1tnJaWxk033URkZCR9+/Zl//79AKSmpjJq1Ci6dOnCgw8+WC5H0LfffkufPn2IiorioYcewlxBmpvBgwfjY13St7piYmK45ppruPfee+natSvnzp3jkUceoVevXnTp0oVXXnml9NihQ4dSMuHWzc2Nv//973Tr1o2+ffvaPNGdLdksiZ4Q4gtgPJAspbysHieEuAt4DhBANvCIlHKfrcpTlt7HF2dTIcdiLzTE5RSlyfj3jn9zNO1ovZ6zo09HnuvzXJXH3XHHHbz++uuMHz+e/fv3c//997Nx40YAXnnlFbp3785PP/3E2rVruffee4mOjua1115j4MCBvPzyy6xYsYLPP/8c0Gb2Llq0iM2bN2M0Gnn00UdZsGAB9957b73c04kTJ/jqq6/o27cvoDU5+fj4YDabGTFiBPv37ycyMrLce3Jzc+nbty9vvvkmM2fO5LPPPuPFF1+sl/I0NFtmV50PfAh8Xcn+M8AQKWW6EOJ6YC5wrQ3LU8rgq32DSIk/T16RCRcHu0oyqyiNIjIykpiYGL7//nvGjh1bbt+mTZtYsmQJAMOHDyc1NZWsrCw2bNhQmoZ63LhxeHt7A7BmzRp2795N7969AS2td9k8RXXVqlWr0qAA2iI+c+fOxWQykZiYyOHDhy8LDA4ODqV9Jj179uTPP/+st/I0NJt9IkopNwghwq+wf0uZl9uAEFuV5VJ6H18APAtyOJKYTc9W3g11aUVpVNX5Zm9LEyZM4JlnnmH9+vWkptZ+JUUpJVOmTOFf//pXPZbuIldX19LnZ86c4e2332bnzp14e3szdepUCgoKLnuP0WhECAFcTAl+tWoqfQwPACsr2ymEmC6E2CWE2HXhQt2bf0pqDJ6qA1pRGtT999/PK6+8QkRERLntgwYNKk1xvX79evz8/PDw8GDw4MF89913AKxcuZL09HRAW7Bn8eLFJCcnA1ofRWxsrE3KnJWVhaurK56eniQlJbFyZaUfVc1GowcGIcQwtMBQ6VcZKeVcKWUvKWUvf3//Ol9T76vVGEJEgQoMitKAQkJCSkf8lPXqq6+ye/duIiMjef755/nqq68Are9hw4YNdOnShaVLlxIWpqW06dy5M2+88QajRo0iMjKSkSNHkph4eZqbyZMn069fP44dO0ZISEhpH0VNdOvWje7du9OxY0fuvPPO0pXimjObpt22NiX9WlHns3V/JLAMuF5Kebw656xr2m0AS14ex3r0ZN2QiSzvNIJVTw2u0/kUpSlTabftz1WbdlsIEQYsBe6pblCoLzoXF4SLC61EASeScygoVqu5KYqilLDlcNXvgaGAnxAiDngFMAJIKT8BXgZ8gY+sHTam6kaz+mDw8SHAkofZIjl6PpuoUK+GurSiKEqTZstRSZOr2P8g8KCtrl8Vva8PnvnauqsH4zNVYFAURbFq9M7nxmLw8cWQnYGXi1F1QCuKopRht4FB7+uDOTWNrkGeHExQgUFRFKWE3QYGg48vpvR0urZ059j5bApNqgNaURQF7CkwFGTBkV/AminR4OsDJhOR3jqKzZITSTmNXEBFab6aatrtv/76i379+pXbZjKZCAwMJCEhocL3rF+/vrTcy5cv56233qrwODc3tyuWMyMjg48++qj0dUJCArfddtsV39NQ7CcwHFsJi+6GxGjgYlqMTk5aTeGA6mdQFJtpqmm3Bw0aRFxcXLlZ06tXr6ZLly4EBQVVef4JEybw/PPP16pslwaGoKAgFi9eXKtz1Tf7CQztRgACTmiJrUrSYgSY8nB3MqgOaEWxsaaYdlun0zFx4kQWLlxYum3hwoVMnjyZHTt20K9fP7p3707//v05duzYZe+fP38+jz/+OKDlVOrXrx8RERHlsqrm5OQwYsQIevToQUREBD///DMAzz//PKdOnSIqKopnn32WmJiY0ppNQUEB9913HxEREXTv3p1169aVXu+WW25hzJgxtG/fnpkzZ1bxr1479pNW1NUPgnvCiT9g6HOlaTHMaSUd0Go1N6X5O//Pf1J4pH7Tbjt26kiLF16o8rimmnZ78uTJTJs2jeeee47CwkJ+++033n33XQwGAxs3bsRgMLB69WpeeOGF0gywFXnyySd55JFHuPfee5kzZ07pdicnJ5YtW4aHhwcpKSn07duXCRMm8NZbb3Hw4EGio6MBbR2IEnPmzEEIwYEDBzh69CijRo3i+HFtHnB0dDR79+7F0dGRa665hhkzZhAaGlrj+74S+wkMAO1Hwfp/QW4KBuu3CFNaKl2DQ/lqayzFZgtGvf1UohSlITXVtNu9evUiJyeHY8eOceTIEa699lp8fHw4d+4cU6ZM4cSJEwghKC4uvuJ5Nm/eXHoP99xzD889p6V/k1LywgsvsGHDBnQ6HfHx8VUu4rNp0yZmzJgBQMeOHWnVqlVpYBgxYgSenp6AljMqNjZWBYY6aX8drP8nnFqLvvMtANqQ1c6eFJksnEzOoVNLj0YupKLYTnW+2dtSU027PXnyZBYuXMiRI0dKm7heeuklhg0bxrJly4iJiWHo0KFVnqck7XZZCxYs4MKFC+zevRuj0Uh4eHiFabury9HRsfS5rdJ729fX45bdwcUPTvyBMBjQe3lZawxa9FUd0IpiW0017fbkyZP59ttvWbt2LTfeeCMAmZmZpR3k8+fPr/IcAwYMKO2rKLmXkvMEBARgNBpZt25daTnd3d3Jzs6u8Fxl/z2OHz/O2bNnueaaa2p9fzVlX4FBp4P2I+HkarCY0fv6Yk5No7WvK64Oeg6pwKAoNtVU02536tQJV1dXhg8fXrpIz8yZM5k1axbdu3ev1rfy999/nzlz5hAREUF8fHzp9rvuuotdu3YRERHB119/TceOHQHw9fVlwIABdO3alWeffbbcuR599FEsFgsRERFMmjSJ+fPnl6sp2JpN027bQp3Tbh9cAovvhwf+JPaFD5HSQvi33zLxk62YLBaWPtr8c60r9kWl3bY/V23a7UbTdjgIHZz4o7TGANA12JPDiVmYLVdXoFQURalv9hcYnL0h9Fo48QcGX19MaSWBwYOCYgunLqgZ0Iqi2Df7Cwyg9TMk7kPv5oAlMxNZVFTaAa0muinN0dXWZKzUXn38ru00MIwCwGA6D4ApPZ22/m44GXVqZJLS7Dg5OZGamqqCgx2QUpKamoqTk1OdzmNf8xhKBHYF95bos08AYE5NxRgYSOeWHhyKVzOgleYlJCSEuLg4Lly40NhFURqAk5MTISEhdTqHfQYGIaD9SAzrlgMumKwd0BHBnizeHYfFItHpLp+ooihXI6PRSOvWrRu7GMpVxD6bkgDaj8Kg0yaXmNO0GZhdgj3JLTJzJjW3MUumKIrSqOw3MLQegt5ZD1CuxgCqA1pRFPtmv4HByQNdu2sRuos1hnYBbjgYdCowKIpi1+w3MACiw2j0jmZMiecAMOp1dGrpoUYmKYpi12wWGIQQXwghkoUQByvZL4QQs4UQJ4UQ+4UQPWxVlkq1H4XByYwp7mTppq5B2sgki5oBrSiKnbJljWE+MOYK+68H2lsf04GPbViWivl1QO/miPnC+dJNEcGeZBeaOJuW1+DFURRFaQpsFhiklBuAtCscciPwtdRsA7yEEC1tVZ4KCYEhIAhTZg6YCgEuzoBOUM1JiqLYp8bsYwgGzpV5HWfddhkhxHQhxC4hxK76nqSjD+2AuUAgYzYD0CHQHaNeqH4GRVHs1lXR+SylnCul7CWl7OXv71+v5za0jkCaBZaDKwFwMOi4poW7mgGtKIrdaszAEA+UXag0xLqtQekDtNYr88E1pdsigj05EJ+pcssoimKXGjMwLAfutY5O6gtkSikvX4LJxgy+PgCYzp+FtNMAdAnyJDO/mLj0/IYujqIoSqOz5XDV74GtwDVCiDghxANCiIeFEA9bD/kNOA2cBD4DHrVVWa5E7+sLgLlADydWA6gU3Iqi2DWbJdGTUk6uYr8EHrPV9avLYA0MJkMgnPgDrp1Oxxbu6HWCgwmZXB/RsAOlFEVRGttV0flsS3ofrSnJ7NwWYjZCUR5ORj3tA9w4oDqgFUWxQ3YfGHQODujc3bUag6kAYjYBWgf0IdUBrSiKHbL7wABg8PHBXOwIRhetOQmtnyE1t4jEzIJGLp2iKErDUoEBrQPalJ4JrYfAid9BStUBrSiK3VKBAW3IqjktFdqPhIyzkHKCzi090AkVGBRFsT8qMAB6H19tsZ72I7UNJ/7A2UFPuwA3DiaoDmhFUeyLCgxYawzp6Uj3YPDvBCf/BKBHmDfbT6eSmVfcyCVUFEVpOCowoNUYkBJzRoZWa4jZDIU53NOvFblFZr7dHtvYRVQURWkwKjBQJi1Gaiq0HwWWYjjzF12CPBnU3o8vN8dQUGxu5FIqiqI0DBUYsNYYAHNaGoT1BQf30mGrDw9pS0pOIcv2Nnh+P0VRlEahAgOX1Bj0Rmg7FE78CVLSv60vEcGezN1wGrNa7lNRFDugAgNlEumlWhecaz8KsuIh+TBCCB4a0oYzKbn8efj8Fc6iKIrSPKjAAOg9PUGnw5SWqm1od3HYKsCYLi0I83Hh479OqxQZiqI0eyowAEKnQ+/jc7HG4NESWkRozUmAQa9j2uA27DuXwY4zV1rGWlEU5eqnAoOVwdcXU1qZD/32o+DsNsjPAOD2niH4ujrwyV+nyr+xKBfOboftc+Gnx+DTIbB3QcMVXFEUpZ7ZbD2Gq43B1wdzaurFDe1HwcZ34PQ66HIzTkY90/r4sXb9GpL+2ERgzlFI3Acpx0FatPe4+IGDC6z4PwjuCQEdG+dmFEVR6kAFBiu9jy9FcfsvbgjuBU5esOVDOPILJO7j4dSTPOwIbAHcWkBQFHS+EVpGQctu4BEEOcnwcT9Y8iBMWwMGx0a5H0VRlNpSgcHK4OuDOSXl4ga9ATqNh73fQk6S9sEfOYkF57z58LALSx68hSAv58tP5B4IN86B7++Atf+AUW803E0oiqLUg2r1MQghXIUQOuvzDkKICUIIo22L1rD0Pr5Y8vKw5Odf3Dj+PZh5Bp4+CHcsgCEzGTLuLpLx5vNNZyo/2TXXQ6/7YcsHcHq9rYuuKIpSr6rb+bwBcBJCBAN/APcA821VqMZQMsnNXLYDWm8EF59yx4V4u3BDZEu+33H2ysn1Rr0Jvu1h2SOQp0YyKYpy9ahuYBBSyjzgFuAjKeXtQBfbFavhlaTFKDcyqRLTB7clr6rkeg4ucOtnkJsMvz4Fav6DoihXiWoHBiFEP+AuYIV1m942RbKN2KxY3t/zPsWWir/ll0uLUYXOQR4M6eDPl5vPXDm5XlB3GP4iHP4Zor+rVbkVRVEaWnUDw1PALGCZlPKQEKINsK6qNwkhxgghjgkhTgohnq9gf5gQYp0QYq8QYr8QYmyNSl8DZzLPMO/APLYmbK1w/2VpMarw0JA2pOQUsWRP3JUP7P8EtBoIK2dC2ukalVlRFKUxVCswSCn/klJOkFL+29oJnSKlfOJK7xFC6IE5wPVAZ2CyEKLzJYe9CPwgpewO3AF8VOM7qKYBQQPwcvTi19O/Vrjf4GOtMaRVXWMA6NfGl8gQTz6rKrmeTg83fwJCD0ung9lU47IriqI0pOqOSvpOCOEhhHAFDgKHhRDPVvG2PsBJKeVpKWURsBC48ZJjJOBhfe4JJFS/6DVj1BsZHT6adWfXkVuce9l+nYsLwtm52jUGIQQPD2lLTGoefxyqIrmeVyiMfxfidsKG/9am+IqiKA2muk1JnaWUWcBNwEqgNdrIpCsJBs6VeR1n3VbWq8DdQog44DdgRkUnEkJMF0LsEkLsunDhQjWLfLnxbcZTYC5gzdk1Fe43+PhUu8YAMLpLC1r5uvDJX6eqTq4XcRtE3gEb/qOl0FAURWmiqhsYjNZ5CzcBy6WUxWjf9utqMjBfShkCjAW+KZkvUZaUcq6UspeUspe/v3+tL9bNvxvBbsGsOL2iwv16X99q1xgA9DrBtEFt2BeXybbT1Xjf2P+CZwgsnQYFWdW+jqIoSkOqbmD4FIgBXIENQohWQFWfbPFAaJnXIdZtZT0A/AAgpdwKOAF+1SxTjQkhGNdmHNsSt5GSn3LZfq3GULM5B7f1DMHPzYFPN5yq+mAnD7jlM8g8Byufq9F1FEVRGkp1O59nSymDpZRjpSYWGFbF23YC7YUQrYUQDmidy8svOeYsMAJACNEJLTDUvq2oGsa1GYdFWlh5ZuVl+/SXJtKrBiejnqn9w1l/7AJHEqtRCwjrC4OegX3fwcGlNbqWoihKQ6hu57OnEOLdknZ+IcQ7aLWHSkkpTcDjwO/AEbTRR4eEEK8LISZYD/sbME0IsQ/4HpgqbbwSThvPNnT27Vzh6CSDj5Z6u6ZFuLtvK1wc9MzdUM3hqENmatlXf30KMqsY7qooitLAqtuU9AWQDUy0PrKAL6t6k5TyNyllByllWynlm9ZtL0spl1ufH5ZSDpBSdpNSRkkp/6jdbdTM+DbjOZx6mNOZ5T/IDX6+YDJhyapZ+7+XiwN39A5j+b4E4tLzqn6D3qg1KZlNsOxhsFxhkpyiKM1P8hGI2dzYpahUdQNDWynlK9ahp6ellK8BbWxZMFu6vvX16ITusk7o0rQYNeiALvHAoNYI4ItNMdV7g29buP4tiNmoJdtTFKX5kxJ2z4dPB8P8sbDt48YuUYWqGxjyhRADS14IIQYA+Vc4vknzc/ajb8u+rDi9olyz0cVEejXrZwAI9nJmQrcgFu48S0ZeUfXe1P0e6HQDrH0D9i2s8TUVRbmKFOfDz4/DL09CqwHQcTyseh7+eAkslsYuXTnVDQwPA3OEEDFCiBjgQ+Ahm5WqAYxvM574nHiiL0SXbitJi2FKqXlgAJg+pA15RWY++auafQ1CwA2zIbQPLHtIy8RamFOrayuK0oSlnYHPR0L0tzB4Jty9BCZ+Db0fhC2ztb9/UzW/UDaA6o5K2iel7AZEApHWFBbDbVoyGxseNhwnvVO55qSapsW4VMcWHkzsFcKnG06x7XQ1z+HiA/cuhyHPwb7vYe5QOH+wVtdXFKUJOrYK5g6BjLNw5w8w/O9aqhydHsa+rSXaPPADfDcRCrMbu7RA9WsMAEgps6wzoAH+zwblaTCuRleGhQ1jVcwqis1axlW9tzdQ/UR6FXnlhi609nXl6UXR1W9S0htg2AswZbn2H+Oz4bBznkrVrShXM4sZ1vwDvp8EXq3goQ3QYXT5Y4SAwc9qqz6e2QDzx0F2UuOUt4waBYZLiHorRSMZ32Y8mYWZbE7QRgcIgwG9l1etawwAro4GZk/uTkpOIc8t2V+zoa+tB8PDmyB8IKz4G/xwL+Rn1LosiqI0ktxU+PZW2Pg2dL8bHvgDvMMrP7773TB5IaSc0JqcUqsxYdaG6hIYrvqvs/2C+uHt6F1uTkNN02JUpGuwJzNHd+T3Q0l8t+Nszd7s5g93LYaRr8Ox3+DTQRC3q07lURSlAcXt1kYdxW6BCR9otQFjBevDX6rDKJjyKxTlaMEhbrfty1qJKwYGIUS2ECKrgkc2ENRAZbQZo87ImNZjWH9uPTlFWqdvTRPpVeaBga0Z1N6Pf/x6mBNJNWw31OlgwJNw3yot/H4xGjbPbnIjF5RmSEr46z/wbmdttFwTaNa4akipNQF/MVr7G37gd+hxb83OEdITHvgTHNzgq/FwvEGmdl3mioFBSukupfSo4OEupTQ0VCFtaVybcRSaC1l9djVQPzUGAJ1O8M7Ebrg5Gpjx/d4rr/RWmdDe8PAGuOZ6+PMlrXMq9/IcT4pSL0xF8NMjsO5NcPKEDW/De13h58e0CVlK5YrytMmqK/4GbYfB9L+0FRxrw7ctPLga/NrD93fA3gX1W9ZqqEtTUrMQ6RdJqHtoaXNSbRLpVSbA3Yn/3t6No+ez+ddvtfzDcvaGid9ooxfObIBPBsKZjfVSPkUplZ8O396ijYwb+gI8sgUe36W1fR9YDB/1hW9vg9Pr1aCIsiwWOLEa5l0H+xfBsL/D5EXaaMO6cAuAqSu0fsefH9XWcWnAf3e7DwxCCMa3Gc+OxB0k5yWj9/XBkpmJLKqfMcXDrgng/gGt+WprLKsP17JaLgT0maZ9i3Bwha8nwMZ366V8ikJ6DHw+Cs5ug5vnwtDntP9zfu1g/P/g6cPaB15iNHx9o9bvtW9hkxp3XylToW2GgOZc0P4GZ0fBglsh9wLcvVjLg6arp49VR3dteGvkJK1Z77dnGix9jt0HBtCakySSlWdWYiiZ5JaeUW/nf+76a+jc0oNnF+8jKaug9idqGalVUbvcDGteg4NL6q2Mip2K2wWfjYCcZLj3J+g26fJjXH21D7ynDmqdqaYibULW+91g03tNc+RcQRZsfAfe7QRvtYIvx8Km/0HS4dp/85YSYjbBj/dp513zGniFwW1fwNOHoN119XsPAAYHuOkTrc9x5zz4/e/1f40KCBsnM613vXr1krt21f8onTtX3EmxpZjPHacR/8STtF62FKdOnert/CeTc7jhg030aOXFN/dfi05Xh9G+5mLtP3ryYS1Q+LWrt3IqduTwz9o65O4t4M4fwb9D9d5nscDJ1bD1A61508FNS+/S/3FtIarGlJcG2z+F7R9DQSa0HwWBXeHkn3D+gHaMZ6i2vcNoCB8EDi5XPmd+ulZD2vUFpBzX+l+i7oKe91X/36w+7Pwc2gzV+iBqQQixW0rZq1rHqsCgWXBkAW/teIslrd7A/PDzhM6bh9vAAfV6jYU7zvL80gM8N6Yjjwyt3S+3VGYcfDII3FvCtDXVGw6nVI+UsPdbcPWHa8Y0dmnqn5Sw9UMtR09IL238vGst18dK3Adb52i1Vwc3uH2+1vna0HIuaPe0c5423LPjeG3iWFDUxWOyEuDEH9pIn9ProTgXDE5acOgwWgsW3q20Y6WE+N1aMDi4BEwFENIbet2v1divwr83FRhqITU/lRE/juAx35sZ+LeFBP3n33hOmFD1G2tASslj3+3hj0NJLH6kP1GhXnU74YnVsOA26H6XNlZaqTtTIfzylLaQEkDfx2Dka1qq9ObAbIKVM2HX59BpAtwyt34+5FJPwaK74cIxGP1PuPYhrZ/C1rIStOzEu77UPry73qIthBXY+crvMxVqzUIn/oDjv0P6GW27f0doPQTObtFqGA5uEDlRqx20jLT9/dhQTQJDsxhyWh98nX3pF9SPX85vZCC1S71dFSEE/7o5kn3nNvLkwr2seGIQbo51+BW0vw4GP6ONWAjrrwUIpfZykmHhXRC3A4bO0polts3RvjnePh88WjZ2CeumMBsW3699GPZ/Aq57rf46Sn3barN7lz4Eq56D5EMw9h2tjdwWMs5q/Rt7v9E6ZLvdAQOf1oZ4VofBEdqN0B7X/xtSTsKJ37UgsesLLUCM/x9E3K51AtsZFRjKGNdmHLPinkcaDbVKvV0dni5G3rsjikmfbuXlnw7y7qSoup1w6CxtNMmKv2nV5sAu9VHMhnNuh9aM4dPIy3ucPwDfT9bmidz+FXS5Sdse2geWz9BG4tz2JbQe1KjFrLWsBG0eTNJh7QOv1/31fw1Hd5j0rTYPYuPb2oftpG9q30xVkdRTsOlda5p6oX0ZGvj0ldNNVIdfO+3R7zGtVqXTN0yNp4lSo5LKGB46HGejC/luRpvUGEr0DvdhxvD2LN0bz0974ig8VYe8KDo93Po5OHnAD1OaTHbGaondAl9eD58M1jozG8uRX+Hz0do3z/tXXQwKABG3wbS14OSlDRPe9L+rbxz/+QPayKO0M9rwR1sEhRI6HYx4Sfs/mbAH5g672OlbF8lHYck0+LCXNq+i94Pw5D644f26B4VL6Q12HRRABYZyXIwujAgbwQWnIopTL9j0WjOGt6NXK2+2/ftDTo8bT15d+k3cA7U/xLRT2iIgV8MHV1aCliTQq5X2h71gotZx2JCk1IY0LroLAjrC9HXlOytLBHTS9nW+EVa/qjU3NcUhmmWVDK1c9rA2+Qq0oNfeBkMqKxJxG9y3EiwmLege+aV250ncD4vu0SbYHV2hfaN/cr/W/OMZXL9lVkqpwHCJcW3GkeZsISMx1qbXMeh1vNPXk8kHtPUgMn5bVbcTth6kTUI6uETrWGzKTIXaH3txPtzxHdy/UhsDvuJvsOqFhpnEU1ygDdVc87rWjjx1hTZsszKO7lpT0pi3tLbouUPr55twfcuM1/qcZnfXUjgf+VWbIDVtDbSIaNiyBPfQAmpAJ61j+q//VP9LS9xu+O4OrQnv9HqtL+2pAzDqDe2LkGJTalTSJUwWE19P7k3Xc9Bny16bXUeaTMRMvpPcM7EccfQlrDiTbpv/wslYh24fi0VrRz7zl9YRWNtcLba2/AnY85WW6qOzdeSXxQy/vwDbP4FrxsItn4Gjm22un31e+9YfvwuGvwSD/lazpoOz2+DHqdr49nHvNn6nv6lQy8S791s4tRakRRuC2f1ubeRRVeP0ba24QKvJ7l8InW+Cmz6uvEyxW7QAcnqdlg6m72ParH9nr4YscbNUk1FJqsZwCYPOgF9QWxyzCsgszLTZdVLnfU7BgQOEvf4KrjfdjEdWGq+9vYRCUx2+Let02vBD1wCtvyE/vf4KXF92z9eCwsD/uxgUQOsruf7fcP1/4fgqre8hK6H+r58QrS2ElHxY6ygd/EzN25PD+mqLroT01vLYLH9C+/BraOcPwMrn4J1rtECVfEQbqvlENEz9VRup09hBAcDoBDd/oo2COvyzln00M+7ifinh1Dpt0uaX10PSQe3Ypw7AkGdVUGgENq0xCCHGAO8DemCelPKtCo6ZCLyKlmB6n5Tyziud09Y1BoBDs99E99G3HFv0Mjd1m1zv5y84dpwzt92G+/DhBL/3P8wZGRwfMJBF7YZx9uZ7+fjunjgZ9bW/wLkd2h9Y+9Fwx4Km05EWt0srV/gguOtHLRhU5PgfsPg+cPSAOxfV3/jxwz9rwyldfGHy93U/r9kE697QOqRbdtPW8L1SR6jFAuZC7Ru+uejiz0uV/k3Ky7dJC8Rs1IZpJu4DvYM2mav73dqs2Mr+TZuK47/D4ge0uROTvoWCDK2GEL9Lm6w54EnoMaVpBLRmpklMcBNC6IHjwEggDtgJTJZSHi5zTHvgB2C4lDJdCBEgpUy+0nkbIjBkLFtG4qwX+OylHrx7V/2mvJXFxZyZNAnT+STa/PpL6TrTsVOmknYukZv7PMGQDv58ek8dg8PWj+D3WTDqTS1VQWPLTtLa5Q0OMG1d1dknzx+A7yZpnby3fVG3Gcglawys/yeE9NGCpVtA7c93qaO/aZ28SG3mrKnIGgCKtElXJUHAUlx/12wRqaWhiLit7pk8G1ryUS2ddMmkMs8wGPiUFtwMjo1atOasqUxw6wOclFKethZqIXAjcLjMMdOAOVLKdICqgkJDKUmkFxuzj/O552nheoVOyRpK+XQuhYePEPzB7NKgAOB+3XXkvfkm7/X34umtF5j29S4+u7dX7YND30e02ZurX9GaPMKurac7qAVz8cU2+Qf/rN4HWYsIbZjod5Ng4WQY/S/o+3D1r5mfruXxObVWe2SchW6TteGN9f3h03EsPLReW9+3OF8LfnpH7afB6eJzvaN2bYOj9k2/5GfJKrnlanYVbbPy63B1z8IN6Kj9bte9qfWDRU5qPjPLmwlbBoZg4FyZ13HApZ9OHQCEEJvRmptelVJeNjxHCDEdmA4QFhZmk8KWpffRAoNHnuS3M79xf9f6Gfedf+gQKZ98gsf48XiMHFlun/t1I0h6800Gnj/Mv28dw3NL9vPgV1pwcHaoRXAQQkuT8elg7UP54Y31O9GoJn7/uxakbv28ZiNj3FvAfb9po4dWPacNxx39L22c+aXMxRC3U2urPrVWG0MvLeDgruW0H/Z37QPIVs1qPm3g9i9tc+7myMUHxr3T2KVQKtHYM58NQHtgKBACbBBCREgpM8oeJKWcC8wFrSnJ5oXy1b7RdtGF8O3hb+kR0IOogKg6ndNSVETirBfQe3vR4sXLU+caW7bEqWtXslevZuL0aeiE4NnF+3jgq518PqV37YKDk6c2i/fzUdqH612L6y8FQnXtWwg7PoV+j2vNHjXl4KqNXlr9spYTJ+2M1rTk6K7Ngj1tDQRnNkJRNggdBPfSEqi1HQ7BPdW3UUWpIVsGhnggtMzrEOu2suKA7VLKYuCMEOI4WqDYacNyVUlvbeIZ5z2Q1frNTFk1hYciH2J65HQMutr9k6XM+YjC48cJ+fgj9F5eFR7jft11XHjvPYqTkritZwg6Ac/8uI/75+/k86m9cHGoxbWDouD6t+DXp7WJXP2f0EbVNESHdEK0NkwxfJA2yqS2dDpt/LpPW22uw6eDteGtmWe1/V6tIPJ2aDNMqx2oUSyKUie2/Pq4E2gvhGgthHAA7gCWX3LMT2i1BYQQfmhNS6dtWKZq0Tk6onNzwztfz+IbFjO+zXg+3vcxU1ZN4VzWuapPcIn8AwdI/ewzPG++Gfdhlackdh+pzUrNXq2lh7ilRwjvToxi+5lU7vtyJ7mFptrdUM/7tKaU2M3w5Rht0tCer7V1am0lN1Wb1OTipyWgq6j5p6Z63aetkuXgqrWxj3sHntgLT+3X8v90nqCCgqLUA1sPVx0LvIfWf/CFlPJNIcTrwC4p5XIhhADeAcYAZuBNKeXCK52zIUYlAZwcPRrnLl0JfldrB111ZhWvb3sds8XMrGtncWPbGxHV+NZtKSzkzC23YsnNpc3yn9F7eFzx+FPXj8XQIpBWX15sr/45Op6nF0XTq5UPX97XG9faZmQtyoX9P8COudo4fmdvbWRL7wfqN9+M2aStH3x2m5aGIbhH/Z1bUZRaaTIT3KSUv0kpO0gp20op37Rue1lKudz6XEop/09K2VlKGVFVUGhIBh9fTGkXE+mNaT2GpROW0tm3My9tfoln/nqmWhPgLsyeTdGpU7T8xz+qDApgHZ20YyfmjIzSbTdGBfP+Hd3ZfTadqV/uIKe2NQcHV+1b9yNbLi40vnUOvB+lZRY9tbZ+8iyteU2bfT3+fyooKMpVSM18roTBzxdzavnU2y1cWzBv1Dye6vEUa8+u5Zblt7AjcUel58jbs5e0L77Ea+JE3AYNrNZ13UdeB2Yz2evXl9t+Q7cgZt/RnT1nM5jyxQ6yC+owJl4ICB+oTch6ar+WEuLcDvjmZviwN2yfq62ZWxsHl8KW2Vr2y8ZOFaEoSq2oXEmVSHzlVbJXr6bD5k0V7j+UeojnNzxPbFYsU7tMZUb3GRjLjH6x5Odz5qabkcXFtF6+HL2ba7WuKy0WTg4bjlNEV0I//PCy/SsPJDLj+710Dfbki6m98XGtp4VQTIVwaJm2Xm7CHm3lqojbwC0QENpoHyGsz9FeI8psE1qH8Ib/apOvpvxiu0VaFEWpsaYywe2qZvD1wZyejjSbEfrLh4p28e3CovGLeGfXO3x56Eu2JW7jrUFv0cZLW3Am+X//oyg2lrD586sdFACETof7iBFkLF2KJT8fnXP5ZRevj2jJRzrBjO/3cstHm5l/Xx/C/ap//koZHLXcOt3u0DJb7pgL0d9rM3hrwqsVTPxKBQVFuYqpGkMl0r5dQNIbb9B+y+ZyM5Qrsu7sOl7Z8gr5pnye6fUM4zNbc3bKFLzvuosWL71Y42vnbt3K2fvuJ/iD2ZdNhCuxOzaNB7/ahRCCz6f0onuYd42vU21SapPFpATkxdclzymz3+hSPyOQFEWpV02m8/lqVjLJzZSSUuWxw8KGsfTGpfQM7Ml/N/6D6KcfpKCFF7pH763VtV169ULn6UnO6spXNevZyoclj/THzdHA5M+28ceh87W6VrUIoSVn0xu0yWIGBy1jptFZS3bm4KpNOHPyUEFBUZoBFRgqUZIWw1xmZNKV+Dn78eHg9/hwXxTe6cW8eV02I1fcwMOrH2blmZUUmKqfllkYjbgPHUr2uvXI4so7mdv4u7H00f5c08KDh77dzddbY6p9DUVRlMqowFCJ0hrDJSOTKmLJyyPtq684M2oMnqt34/fAA/x3xi880PUBTmWcYuaGmQz/YTivbnmVvcl7qU7znfvI67BkZVW55KefmyPfT7uWER0DePnnQ/zrtyNYLFdX86CiKE2LqvdXQm/NsGpOrbzGYM7OJn3Bd6R99RXm9HRc+vQh6F//xKVfPwKE4IkeT/B498fZcX4Hy08u57czv7HkxBLC3MO4oe0N3ND2BoLdKl631nXAAISTE9l/rsa1X78rltXFwcCn9/Ti1eWH+HTDaeIz8nn79m51S9utKIrdUp3PlZAWC0e7RuA7fRoBTz1Vbp8pPZ20r74ifcF3WLKzcR08CL+HH8alx5Unc+UW5/Jn7J8sP7Wcnee1dFC9Ansxoe0EhoQOwcepfCd33IwZ5O8/QLt1axHVSH4npeTTDad5a+VR+rT2Ye49PfFyUaODCo4dJ2/7NnzurV2fj6I0B2q4aj0QOh16H59yNYbipGTSvvyS9EWLkAUFuI8cie9D03Hu0qVa53Q1unJTu5u4qd1NxOfE88upX/jl1C+8vOVlBIKufl0ZGDyQQcGD6OLXBffrriP7z9UUHDyIc2TV+feFEDw8pC0tPZ149sf93PrxFubf14dQH/tdDUuaTCQ88wyFJ07g1DUClx5NdB1sRWlCVGC4AoOPD6a0NIri4kmd9xmZS5YiLRY8xo3Fb/p0HNu1q/W5g92CebjbwzwU+RCHUg+xMX4jm+I28cm+T/h438d4O3ozzKs3k3Q6Lqz6lbBqBIYSN0YFE+jhxPSvd3HLx1v4YkpvIkI8a13Wq1n6Dz9QeOIEGI2kzpuHy0dzGrtIitLkqaakK4i97z7y9+1HFhYidDo8b74Z32kP4hAaWvWbaym9IJ0tCVvYGL+RLfFbeGx+Cr5Zki9f7MHA4IEMDh5MJ99O6ETVTUsnkrKZ+uVO0vOKmHNnD4Z1rMflLK8C5owMTo0eg2PHjrj06kXKnDm0+WU5ju3bN3bRFKXBNYk1n22lIQPD+TfeJGPxYrwnTcTn/vsxBgY2yHVLmC1mjnz2Lvr/fcHHMzuxXn8SicTHyYcBQQPoF9SPfkH98HOufGW2pKwC7p+/k6Pns3lyRHseHNS6dus6XIXOv/4P0hcupPWyZRgC/Dk5bDgeY8YQ9Na/GrtoitLgVGCoJ7K4GGkyXZaWoiEVJyVxcshQ/J96Ct3U29kcv5mN8RvZmrCVjMIMAK7xvob+Qf3pF9SPHoE9cNSXX9M4p9DEzMX7+O3AefzcHHlyRDsm9Q7DwdB8RysXHDvOmZtvxvuOO2jx8ksAnH/zn6R//z3t/vwDY8uWjVxCRWlYKjA0M2cmTgKLhdaLfyzdZpEWjqQdYWvCVrYmbGVP8h5MFhOOekd6BfYqrU2092pfum7E7tg0/r3yGDti0gjzceFvozpwQ2QQOl0DrObWgKSUnJ16H4VHj9L291WlK+YVx8dzctRofO6+i8BZsxq3kIrSwFRgaGZS5n7GhXffpd26tZV+080rzmNX0i62JmxlS8IWTmdqC+H5O/uXBonOvp0Jdg1my6lM/rPqGEcSs+jU0oOZo69h6DX+1Vp46GqQ9fsfxD/5JIEvv4TPnXeW2xc/cybZq9fQfu2aSpdYVZTmSAWGZqbw9BlOjx1L4N//js89d1frPedzz5fWJrYmXmx2EggCXAIIdQ/FUuTD4XNG0jPd6eQXzt+G9WNIu9ZXdYCwFBRweuw4dG5utF66BGEo359ScOw4Z268Eb8nZuD/6KONVEpFaXgqMDRDp8aNx+DnR6uv5tf4vRZp4WjaUU5lnCIuO464nDjOZZ8jLjuOC/kXyh2rw4kw91DaebcixD2EVh6tCPcIJ9wzHF8n3yYfNC589BEpsz8gbP58XPteW+Ex5x56mPz9+2m3dk2j9h8pSkNSE9yaIffrriN13jxM6ekYvGuWYlsndHT27Uxn386X7cs35ROfHc+pjFiW7t/PltjjnMxJ4ULOYYrEBootRRfL4OCuBQlroCj52cqj1WUd3o2hODGR1Lmf4T5qVKVBAcB32oPE3n0PGUuW4nO3WmVOUS6lagxXifwDB4m5/XZa/vOfeN1ys82uk55bxCd/nWL+lhgs0swNPV0Y1hUyTQnEZMUQkxnDmawzJOcll75HIAhyCyoNFGHuYYR7hBPmEUZL15bodQ2Tsyn+b8+QvXo1bVaswCGk4hxUoHVOx955F6akJNr+vgphNFZ6rKI0F6rG0Aw5de2CoWVLslevtmlg8HZ1YNbYTkwdEM7sNSf5cdc5ft0juLNPdx4dehsBHk6A1tkdkxVDbFZsabCIyYxhT/Ie8k35pecz6oyEuofSyqNVuUeYexgBLgH11jSVt3s3WStW4PfoI1cMCqClDvGd9iBxjz5G1qpVeN5wQ72UQbFP0mLBnJaG3rfpN7VWl6oxXEXOv/EmGT/+SIetW9C5NEz+o3NpeXy49iSL98Rh0Anu6duKh4e2xc+t4qYjKSUp+SnEZsVqj+xYYjNjOZt9lrNZZykq0zTlbHAmzD2MMI8wQtxCCHEPIdgtmBD3EIJcg8qtoX0l0mzmzO23Y05Lp+1vK6r1byMtFk5PmIDQG2j907Jm8wetNAxZVETu9h1kr1lNztp1mJKTMYaE4DZ4EK4DB+F6bR90rvWw5G49ajKdz0KIMcD7gB6YJ6V8q5LjbgUWA72llFf81LfnwJC7bTtnp04l+P338Rg9qkGvHZuay+w1J1m2Nw5Hg557+7fiocFt8XGtfvZWs8VMUl7SxaBhfcTlxBGfHV8uaAgELVxblAaKSwOHl6MXBp1W4U3/4QfOv/wKQe+8jee4cdUuT8ayn0icNYvQuZ/iNnhw9f8xFLtkzsoiZ8NGctauIeevDVhycxHOzrgNHIBTZCT5e/aSu307Mi8PYTTi3KsnbgMH4TZ4EA7t2jX6l48mERiEEHrgODASiAN2ApOllIcvOc4dWAE4AI+rwFA5aTJxYuAgXAcNIvi//2mUMpy+kMPsNSf4eV8CLkY9UweEM21Qmzqn97ZICxfyLmhBIideGz1lHUEVnx1Pcn7yZe9xN7oTYHHjxf8lkNHCjT9mDsLLyRtPR0+8HL3wcPDAy9ELT0dPfJx8CHQNxKi7WAuRRUWcHDUah5AQWn37TZ3KrzRPxYmJZK9dS86ateTu2AEmE3pfX9yHD8Nt+HBc+/VD5+RUerylqIj83bvJ2biJ3I0bKDxxEgBDy5a4DRyI66CBuPbvj97NrcHvpakEhn7Aq1LK0dbXswCklP+65Lj3gD+BZ4FnVGC4soRZL5C9ejUdNm9CODTeWgsnkrJ5f80JVhxIxM3BwH0DW/PAwNZ4OtumI7fAVEBCTkJp4MgoyCCzKJP2X2+k05rTzHvqGo75F5NRmEF2UTaSy/9f64SOQJdAgtyCCHYLJtgtmC6rTxMwbwUuX84m+NphpbUQxX4Vnj5N1qpV5KxZS8GhQwA4hIfjft0I3IaPwLlbJEJfvQEVxYmJ5GzcSO7GTeRu3YolJwcMBlyiovC86UY8b721wWoSTSUw3AaMkVI+aH19D3CtlPLxMsf0AP4upbxVCLGeSgKDEGI6MB0gLCysZ2xsrE3KfDXIXruWuEcfI3TePNwGDmjs4nD0fBbvrz7ByoPncXcy8ODANtw3MBwPJ9uP9Ck8dYrTN96E1y230PL110q3my1msouyySzKJKMwg8zCTFLzU4nPiSchJ0H7mZtAUm4SDkUWPp5j5nCY4H+3ORDoEkiwezBBrkH4OvviZnTD1eiKm4Mbbkbt4ergWrrd3cEdB51DozcTKHVnKSjgwuwPSJs/H6TEOTISt+tG4D5iBI5t2tT5/LK4mPzoaHI2biJn3ToKT5zA88YJtHjttXK1Dlu5KgKDEEIHrAWmSiljrhQYyrL3GoOloIDj/QfgOeEGWr76amMXp9ShhEzeW32CPw8n4e5k4P4BrbnfhjUIKSXnHpxG/v79tP19FQYfn6rfdIliczHn886TMvtDnL5Zzpa37+Ck58WaSUZBRrl+j8oYdIbSQOHl6KU9nLxKm7G8Hb3LbSt5OBls/2GgVE9+dDQJs16g6MwZvCZOxO/xxzAG2C5NvbRYSPnkE1Jmf4BT166EfPgBxhYtbHY9aDqB4YpNSUIIT+AUkGN9SwsgDZhwpeBg74EBIO7pp8n+czUeo0bhfc/dOEdFNZlvrAfjM5m95gR/HE7C3dHAfQPCuX9g63pfYjR77TriHn2UwFnP4zNlSp3OZUpL4+TwEXiMHUvQP98st6/IXEROcQ65RbnkFOdoj6Kc0ue5xbmlr0tqKZkFmaQXppNZmElOcU4lVwUnvRMejh64G91xdXDF1aDVTFyNF2sk5WooFiPeHy/FkJKJ67Ah+I0ai0vLkDrdu72zFBZyYfZs0r6cjyEwkJZv/AO3AQ1XE89es4aEZ2ciXFwImT3bpisMNpXAYEDrfB4BxKN1Pt8ppTxUyfHrUTWGajGlpZH66VwylizBkpODU0QEPvfcjfuYMegasd+hrEMJmXyw5iSrDp3HzdHA1P7hPDCwNd41GMVUGUtREafH34AwGmnz07J6maB2/h9vkP7DD1pK7nr85lZsLtaatAoyyCi85GHtJ8ktztUCTJkAVLKtpK/EpUAyc7GZjucg2QtaZGjnPxms43AXd2K6BWIKDSitpVzpp5vRrcEmHTZl+dHRJLzwd4pOn8br9tsJeG5mo3QKF544wbnHH6c4IZEWL72I98SJNrlOkwgM1oKMBd5DG676hZTyTSHE68AuKeXyS45djwoMNWLJzSXj559J/+Zbis6cQe/nh/cdd+A9aSIGf//GLh4ARxKz+GDtCX47cB5XBz1T+ofz4KA2NRrmeqmUzz7jwjvv1ms/S1FcPKdGj8bnnnsIfP65ejlnXVmkhQJTAVkJsWQ89jcsMWfJnfUgaf07UnDyJA6b9+K1/TheZ1IAuBDoxP5OTmxrL9nvm4uspBIpELg7uJcGCw9HDzwdLgYPT0dPPBw8cHdwL+1HcTW6ltZsyo7suhpZCgtJ+eADUr/4Uqsl/OMfjd5fZ87MJP7//kbu5s143zmZwFmz6n1GfpMJDLagAsPlpMVC7uYtpH37Dbl/bQCjEY/rx+Bzzz04R0TU+HyW3FyKExIwpaXj1Kkjeg+POpfx2PlsZq89wW8HEnE26rm3XzjTBrXGt5KJcpeSUlJw+DA5a9eR+uWXuPbtS2g9r98c/8yz5KxdS7t1a9F7No01sotiYjj7wIOY0tMJ+WB2hc0cxYmJZK9ZS/bq1eTt3AlmM4bAQByGDsI8qCfZXULJNOeSWZipPYq0nxmFGWQVZpU+zyzKJLsou8oyOemdLuuMdze6lw4L9nbyxsfJp9zDy8mrNKBIk4n0BQtI+ehjDEFBeIy9Ho/rr8chxPbNYvn79mm1hFOnGrWWUBFpNpP87rukff4FLr16Efz+exh8fevt/Cow2LGimBjSFnxH5tKlWHJzce7WDe977sFj1MjS4a3mnFyKE+Ipjo+nOD7B+vPiw5yRcfGEej3OERG4DhiA64ABOEdGXJbKuiZOJGXzwdqT/LI/ASeDnnv6tWJir1Da+LletmCQpaiIvO3btXHka9dhSkoCnQ6Xnj0JeutfGIOvnPqipgqOHePMjTfh/9ST+D38cL2euzbyDx3i3LTpICWhc+fiHNG1yveY0tPJ+esvslevJnfTZmRBAToPD1x69sS5Wzeco6Jwjuha6azcsiO6SvtSyvSpZBdlk1uce/Fncba2vyiHrKIs0grSMEtzhef2dPQk6rwTty9PIyAhn6TOgRgLTPicTgUgrY0vZ/uEcrZXKHk+zkgpsUgLEomUEolEJ3R4OHhcVsvxcvTCw9GjtKns0j63plhLqEzmL7+Q+OJL6H19CP3wQ5w6X578sjZUYFAw5+SQuXQZaQu+pTj2LAZ/fwwBAZd/8APC0RFjUBDG4OAyjyD0Hh7k7dlD7pYtFBw4CBYLOjc3XPpei2v//rgNGIAxLKxWHd8nk3P4cO0Jlu9LwCLB3dFARIgnvbx09Eo6QstDO7Fs34olLw/h4oLbgAG4DR+O25DBtRqBVF1np0+n4OAhLSV3AwwhrEzutm3EPfY4ek9PQj+fh2Pr1jU+hyU/n9zNm8leu478vXspOnNG26HT4dihA85R1kDRrRsO4eH1MoDBIi1kF2WTWpBKWn4a6YXppOWnkXUhnuBv1tJ6wymyvBz4ebwvm9oWY8aCf4aF3oeK6XWokLBEEwCnwhzYE+FMdFcXct2NCCEQCCzSQlZR1hU79fVCX9oc5unoSet4M6MXHMf3fB6H+wex9dYOmF2cEEKgF3p0QlfuoRf60uvphA6BQIhLnqPTjrE+1+v0pdfzdPDEy8kLTwdrM52jZ42b3/IPHiLu8ccxZ2TQ8o038Bxf/Rn9lVGBQSklLRZyN24kfdEPyOJijMFaAHAoEwSqk/zLnJlJ7rbt5G7eTO7mzRTHxwNgDAnBtX9/rUbR99oaN8GcS8tj9+Z95Kxdi3f0dlolnkSPJMXJg32hEWRE9cWzfz8i2vjTLcSrXjqvryR3xw7O3julwtXfGkrWqt9JePZZHMLDCZ33GcbAwHo5ryk9nYIDB8iPjtYe+/Zjyc0FQO/piVNUN1yionCOisIpIhK9W91z/UiLhcxly0j+79uYs7PxmTIF/8cerbTGUhQTQ9bKlWT9tpLCEye0GmLv3nhcfz3uo0eVppwvthSTWZBJZnoi2Ulx5F5IJC8liaLUC5jT0rFkZCIysjBm5NLqWAbZHkaWTwzhRAdXLNJy2cMszUgpMUtzaS3FIi0ApceU1Fwqem6ymCqcVFnC1eiKp4NnaR9OSeByNjjjYnTBxaA9nI3Opc9dsotwfGU27DuC89Q78X/qKVwcL68NVZcKDIpNSSkpPnuWnM2byd28hbxt27QPGJ0Oh9BQEAKk9oeDxWJ9bgGLBOu2kn3SbMaSmQmAY8eOOA8ZSlJEb/Y5tWBfQhb74zI5dSGHkv+moT7ORIV6My6iBcM7BuJg0NX7vcXeMRlTaiptV62sU7NZbaQvXMj5117HuXt3Qj/+yKZ9HdJspvDUKfL37bMGi30UnTql7TQYcOnZE7ehQ3EbOqRWNZaCY8c4/9rr5O/Zg3PPnrR4+WWcrulQ7fcXnjxJ1m8ryVq5Uqvt6PU4de2CLCjEnJaGKSMDiosrfK9wdETv44PB2xvn7t3xf+pJ9O7uNb6H6rJIC7nFuRX221S0Laswi6yiLPJN+eWyEV9Kb5ZM/dPC6L2SvW0EF567myeHvFCrMqrAoDQoWVxM/oED5G7aTOGZ09o3GqEDnQ4EiNLnAnRCe219jhA4tmmL+/BhlfYZZBcUcyA+k/1xmeyPy2DHmXRScgrxdXXglh7BTOodSruA+vujz169mrjHZxAwcybed0xqkEy2UkpS5nxEyocf4jZ0KMH/e7dRVpczZ2WRv28/eTt2kPPXXxQePw6AQ6tWuA0bhtvQobj07HHFETPmnFxSPvyQtG++Qe/uTsCzz+J5800IXe2CuJSSwmPHyPptJfl796Jzd0fv443B2we9t7f23Mf63NsHg483wtm5ycztqUrJ6LM8Ux75xfnkmfIue+7860aCPvsN09ghdPvPR7W6jgoMSrNmMlvYcOICi3aeY82RZEwWSc9W3kzqFcq4yJa4OtbtW760WIi57XYKDh8GoxHniAhc+vTG9dprcY6KqvcPbGk2k/Tmm6R/9z2eN91Ey3+83mQWDyqKiyfnr/XkrP+LvG3bkMXF6NzdcRs0ELehQ3EdNKi0eUdKSfYff5L0z39iSkrC6/bb8f+/p2u84qBSsby9e3Fs27bWowRVYFDsxoXsQpbuiWPRrnOcvpCLq4Oe8ZFBTOwdSo8wr1p/a7Tk55O3azd5O7aTu2MHBQcPgdmMMBpx6haJa58+uPS5FueobnXqpLYUFZHw3HNkr1yFzwP3E/DMM032m64lN5fcrVvJXq8FCnNKCuh0OEdF4TZ0KHk7d5K7cSOOHTvS8tVXcI6KauwiK2WowKDYHSklu2PTWbTzHCsOJJJXZKZdgBuTeoVyc4/gShcWqi5zTg75e/aQu307eTt2alk3LRaEgwPO3brh0qcPLr17oXN1A2nR+k8sUnsuJdJS0sdiKfc8bf58crdsJeDZZ/F94P56+tewPWmxUHDoEDnr1pOzfj0Fhw+jc3XF/8kn8L7zzgbvm1GqpgKDYtdyCk38ui+BRbvOsfdsBgadYFjHAEZ2DmR4x4A6BwkAc3Y2ebt3k7d9B3k7dlBw5IjW0V5Tej0t33gDr5tvqnOZGlNxcjI6R8cmMzFQuZwKDIpidTwpmx92nuPX/YmczypACOgW4sV1nQIY3jGQTi3d66XpxpyVRf7+A8jiIq2TVacDoUPohPYca8e77mJHvNDpMPj51ftEPUWpiAoMinIJKSWHErJYezSZNUeS2BenDZEN8nRieKcARnQMpF9bX5yMKrmc0jypwKAoVUjOLmDd0WTWHElm44kU8ovNOBv1DGjnZ61NBBDgodZLUJoPFRgUpQYKis1sO51qrU0kE5+hTThq4+9Kp5YedLY+OrX0INDDscmOGlKUK1GBQVFqSUrJsaRs1hxJZt+5DI6cz+Jc2sWZqd4uxtJg0cn6aBfgVu8zsBWlvtUkMKgxZYpShhCCji086Nji4iSirIJijiZmcyQxiyOJWRxOzOKbbbEUmrRRSEa9oK2/G52DPOjbxpfB7f1p4amaoZSrlwoMilIFDycjfVr70Kf1xayuJrOFmNRcDidmczhBCxgbjl9g6R4tuWCHQDcGt/dncAd/+rT2UZ3aylVFNSUpSj2RUnL0fDYbjl9gw4kL7DyTTpHZgqNBR5/WPgzp4M+g9v50CKx9hkxFqS3Vx6AoTUB+kZltZ1LZcPwCG0+kcDJZW0OghYcTg9r7MaiDP/3a+OLn5qAChWJzKjAoShMUn5HPRmttYtOJFLIKtEVp3B0NhPq4EObjQpivy8XnPi4Eezmrjm2lXqjAoChNnNki2ReXwZ7YdOLS8zmbllf6KDJdTK0hBAR5OhPq40yotxYs2ge6ERHiRZCnk6ppKNWmRiUpShOn1wl6hHnTI6x8SmqLRXIhp1ALEqlaoDhnDRh/Hb9AcnZh6bF+bg5EBHsSEeJFtxBPIkI8CXBXo6GUulOBQVGaEJ1OEOjhRKCHE73DL1/bOr/IzLGkbPbHZbA/LpMDcZn8dfwEFmvFv4WHE5EhnkSGaAEjMtjT5suhKs2PTQODEGIM8D6gB+ZJKd+6ZP//AQ8CJuACcL+UMtaWZVKUq5mzg56oUC+iQr1Kt+UWmjicmMW+cxkciNeCxR+Hk0r3h3g7E+zljJ+bI75uDvi6aj/93BzwdXPE11X76eFkUE1TCmDDwCCE0ANzgJFAHLBTCLFcSnm4zGF7gV5SyjwhxCPAf4BJtiqTojRHro4Geof7lKthZOYXcyg+k31xmRxKyCQ5q5Aj57NIzSkiM7/idZKNelEaNHzdHAlwdyTQw5EAdycC3B0J8Cj56YijQc3LaM5sWWPoA5yUUp4GEEIsBG4ESgODlHJdmeO3AXfbsDyKYjc8nY30b+dH/3Z+l+0rMllIzysiJaeQ1JwiUnO1nyk5RaTmFJKaq+07fj6bCzmFmC2XD1DxcjFqQcLdiQBr8Aj2ciLcz5VwX1eCvJzR61Tt42ply8AQDJwr8zoOuPYKxz8ArKxohxBiOjAdICwsrL7Kpyh2ycGgK+3HqIrZIknLLSI5u4Dk7EKSswpIziokObuQpCxt25nTuSRnF1BsvhhAHPQ6Qn2cCfd1tQYLFxU0riJNovNZCHE30AsYUtF+KeVcYC5ow1UbsGiKYtf0OoG/uyP+7o50ucJxJaOpzqTkEpuay5mUPGJScolJzWXLqVTyi82lx5YNGv7ujni6GPFydsDLxYi3ixFP63PttYNKJ9IIbBkY4oHQMq9DrNvKEUJcB/wdGCKlLLx0v6IoTV/Z0VR92/iW2yelJCmrkJjUXGJScjmTmktsSh4xqbkciM8kI6+YInPly6I6GnRaoHB2wNvViL+7E4HWvo6yTVmBHo64OaoO9Ppgy8CwE2gvhGiNFhDuAO4se4AQojvwKTBGSplsw7IoitJIhBC08HSiheflQQO0wFFQrPV7ZOQVk5Fv/Wl9nplXXLovPa+I/XEZJGUVUFB8eTBxNuoJ8HAk0N0Jfw+tA93f3REfFwd8XLWHt6sDPi4OeDob0akmrQrZLDBIKU1CiMeB39GGq34hpTwkhHgd2CWlXA78F3ADfrRG+bNSygm2KpOiKE2PEAJnBz3ODs4EeTlX6z1SSrILTdb+joJyP5OsfSFHErJYn1VAbpG5wnPoBHi7XAwU3q5GfFwd8XYx4uZkwMWox8XBgLODHhcHvfWnQXtu1La5OBhwMuqaXS1FpcRQFKVZyy8yk55XRFqu9ih5np5bRGq518WlrysaiVUZIcDVwYCHkwFPFwc8nQ14OmtNX54uRjydyz+8rNtcHQ0YdToMeoFRr8OoFzYNMColhqIoilVtaiOFJgt5RWbyikzkF5nJKzKTW+Z5vnVfXrH2PKfQRFa+icx8bZ7ImZRcMvIyyMwvLl3QqTr0OoFBJ3DQawHDoNdh1Fl/6gWT+4Tx4KA2tf2nqDYVGBRFUcoQQuBk1ONk1ONTD+lECorNZOYXlz4y8rSfeUUmis0Sk9lCsdmiPbdYMJll6fNy+y0Sf3fHerjDqqnAoCiKYkMlQaY680aaCpXoXVEURSlHBQZFURSlHBUYFEVRlHJUYFAURVHKUYFBURRFKUcFBkVRFKUcFRgURVGUclRgUBRFUcq56nIlCSEuALVdF9oPSKnH4lxt7Pn+7fnewb7vX927ppWU0r86b7rqAkNdCCF2VTeJVHNkz/dvz/cO9n3/6t5rfu+qKUlRFEUpRwUGRVEUpRx7CwxzG7sAjcye79+e7x3s+/7VvdeQXfUxKIqiKFWztxqDoiiKUgUVGBRFUZRy7CYwCCHGCCGOCSFOCiGeb+zyNCQhRIwQ4oAQIloI0ewXzBZCfCGESBZCHCyzzUcI8acQ4oT1p3djltFWKrn3V4UQ8dbff7QQYmxjltFWhBChQoh1QojDQohDQognrdvt5Xdf2f3X+PdvF30MQgg9cBwYCcQBO4HJUsrDjVqwBiKEiAF6SSntYpKPEGIwkAN8LaXsat32HyBNSvmW9YuBt5TyucYspy1Ucu+vAjlSyrcbs2y2JoRoCbSUUu4RQrgDu4GbgKnYx+++svufSA1///ZSY+gDnJRSnpZSFgELgRsbuUyKjUgpNwBpl2y+EfjK+vwrtD+YZqeSe7cLUspEKeUe6/Ns4AgQjP387iu7/xqzl8AQDJwr8zqOWv6DXaUk8IcQYrcQYnpjF6aRBEopE63PzwOBjVmYRvC4EGK/tampWTallCWECAe6A9uxw9/9JfcPNfz920tgsHcDpZQ9gOuBx6zNDXZLau2nzb8N9aKPgbZAFJAIvNOopbExIYQbsAR4SkqZVXafPfzuK7j/Gv/+7SUwxAOhZV6HWLfZBSllvPVnMrAMrWnN3iRZ22BL2mKTG7k8DUZKmSSlNEspLcBnNOPfvxDCiPahuEBKudS62W5+9xXdf21+//YSGHYC7YUQrYUQDsAdwPJGLlODEEK4WjuiEEK4AqOAg1d+V7O0HJhifT4F+LkRy9KgSj4UrW6mmf7+hRAC+Bw4IqV8t8wuu/jdV3b/tfn928WoJADrEK33AD3whZTyzcYtUcMQQrRBqyUAGIDvmvu9CyG+B4aipRxOAl4BfgJ+AMLQ0rZPlFI2u07aSu59KFozggRigIfKtLk3G0KIgcBG4ABgsW5+Aa2d3R5+95Xd/2Rq+Pu3m8CgKIqiVI+9NCUpiqIo1aQCg6IoilKOCgyKoihKOSowKIqiKOWowKAoiqKUowKDolgJIcxlMlBG12cWXiFEeNmMp4rSlBkauwCK0oTkSymjGrsQitLYVI1BUapgXc/iP9Y1LXYIIdpZt4cLIdZak5OtEUKEWbcHCiGWCSH2WR/9rafSCyE+s+bK/0MI4Ww9/glrDv39QoiFjXSbilJKBQZFucj5kqakSWX2ZUopI4AP0WbQA3wAfCWljAQWALOt22cDf0kpuwE9gEPW7e2BOVLKLkAGcKt1+/NAd+t5HrbNrSlK9amZz4piJYTIkVK6VbA9BhgupTxtTVJ2XkrpK4RIQVsYpdi6PVFK6SeEuACESCkLy5wjHPhTStne+vo5wCilfEMIsQptcZ2fgJ+klDk2vlVFuSJVY1CU6pGVPK+JwjLPzVzs4xsHzEGrXewUQqi+P6VRqcCgKNUzqczPrdbnW9Ay9QLchZbADGAN8Ahoy8oKITwrO6kQQgeESinXAc8BnsBltRZFaUjqm4miXOQshIgu83qVlLJkyKq3EGI/2rf+ydZtM4AvhRDPAheA+6zbnwTmCiEeQKsZPIK2QEpF9MC31uAhgNlSyox6uh9FqRXVx6AoVbD2MfSSUqY0dlkUpSGopiRFURSlHFVjUBRFUcpRNQZFURSlHBUYFEVRlHJUYFAURVHKUYFBURRFKUcFBkVRFKWc/wcKrXAf/fdqSQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.22343158721923828 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "plt.plot(history2.history['loss'])\n",
+    "plt.plot(history2.history['val_loss'])\n",
+    "plt.plot(history.history['loss'])\n",
+    "plt.plot(history.history['val_loss'])\n",
+    "plt.title(\"Model Loss\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Loss')\n",
+    "plt.legend(['Resnet Train', 'Resnet Validation', 'Model1 Train', 'Model1 Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "compliant-philippines",
+   "metadata": {
+    "papermill": {
+     "duration": 1.448211,
+     "end_time": "2021-04-25T14:39:59.342288",
+     "exception": false,
+     "start_time": "2021-04-25T14:39:57.894077",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Accuracy vs no. of epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "enclosed-momentum",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:40:02.207435Z",
+     "iopub.status.busy": "2021-04-25T14:40:02.206316Z",
+     "iopub.status.idle": "2021-04-25T14:40:02.381972Z",
+     "shell.execute_reply": "2021-04-25T14:40:02.381112Z"
+    },
+    "papermill": {
+     "duration": 1.614944,
+     "end_time": "2021-04-25T14:40:02.382171",
+     "exception": false,
+     "start_time": "2021-04-25T14:40:00.767227",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAABTJklEQVR4nO3dd3xUZdbA8d+ZmfRe6AFCifQqUsVFBcUGq6AuVlZX7LpFXXVtsLq6rrq7Kru+6CpWsKKo2AVRBKRFeidIIEAS0pNJpjzvH3cyhBAgQCYTmPPV+cxtc/PcDLnnPl2MMSillFIAtmAnQCmlVNOhQUEppZSfBgWllFJ+GhSUUkr5aVBQSinlp0FBKaWUnwYFFRJEJF1EjIg46nHsRBH5oTHSpVRTo0FBNTkikiUiVSKSWmv7Ct+NPT1ISauZllgRKRWRz4KdFqUakgYF1VRtAyZUr4hILyA6eMk5yDigEhglIi0b8wfXJ7ej1LHSoKCaqteBa2qsXwu8VvMAEUkQkddEJFdEtovIAyJi8+2zi8hTIpInIluBC+r47P9EJEdEdorIoyJiP4r0XQu8AKwErqp17tNF5EcRKRSRHSIy0bc9SkSe9qW1SER+8G0bISLZtc6RJSIjfcuPiMh7IvKGiBQDE0VkoIgs9P2MHBF5XkTCa3y+h4h8JSL7RGSPiNwvIi1FpFxEUmoc19/3+ws7imtXJzENCqqpWgTEi0g33836N8AbtY55DkgAOgK/wgoiv/XtuwG4EOgHDADG1/rsdMANdPYdcw7wu/okTETaAyOAN32va2rt+8yXtmZAXyDTt/sp4FRgKJAM3AN46/MzgbHAe0Ci72d6gD8AqcAQ4GzgFl8a4oCvgc+B1r5r/MYYsxuYB1xW47xXAzONMa56pkOd5DQoqKasOrcwClgH7KzeUSNQ3GeMKTHGZAFPY93kwLrx/csYs8MYsw94vMZnWwDnA783xpQZY/YC//Sdrz6uBlYaY9YCM4EeItLPt+8K4GtjzAxjjMsYk2+MyfTlYK4D7jTG7DTGeIwxPxpjKuv5MxcaYz40xniNMRXGmGXGmEXGGLfv2v8PKzCCFQx3G2OeNsY4fb+fxb59r+LL2fh+hxOwfs9KAaBlk6opex2YD3SgVtER1hNyGLC9xrbtQBvfcmtgR6191dr7PpsjItXbbLWOP5xrgBcBjDE7ReQ7rOKkFUBbYEsdn0kFIg+xrz4OSJuInAI8g5ULisb6W17m232oNAB8BLwgIh2ALkCRMeanY0yTOglpTkE1WcaY7VgVzucDH9TanQe4sG7w1dqxPzeRg3VzrLmv2g6sSuJUY0yi7xVvjOlxpDSJyFAgA7hPRHaLyG5gEHCFrwJ4B9Cpjo/mAc5D7CujRiW67wm+Wa1jag9n/F9gPZBhjIkH7geqI9wOrCK1gxhjnMA7WLmFq9FcgqpFg4Jq6q4HzjLGlNXcaIzxYN3cHhOROF9Z/h/ZX+/wDnCHiKSJSBJwb43P5gBfAk+LSLyI2ESkk4j8iiO7FvgK6I5VX9AX6AlEAedhlfePFJHLRMQhIiki0tcY4wVeBp4Rkda+ivAhIhIBbAQiReQCX4XvA0DEEdIRBxQDpSLSFbi5xr5PgFYi8nsRifD9fgbV2P8aMBEYgwYFVYsGBdWkGWO2GGOWHmL37VhP2VuBH4C3sG68YBXvfAH8DCzn4JzGNUA4sBYowKrEbXW4tIhIJFZdxXPGmN01Xtuwbq7XGmN+wcrZ/AnYh1XJ3Md3iruAVcAS376/AzZjTBFWJfFLWDmdMuCA1kh1uAur/qLEd61vV+8wxpRg1cNcBOwGNgFn1ti/AKuCe7kvN6aUn+gkO0qFHhH5FnjLGPNSsNOimhYNCkqFGBE5DasIrK0vV6GUnxYfKRVCRORVrD4Mv9eAoOqiOQWllFJ+mlNQSinld8J1XktNTTXp6enBToZSSp1Qli1blmeMqd3/5SAnXFBIT09n6dJDtVBUSilVFxGpV/NjLT5SSinlp0FBKaWUnwYFpZRSfhoUlFJK+WlQUEop5RewoCAiL4vIXhFZfYj9IiLPishmEVkpIv0DlRallFL1E8icwnRg9GH2n4c1Ln0GMAlrfHillFJBFLB+CsaY+SKSfphDxgKvGWucjUUikigirXxj3SulVMB4vYZKt5dKtweny3qvdHtxujxUub3+GY0E2D85n/iXqzeJCII1A5LL48Xl9lLl8eLyGKrcXlye6nVrn8tjqPJ4/T/DJmATwW6zzm0TwS7Wst0m2ESsY3zLp6Un0bl5XEB/N8HsvNaGA6cYzPZtOygoiMgkrNwE7dq1q71bKXUC8HoNhRUu9pVVkldaRWF5FW6vwWvAGIPXGLxe6wbrNca3rXrZOsZdfTN3HXxDt7Z7cPrea26rDgCVLi9OtweX58Qc8+2xi3ue1EGh3owx04BpAAMGDDgxv02lmhhjDC6PweXx4vYYXF7v/mWP139D9hqDx2vdsL3G4PHdsD1e8Hh9y8ZQ4nSTX1bFvtIq8ssqyS+rIr+0kn1lVf6XtwH/esPsQoTDToTDRmSY9R7usBHhW46LdJDqsBMZZrOOC7MR6Xuv+Zm6zmETwWAFI7ACVfXgof5LMGBqzJIabrcTZhfCHDbC7TbC7Na5wuziXw/zrYfZbNhs4vs9mgN+116z//dac9ljDPGRYQ33CzyEYAaFnRw4h24a++fXVUrVU3mVm91FTnYXO9lbXMnuYie7i5zsKba25ZVWUuny1rr5WzejQEmICiMlNpyUmHA6pMYwID2ZlBhrPTk2gtSYcBKjwwl3iL8IxioqsYpOqotSqotPqFG0EhlmJ9xhw26TIyWjyRMRHPamdR3BDAqzgdtEZCbWxOdFWp+gQo0xhgqXh/IqDxVVHsqq3JRXeSiv9FBevVy1f7msyk1+aZV1w/cFghKn+6DzxkU4aB4fQcuESAa0TyYyzIbD5ntatVs3ojDf06vDJjjsNsLt1rvDZu2zyrHxlXFb5d52m3Ujs1ffsG3WfptNiI1wkBITTlJMOGF2be1+ogpYUBCRGcAIIFVEsoGHgTAAY8wLwBysuWw3A+XAbwOVFqWCyenykJVfRlZeue+9jG15ZWTll7G3pJKjmdIk3G4jOSacFgmRdGwWw9BOKbRIiKRlvPVqkRBJi/hIYiNOiJJh1QQFsvXRhCPsN8Ctgfr5SjUWt8dLYYWL/NIqsvLL2J5fxra8crJ8N/6cIucBx6fGhtM+JYbTOzejdWIkMREOosPtRIdXv9exHGEnOsyOQ5/AVYDp44RStThdHrblWU/xheVVFJRVUVjhorDcRUF5FQXlLmt7eRWF5a46i2+SY8JJT4lmSMcU0lNjSE+NoUNKDO1ToxulslCpY6VBQYWsgrIqNueWsmVvKZv3llrLuaVkF1TUWaQTF+kgKTqcpOgwkqLD6ZgaQ2J0OIm+9eSYcNolR5OeEkNCtN741YlJg4I6qRlj2FNcyfrdxWzeW8qW3DK27LVu/vllVf7jIhw2OjaLpU9aIuP6p9GpWSytEiJJ9AWBhKgwLbpRIUGDgjppGGPYsa+CNbuKWL2riNU7i1mzq4i80v03/8ToMDo3i2VktxZ0bh5L5+axdGoWS5ukqJOiiaNSx0uDgjohebyGbXllVgDYuT8AFPvK9+02IaN5LCO6NKdH63i6tYqnc/NYUmLCEdGbv1KHokFBBZXb46XE6aa00k2x00Wpb7nE6aak0k2p002J00Wpb7nY6Sa/rJL1OSVUuDwAhDtsdGsZx4V9WtOzdQI928RzSos4IsPsQb46pU48GhRUo6pye/k5u5CFW/JZtDWfZdsLqHR7D/sZu02Ii3QQG2G9kqLDufy0tvRsYwWATs1itbOUUg1Eg4IKqCq3l5XZhSzams9CXxBwuryIQPdW8Vw5qD3tkqOIjQwjNsJBXKRjfwCIdBAXEUZkmE2LfJRqJBoUVINyebyszC5i0VYrJ7A0q8BfzNOtVTxXDGzP4I7JDOyQTGJ0eJBTq5SqTYOCOi5er2HDnhJ+2JTHD5vzWJK1j/IqKwh0bRnH5ae1ZXDHFAZ1SCYpRoOAUk2dBgV11HYWVrDAFwR+3JLnb/LZuXksl56axpBOKQzskEKyBgGlTjgaFNQRFVW4WLglnwWb81iwOY+teWUANIuLYHhGM07vnMqwzqm0TIgMckqVUsdLg4I6QJXby/b8MjbtLWXNriJ+2JzPquxCvAaiw+0M7pjCVYPbc3pGKhnNY7UCWKmTjAaFEFVR5WFLrjXmz6a9JdbYP3tLycov90++YrcJfdsmcvtZGZyekUqftETCHdr0U6mTmQaFEFBW6eartXtYs6vIFwRK2Vm4f9A3u01IT4mmc/NYzuvZ6oDhH6LCtQOYUqFEg8JJyhjD8l8KeHvJDj5ZmUN5lYdwh41OzWLp1y6Jywa0pXPzWDKax9I+JUZzAEopQIPCSWdviZMPlu/knaU72JpbRky4nYt6t+bSAWn0a5ekg74ppQ5Lg8JJwOXxMnf9Xt5Zms3cDXvxeA2npSdx0686cUGvVsTo1IxKqXrSu8UJbPPeUt5duoP3l+8kr7SSZnER3DC8I5cOsOYDUEqpo6VB4QRijCErv5z5G3OZ/fMulm0vwGETzuranMsGtGVEl2Y6EYxS6rhoUGjiispd/Lglj/mb8vh+Uy7ZBRWA1Xv4/vO7cnG/NJrFRQQ5lUqpk4UGhSbG5fGSuaOQ7zfmMn9THit9HcdiIxwM7ZTCjb/qxPDOqbRPidaOY0qpBqdBoQnIyivj+01WEFi4JZ/SSjc2gT5tE7ntrAzOyEilT9tEnTNAKRVwAQ0KIjIa+DdgB14yxjxRa3974GWgGbAPuMoYkx3INDUV2/LK+OTnXXy8chcb95QCkJYUxZi+rTkjI5UhHVNJiA4LXgK9XijJgdgWYNdnB6VCRcD+2kXEDkwFRgHZwBIRmW2MWVvjsKeA14wxr4rIWcDjwNWBSlOw7dhXzqercvj4512s2VUMwMD0ZB65qDsjujQPfpFQ6V7Y8i1s/tp6L88HmwMS20Fyx4Nfie3BoSOhqqNUVQb7tkLhL+CIgMhE3yvBegXr35Qx4KkCVzk4i8FZ5HsV7l+uKKx7u9ig4wjoch60HQT2ID7QHadAPgIOBDYbY7YCiMhMYCxQMyh0B/7oW54LfBjA9ATF7iInn67K4ZOVu1jxSyFgFQs9cEE3LujdilYJUcFLnMcF2UusILD5a8j52doe0ww6j4I2p0LpbusPeN9W+GUxVJXs/7zYICHtwEDRbiiknRqc6zlRlOXDxs9hwxzI22TdBB2R1stevRxR41Vre1g0RMRCeCxExNdYjoXwOOvdEeTGBx43FG6H/C2Qv9n32mStF+88/GfDon0BItF6j0rcvx4ebd28jcf37t3/8noOXK8+zlMFLie4K8BdCa4KcDt975XWdpfT2oY5woUJRMYfGMRSOkFlCfw0DRY+b23rPBJOOQ86nw3RyQ3xG200gQwKbYAdNdazgUG1jvkZuASriOliIE5EUowx+TUPEpFJwCSAdu3aBSzBDSWvtJLPVuXw8coclmTtwxhr6sl7Rnfhwl6taZcSHbzEFWXvDwJbv4PKYhC79XRz1oPWP+aWvcFWR/2FMVbuoTpI1Hyt/sB6cgIroJz1F2jdr1EvrUnL3wLrP7UCwY7F1k0rvg206W/dzNxOcFdZT53uveCp9G2rrPGqz03Lxxa2P0hEJvhyex0ODOAJaWA7xrGtjIGKAusGX7zL+ndVsG1/ENi3Dbyu/cdHJkBKBqQPh5TO1o00Kd16MKl+4vY/hRceuK14F+xdZ22rKrceRsRmpV1sILJ/m9hrLPte9jAIi/IF2CjrJl0dhMMirW1hkTW2RVnBtmYwqg4AEfF1/22AFRi2zoMNn8OmL2D1+1Z62g2GU861gkRqhpXew3FXQsH2uv/OznoAeo0/tu+snsSYev4jO9oTi4wHRhtjfudbvxoYZIy5rcYxrYHngQ7AfGAc0NMYU3io8w4YMMAsXbo0IGk+Hl6v4dv1e3l1YRYLNufhNVaz0Yt6t+bCPq2C25msshR+eMa6KeWut7bFt7ECQOeR0PFX1j/441WWDytehwX/sm4YXS+EM++HFj2O/9zVnEVWjsXtBK+7xhOix1r3L3sP3BbXCrpeYN0oG4PXA9lLrSCwYQ7kbbS2t+wFXc63Xq36HPkGUZMx1k3UVWZ9p1Wl1ntl8f7lqlLr5lRzvaLQemrft9UXWHxsYdaN+aCiwQ7WjbBkFxTt3H/jL/YtF/nW3RUHps8eYd3sUzr5bvzVrwzrRhxKreW8Xti13Jcj/Bz2rLK2J3WAU0ZDl9FWfV31zT5/i295GxTt4IDgHxG//7s59VqrmOoYiMgyY8yAIx4XwKAwBHjEGHOub/0+AGPM44c4PhZYb4xJO9x5m1pQKK10897SHbzyYxbb88tplRDJJf3bcFGf1nRpERf8ZqO/LIJZN1pPHh1/ZT3Fdx4JzboE7o/UWQyL/mtlpStLoOc4GHEfpHY+tvO5K2HTl7DyHdj4hfUUfSzCY6HHr6HvVdbTW0Nff1W570lxjnUzKMu16mTST4cuF1g3gsQg5nSrGw8c9AS6zXp3lR36s2K3AmtCG4hvbT1UxNdcbg1xLY8953GyK8q2/k1s/MLKodf+NxyVXHe9XXLHBguoTSEoOICNwNnATmAJcIUxZk2NY1KBfcYYr4g8BniMMQ8d7rxNJSjs2FfOqz9m8faSHZRUuunfLpHfDuvA6J4tm0bTUXcVzPsbLPg3JLSFi1+A9kMbNw3l++DH52DxC9YTap8r4Ff3QFL7I3/W64XtP1iBYO1sqCyy6jp6XALdLrKy9jaHdbOqLkawOXzLdt+ybf/+nJWQ+Qas+dB6ek7uBH2vgD4TrBvdsfB6rHqYbd9Zf+i/LLKeniPiIWOUlRvoPNJKa1NnjNXQoDpQVBYfePOPba43/IZSVQbb5lvv1TmzqKSA/9igBwVfIs4H/oXVJPVlY8xjIjIFWGqMme0rYnocK680H7jVGHPYx8BgBgVjDEuyCnj5h218uXY3NhHO79WK3w5Lp1+7wH+p9bZnDXxwo5Vl7Xc1jH4cIuKCl57SXPjhn7DkJau4p/81cMZd1k2nJmNg90orEKz+wCq+CI+1gkCv8dBhxPE3j60shXWzYcWbVtARG3Q8E/pdZd3Eww4zpagxkLvBCgLb5kPW91ZxFkDz7tDhDKtooP0wbZWlmpwmERQCIRhBodLt4dOVOby8YBurdxaTGB3GFQPbcfWQ9sFtPVSb1wMLp8K3f7XqCMY8ZzWRayqKd8H8p2D5q9aT/Gm/g2G/t57cV70Hq96FvA1WWXfGKCsQnHKe1eIkEPZthcy3IHMGFGdb5ei9LoV+V0KrvlaWvWC7FQCqA0HpHuuzie2t4rgOv7KCQWzzwKRRqQaiQaEBFBQW8taSbKb/tJvckko6N4/lumEduLhfm6Y3I1lBFnx4C2xfYFXwXvRviEkNdqrqVpAF3z0JP8+wgoOnytrefph1U+4+tnGb8Xk91k1/xZuw7mOrvLd5d6u9ekGWdUxMc+vm39EXBJLSGy99SjUADQrHyVmwi33PnonTA8+2/SeX/Oo0hmekBr/iuDZjYMUb8Pm9gMD5T1rl5E0tnXXJ22S17Y5vY+UKEg7bxqBxVBRaTQlXf2DltqoDQbOuJ8bvVKlD0KBwPCpL2PPsSOJKtxEe5sAR1xwmftI0blo1lebCx3dYrV3Sh8Ov/xPc1i0hyHi9VG3ZQvmKFVSuX4+3shLcHozXCx4PxuMBrwfjOXjdeNxEdOpMi3v/jC2qCRVDHgVvVRUln39O4axZhLdrT/M//gF7QgM0b1YNrr5BQQe1qc1dRfkbV5JSupH/tf0bN44+DV6/BF453woMTeWmu/5TmH2H1eTz3L/BoJsP3alGNRhvRQUVq1ZRsXwF5SuWU5H5M94iq7LZFheHLToasdvBbkdsNnA4rHe7vdZ2O4JQ+O67VG7YQNp//4MjqQk1VjgC165dFMx8m8L33sOzbx9hbdpQ/tMSSr75hpYPPEDcuec0vVy1qhfNKdRkDGbWjcjKt3mYm7n9rsmkxkbAzuXw+q8hIgEmfhy88uTCHVZ7/Q1zrB7JLXvDJdOgebfgpCcEuHNzKV++gorlyylfsQLn2rXgdgMQ3qkT0f37EdW3H1H9+xGenn7UN8LiL79k1113E5aWRrsXpxHW5hibxzYCYwxlP/5IwVszKJ07F4DYESNIuuIKYoYOoXL9enIeeBDn2rXEjjyblg8+RFgLrYCvqcpTRamrlDJXGU63kypPFZWeSio9lbi8Lv9y9faa+6s8VZzd7mz6Nu97TD9bi4+OxdeT4YdneNo1nrRfP8zlp9XIFezKhNfGWk0kJ35stS8ONI/LGhJh05ew8UvIXWdtT2xndcA6/Q/1bvpoPB6w2QLy9GZcLkq++op9b7xJ5caNiMMBYQ4kLAxxhPneHfvfHQ4kPMx6ig4PJ7pfP+IvuICwli0bPG3HwhhD7jP/pPizz3BlW4P2SkQEkb16Et2vP1H9+xHVt2+DPdmXL13KjltuxRYZSdsXXySyyykNct6G4ikupujDDyl4awZVWVnYk5JIvPRSki6/7KAgZtxu9k2fTu5zzyNhYTS/+24SLx1v5Y6qjzGGElcJueW5uL1uRAT/f75l6/8DtwmCFy9Ot5MKdwVOj3P/co1tB6y7nRgMdrFjt9mxix2HzeFfd4jjoHWbWGk1GIwx+P8zB7978YIBt3FT7iqnzFVGqavUv1zmLqOsyvfuKsPtdR/TdyAIEfYI7h14L+NOGXds59CgcJR+ehHm3MW7jOTdln/i7RuHHHwDzVlpBQZHpFWUlNKp4dNRssfKBWz6ArbMtToR2cKsjmcZ51iv+oyf4uMpLiZ/2jT2vfY6YW3akDB2LAljLiKsdesjf/gI3AUFFL77HgVvvol7zx7C2rUjdvhwMF6My41xuTDumu9V4HZjqvZv95aXU7VtG4gQPXAgCWMuIu6cc7DHBa9fRdHHH7Pr7nuIOf10YoYNI7pfXyK7d0fCA9f3wLlxIztumIS3vJy0qc8TM3BgwH5WvdO0YQMFb75F0ccfYyoqiOrTh6QrryBu9Ghsh/ldON1Odq1fTtlj/8CxYj2F3duw4Oo+bI4tI6csh91luyl3l9c7HQ63oVeWYdAGQ9tcQ0m0UBQDhTFQVGO5OEYojIHSKIhwRBHliCLCEYFd7Li9bjzGg8frwW3c1nv1NuM57t+VIMSExRAdFk1MWAyxYbHWsiPGvz02LPaAYyIdkUTaIwm3hxNhjyDCHnHQcrjNWje5+ex59FGa3XYbkV27HlsaNSgchbWz4Z1rWBU7lMsKbuHjO0fQufkhxsjZswZeHWM1pZz4iXWDPh7GwM5lVvf3TV9CTqa1Pa6V1VY/4xyrLXxk/FGd1ltVRcGbb5H/wgt4iouJP280rr17qVi6DIDoQYNIGDvWugHHxhzVuSs3bWLfa69bNwunk+ghg0m+5hpif/WrA54I66sqK4uiTz6l6OPZuLb/goSHE3vmmSSMuYjY4cMDejOuzVNczJbzziesdWvSZ86w6gEaiWvXLn65YRKuHTto/Y9/EH/uOY32s8F6yneuX0/u4u8p/fIr5Od1mPAwys88lfzzB1LYPpkKd4X/Ve4uP2A9vyKf3WW7Kags8J3QcNbPhqu/9RLmgfnntGLb+b1oEd+aljEtaR7dHIfNccDTuPW/gYpKIpetJ2bBSqJ/Woe93IknKoLKU9riKHPiKChFCksQTx03dLsde3ISjpRUHCkpxJx+OslXXYmE1T2ctTHGHxyqgwaADdv+nAtgE1uduZqa7w3+nRhD0Qez2PPEExiXi1aPPkrChRcc07k0KNTX9oXw2liKE7sxcOed3Hh2T/4w6gjZ973r4NWLAIFrP4bmxxC5K0utdvo/TbMGSxMbpA20AsEp50KLnsfUBNJ4vRR/Oofcf/0L186dxAwbRvO7/kRkN6veoWrHDopmz6boo9m4fvkFiYwkbtQoEsaMIWbokEPeBI3XS+l331Hw+uuU/bgQiYggYcxFJF11dYMVdxhjcK5aRdHsjymeMwfPvn3YExKIGz2ahDEXEdWv3zEFnaOxe8oUCma+Tfq77xDVowEH8qsnT2EhO266mYqff6bFgw+QfMUVDf4ziiqL2Fm6k117NlOybClm5TpiN2TTYlsR4S7rfrArCb7uZ2Nub6Es6uB/hxH2CKJ8T+PVr+TIZFrGtKRlTEtaxbTyL6eUCvv+9ndKvvqaiO7daPXXv9b5u/WUllI67ztKvvyS0u+/x1RUYE9IIPbss4k7ZxQxQ4cekEMxXi/e4mLc+fm48/Lx5Ofhzsu31vPz8OTl48rJoXLDBiIyMmj5yMNEn3riDOvu2rWLnIcepuyHH4gacCqtH3uM8Pb1GCLmEDQo1Mfe9fDyuXijUxlT8SDljkQ+u3M4EY56PB3mbrACg/HCNbOhRff6/cx926zhHpa/bo3n07ofDJxkDY9wnB22yhYuZO8/nsK5di0R3brR/K4/ETtsWJ3HGmOoyMyk6KOPKJ7zGd7iYhzNmhF/0UUkjB3rv9F7Ssso+uAD9r35Bq7tv+Bo0YKkK64g8bJLA9paxrhclC1cSNHsjyn5+muM00lY69a+9I0homPD1+lUrFpF1mWXk3TllbR84C8Nfv7DqS5nzyvPI7cgG/vkfxOzaC2bxvThh/PbkuvMI6/CenmMx1/EEOmI9C9H2COIcEQQYbPeI+3WPrvNzu7SHMp2ZBG3Lpv22yvokm1omws2wCuwu3Uk+zKaU9WjExH9+pDUrjPRjmj/DT/aEU1UmLUcaY/EfgzjIBV/+SW7//pXPPsKSPntRFJvuw3jdFLy7VxKvvySsgULMC4X9tRU4kaeTfw55xB92mmHfMKvr5Jvv2X3o4/i3pVDwiWX0Pzuu5p0Sy9jDIXvvMveJ5/EGEPzP/6RpCsmHPcDkQaFIyneBS+NAq+L/3Z+gb8vqmDmpMEM7phS/3PkbbICg6fKCgwte9Z9nDFWj9nF/wcbPrMGFus+1mpGmjbguDtFOTdsYO9TT1P2/fc4Wrei+e9/T/yFF9b7H5G3qorSufMo+ugjSufPB7ebiG7diOzRnZLPv8BbWmqVJ19zNfHnnHPcf6RHy1tWRsk331A0+2PKfvwRgLTnnyPurLMa7GcYj4esSy/DnZtLxzmfHlWdhjEGt9dNubv8oMrG6pYm/lfNiseqMoqqisgtzyWvIg+nZ/+w1jav4YbPvZz9s2HxqbHMm9CN1LjmpEal4hAHTo/TapXirvS3TnF6rNYsTo+TSpeThD1ldNxcxinbquiS7SW+xCpq8USF4+rekYi+fUgddDqppw7BFnN0RYjHylNUxN6nnqLw3fewp6biKSwEtxtHq1bEjRpJ/DnnWDnCBi6285aXk/ff/5L/ynTsMTE0u+tPJI4bF/Cc59Gqyt5JzoMPUL5wEdGDBtHqsUcJT2uY/lEaFA7HWQQvnweF29l60buMmlHIuP5teHJ8n6M/V/4WmH6hNTrmNR9ZY+RXqyqHlW9bwSB3HUSnwoDfwoDrDh4M7hi4cnLIffY5ij78EFtcHKk33UTSlVdgizj2Wbfc+/ZRPOczij76COe6dcSfey7J11xNVJ9j+N0EgDs3lx033UzV9u10eO9dwtPTj/lcXuOluLKYgsoCSt56m7B/v0r23ZezfWAahc5CytxWs0Gn20mFp8K/7HQ7/S1fqt/rW1kZbgsnNjyWaEc0seGxxIXH0SyqmfWKbkZqVOr+5chUKl54hfz//pfYESNo889nDtvJzZWTQ9mixZQvWkjZosW491jjNDlatSL61FOJ6t+P6P79icjIaNS6krqULVpE/iuvEJmRQdw55xDZq1ej9Guo3LSJnMmTqVi6jKh+/Wj5yMNEdukS8J97JMbrpWDmTPY+9TQCNL/nbhIvu6xBg5YGhUNxV8Ib4+CXhXgmvMu4LyPYsa+cb/70KxKjj7FCc99WmH6RNbDbNR9CdIrVmmn5a9ZsUS17WbmCnuMOPwpnPXlKSvwtivB6Sbr6alIn3YA9MfG4z12T8Xqb3JMUgGvnTraNG4+jWTPSZ8444CnX6Xb6i1lqvvKd+RQ6CymoLKDAWUBhZSGFlYV4jZfEUsO/pnnY1Ep47DfWTF5RjiirhYg9kkhHpFVs4mst4l/3LdfcHhMW43/5W6DUWA6zHX0uq2DGDHZP+StRvXuT9sJ//UUf7n37KP/pJ8oWLqJ80SKqtm8HwJ6URPTgQcQMHkLMkMGEtW2rHclqMMZQNOtD9v7jH3iKi0m+5hqa3XZro+WWaqv65RdyHniQ8p9+ImboUFr9dUpA+qtoUKiL1wsf/M4a2+biabxWPoiHPlrDvy7vy6/7HeeXUJBlBYbyPN/sVmIN+Tzopgad0MUYw/Yrr6JixQoSxlxEszvuaNIdnhqKx+thb/leskuzySnLoWrhEro/9j7bTm3Fe1e2Jc+ZT35FPiWukoM+KwhJkUkkRSRZ75FJJEYk+rd1+fenxPy4Gl7/J8kZPUmISCDK0bSGnfB3cmvThtgzzqBs8WIq11uz6NliYog+7TRihgwmevBgKyfQBIN5U+MuKCD3mWcofPc9HC1b0uIv9xM3cmSjBVDj9VLwxhvs/ee/ELudFvf+mYRx4wL28zUo1OWLv1izgY2czO5eNzHyme/o1y6R164b2DBfROEv1tATrfvCgOshse3xn7OWkrlzyb75Flo+/BBJEyY0+PmDxRjDPuc+dpbu9L+yS7L9yzllOQd1/Ll0sZ1Lv63km7Ht2HZeT3/xS0pkilUM41tPjEjEYat7RJfSBQvYcf3vSL31VprdfludxzQV1Z3cjNNJVP/+xAweRMzgwUT27Gl1GFTHpHz5CnZPnkzlhg3E/upXtHjwgQYrxz8U54YN7J7yVyqWLSPmV2fQavLkgHfe1KBQ2+L/g8/ugYE3wnl/56Y3ljN3w16+/MMZtE8JTrbxaBlj2DZuHN6SUjrN+bTRK3yPVbmrnPyKfHIrcg8q0sktz2VX6S52le2iotacv8mRybSJbUNabBpt4trQJtZ6tY5tTbOoZkQ5oth5xx2UfDuXdi+/TMygo+vw5a2sZNuYsRgMHWfPPq66mMbirawEY7BFHn8xpNrPuN3se/0Ncp97DjweYkeMIPaM4cScPrxBhuowXi/OVaso+fobSr7+mqpt27DFx9Pi/vtIGDu2UXInOiBebenDraafox/nq3V7+XzNbu4+t8sJExAASr76isq162j1xONNJiCUucrYUbKD7JJsdpTsYHfZ7oPK8+vqvWoXO8mRyaRGpdIuvh1DWg8hLS7Nf+NvE9uG6LAjT67T6vHHqbz0Mnb+8Y90eP+9o3rayn/pJaq2b6ftSy+dEAEBOGHSeaIRh4OU304k/rzR5P33BUrnzqXkiy8AiOjaldjhw4k9YzhRffvW+2/PuFyUL1lCyddfU/L1N7j37gWHg5iBp5F09VXEjx6NI7kR5w2pp9DJKfiUVroZ9cx3xEeG8ckdpzeN+ZTrwXg8bPv1rzFuDx0/+bjRWo8YY8iryGNHyY4DXtml2WSXZLPPue+A4+PC4kiNTiU1KpXUyFRSolL8xTjV69VFOsfS1r0ulVu2kHXpZYRndKb9668fdgiGalXbt7P1ojHEjTybNs880yDpUCcPYwyVGzdSOn8+ZfO/p3zFCnC7scXFETN06CFzEd7yckp/+IGSr7+mdN53eIuLkchIYoefTtzIkcSOGBG0ocU1p3AIT3+5gd3FTp6/ov8JExAAij/7nMpNm2n99FMBCQger4edpTvZVLCJTYWb2FSwia1FW8kuyT6w/bzYaBndkrZxbTmz7Zm0jWvrf6XFpREX3vhjFkV06kSrxx9n5513sudvf6PVI48c9nhjDLun/NUasO3P9zZOItUJRUSI7NKFyC5dSL3hBjwlJZT9uJDS760gUTsXEZaWZgWQH37AVFZaPfHPOou4USOtntgn0HwZIRUUVmYX8uqPWVw5qB2ntm+6PRprM243ec8/T0RGBvHnHd+cy9VP/jVv/psLN7OlcMsBN/+02DQ6J3ZmSOsh+2/6sVbxTpi9aRRd1RR/7jk4f3c9+S/9j6hevUkcd8khjy35/HPKFiygxf3369DOql7scXHEn3sO8eeec1AuIv+VV6wOeC1bkjh+PHGjRhI9YMAJW/l/Yqb6GLg9Xu77YBWpsRHcM/rYRhkMlqLZH1OVlUWb55496qaGRZVFLN2zlCW7l7Bh3wY2FW6iqLLIvz8lMoWMpAzGnzKejKQMMhIz6JTYqV7l+U1Ns9//noo1a9g9eTIRXboQ1bPu8XX2/O1xIrp3I+mKk6f1lmo8deUi3Hv2EN6p00nRHyRkgsL0H7NYs6uY/1zZn/jIpvekeyjG5SLvP/8hsnt34kaOPOLx5a5yMvdmsmj3In7K+Yl1+9bhNV4i7ZF0Se7CyHYj/Tf/zkmdSY5sehVdx0ocDto8/TTbxo0n+47b6fD++weNcZP77LO48/JIm/r8Cfskp5oWe1xcUId6b2gh81cxoktziitcnNezaUzkUl+FH8zClZ1Ny/97oc6nEJfHxaq8VSzevZjFOYv5Ofdn3F43DpuD3qm9ubH3jQxqNYjeqb2bZLFPQ3MkJ5P27LNsv/JKdv3pT7R98UV/HYxz7VoK3niTxN9cTlTv3kFOqVJNU0BbH4nIaODfgB14yRjzRK397YBXgUTfMfcaY+Yc7pwBnXmtifFWVrLl3NGEtWhB+5kzEBE8Xg8bCjbwU85PLNq9iOV7llPhrkAQuqV0Y1DLQQxqNYh+zfudkEVADaXwvffIeeBBUiZNovkf/2ANeDfhClw7d9LpsznY449ufgqlTnRBb30kInZgKjAKyAaWiMhsY8zaGoc9ALxjjPmviHQH5gDpgUrTiabwnXdx796N+94beX3t6yzZvYRle5b5h3LokNCBsZ3GMrjVYAa0HEBCRHCaujVFiePHU7FyFfnTphHZqyee/HycK1fS+sm/a0BQ6jACWXw0ENhsjNkKICIzgbFAzaBggOq/0ARgVwDTc0LwGi8bCzaybPuPdHnu3+xo7+Ch3Y/CHqF9fHvOST+H01qexmktT6N5tLacOZwWD/wF5/r15Nx7H9jtRA8aRPxFFwU7WUo1aYEMCm2AHTXWs4FBtY55BPhSRG4HYoAj16Q2ovxXpuNcvZqEsWOIGTYsIP0DvMbLpoJNLNm9hJ92/8SyPcsorirmosVe+hd72XnLWTx+xnkMaDGAljEnVn1IsNnCw0n797/YNm48npISWj780EnROkSpQAp2RfMEYLox5mkRGQK8LiI9jTHemgeJyCRgEkC7du0aLXGF771H1ZYtFH/6KY4WLaxJ7y/+NREdOhzXeXeW7mTRrkUsylnE4pzF/jlt02LTGNl+JKfF9aTzf58memgPbps4tSEuJWSFtWpF+zdex703NyCztSl1sglkUNgJ1BwmNM23rabrgdEAxpiFIhIJpAJ7ax5kjJkGTAOrojlQCa7NnZdH4qXjiRl2OoWzPiD/pZfInzaNqP79SbzkYuJGn1evSe+LKotYnLOYRTlWINhRYmWgmkU1Y3jacAa1GsRpLU6jVWwrAPJe+D9yC4toducdAb2+UBHRsaMGBKXqKZBBYQmQISIdsILBb4Das5D/ApwNTBeRbkAkkBvANNWbt7ISb1GRNS/w6HOJH30urj17KZr9EUUfzCLngQfZ/djfiD/3XBIuudiaS9ZXNFHpqWTF3hX+3MDa/LUYDDFhMZzW4jSu7HYlg1sNpmNCx4OKMzzFxeS//DKxI0Y0mdnOlFKhI2BBwRjjFpHbgC+wmpu+bIxZIyJTgKXGmNnAn4AXReQPWJXOE00TGaHPk5cHgD011b8trEVzUm+4gZTf/Y6KFZkUzfrAmrryww8Ja9sW9+jhvNx2G99WraTSU4lDHPRu1pub+97MkFZD6JHa44gzb+2b/ire4mKa3XF7QK9PKaXqEtA6BV+fgzm1tj1UY3ktMCyQaThW7lwrw+Jo1uygfSJCdP9+RPfvR4v77iP/80/Z8MYLpLz4FtcCowZ3IPrGifQdcAExYfUfmttdUMC+V1+15qzt3r2hLkUppertxBkmtJG5fTkFR+rBQaGmRQWZXGNe5uaxe/nw8dHE/fYq2q7cQ/L1kyl66DGqsrPr/TP3vfwy3vLyJj8DmFLq5BXs1kdNlj8o1JFTAMivyOfJJU8yZ9sc0uPTefnclzmt5WnWZ393E/nTXqRgxgyKPv6YxPHjSL3ppsNOAOPOy2PfG28Sf/75RGRkNPwFKaVUPWhO4RDce3NBBEfKgQPGeY2XDzZ9wJgPx/Dl9i+5qc9NvDfmPX9AAHCkpNDivnvp9NWXJF46nsL3P2DLOeey5/HH/cGmtvwXX8JUVpJ6260BvS6llDocDQqH4M7Lw56cfMBImlsLt/Lbz3/Lwz8+TOfEzrx/0fvc2vdWIux1T5EY1qIFrR5+mE6fzSH+wgvZ9/obbB51DnuffgZPYaH/ONeePRTMmEHC2LHH3QdCKaWOhwaFQ3Dn5uLwtTyq9FQyNXMq4z4ex+bCzUweOplXRr9Cx8T6tX0PT0uj9d8eo+MnnxB31lnkv/QSm0eOInfqVDylpeT/3/9hvF5Sb70lkJeklFJHpHUKh+DOy8ORmsqS3UuYsnAKWcVZnN/hfO4+7W5So1KPfII6RHTsQJunnyJl0iTynn+OvOeep+C11/GUl5M4bhzhaWkNfBVKKXV0NCgcgjsvj61JLn7/xXW0iW3DCyNfYFibhmk9G9nlFNKee46KVavJffZZnKtWkXrTjQ1ybqWUOh4aFOpgjMGdm8uS9L2cl34+k4dNJsrR8BNvR/XqSbsXp2GM0YHalFJNgtYp1MFTWAhuN8WxNu467a6ABISaNCAopZqKIwYFEblIREIqeOz5ZT0Ap3QeqHMWKKVCSn1u9pcDm0TkSRHpGugENQWfLXsLgLP6jgtySpRSqnEdMSgYY64C+gFbsEYzXSgik0QkLuCpC4K8ijxWrZ8PQIt2IREDlVLKr17FQsaYYuA9YCbQCrgYWO6bMe2k8tqa14gt9QCHHuJCKaVOVvWpUxgjIrOAeUAYMNAYcx7QB2vo65NGobOQmRtm0s+ejkRFYYup/winSil1MqhPk9RxwD+NMfNrbjTGlIvI9YFJVnC8se4NKtwV9JI07KlV2ipIKRVy6lN89AjwU/WKiESJSDqAMeabwCSr8ZVUlfDWurcY1X4UkUVOLTpSSoWk+gSFdwFvjXWPb9tJZcb6GZS4Srih1w0HjHuklFKhpD5BwWGMqape8S2HBy5Jja/cVc7ra1/njLQz6JbSzT/ukVJKhZr6BIVcERlTvSIiY4G6JwU4Qb278V0KKwuZ1HsS3spKvMXFOJpr8ZFSKvTUp6L5JuBNEXkeEGAHcE1AU9WInG4n09dMZ3CrwfRp1oeq7J0AmlNQSoWkIwYFY8wWYLCIxPrWSwOeqkY0a/Ms8iryePKMJwHw5OUC2kdBKRWa6jVKqohcAPQAIqubaRpjpgQwXY3C5XHx8uqX6d+8PwNaDLC25VpBwa45BaVUCKpP57UXsMY/uh2r+OhSoH2A09UoZm+Zze6y3UzqPcnfJ8Hjm0PZkao5BaVU6KlPRfNQY8w1QIExZjIwBDglsMkKPLfXzUurXqJHSg+Gth66f3tuHojgSEkOYuqUUio46hMUnL73chFpDbiwxj86IhEZLSIbRGSziNxbx/5/ikim77VRRArrnfLj9Nm2z8guzT4glwDW3Mz25GTEofMPKaVCT33ufB+LSCLwD2A5YIAXj/QhEbEDU4FRQDawRERmG2PWVh9jjPlDjeNvxxqNNeC8xsuLq17klKRTGNF2xAH73Hl5WsmslApZh80p+CbX+cYYU2iMeR+rLqGrMeahepx7ILDZGLPV1+FtJjD2MMdPAGbUM93H5evtX7OtaBs39L4BW635g7Q3s1IqlB02KBhjvFhP+9XrlcaYonqeuw1Wn4Zq2b5tBxGR9kAH4NtD7J8kIktFZGmur3XQsTLGMG3lNNLj0xnVbtRB+zWnoJQKZfWpU/hGRMZJYIcM/Q3wnjHGU9dOY8w0Y8wAY8yAZsd5w/4u+zs2FGzght43YLfZD/w5Xi/u/HzNKSilQlZ9gsKNWAPgVYpIsYiUiEhxPT63E2hbYz3Nt60uv6ERio6qcwltYttwXofzDtrvKSoClwtHMw0KSqnQVJ/pOOOMMTZjTLgxJt63Hl+Pcy8BMkSkg4iEY934Z9c+yDfvcxKw8GgTf7QW5ixkVd4qru91PWG2sIP2u3O1N7NSKrQdsfWRiJxR1/bak+7Usd8tIrcBXwB24GVjzBoRmQIsNcZUB4jfADONMebokn70pq2cRovoFoztVHd9tz8oaPGRUipE1adJ6t01liOxWhUtA8460geNMXOAObW2PVRr/ZF6pOG4Ld29lGV7lnHvwHsJt9c98re/N7PmFJRSIao+A+JdVHNdRNoC/wpUggJla9FW2sS2YVzGuEMe4/aPe6RBQSkVmo6l22420K2hExJol3W5jIs7X0yY/eC6hGru3DwkKgpbTHQjpkwppZqO+tQpPIfVixmsium+WD2bTziHCwiwv49CYFvfKqVU01WfnMLSGstuYIYxZkGA0hNU2ptZKRXq6hMU3gOc1R3LRMQuItHGmPLAJq3xufPyiMjICHYylFIqaOrVoxmIqrEeBXwdmOQEl+YUlFKhrj5BIbLmFJy+5ZOuJtbrdOItKdHmqEqpkFafoFAmIv2rV0TkVKAicEkKDndePoAOcaGUCmn1qVP4PfCuiOzCmo6zJdb0nCcVd+5eQHszK6VCW306ry3xjU/UxbdpgzHGFdhkNT639mZWSqkjFx+JyK1AjDFmtTFmNRArIrcEPmmNa39vZs0pKKVCV33qFG4wxhRWrxhjCoAbApaiIPHk5YHNhiMlJdhJUUqpoKlPULDXnGDHN/dy3SPKncDcuXnYk5MRu/3IByul1EmqPhXNnwNvi8j/+dZvBD4LXJKCQ/soKKVU/YLCn4FJwE2+9ZVYLZBOKjo3s1JK1W/mNS+wGMjCmkvhLGBdYJPV+DSnoJRSh8kpiMgpwATfKw94G8AYc2bjJK3xGK8Xd36+5hSUUiHvcMVH64HvgQuNMZsBROQPjZKqRuYpLAS3W3MKSqmQd7jio0uAHGCuiLwoImdj9Wg+6bhzfR3XmmtOQSkV2g4ZFIwxHxpjfgN0BeZiDXfRXET+KyLnNFL6GoU7z+q4pjkFpVSoq09Fc5kx5i3fXM1pwAqsFkknjerezBoUlFKhrj6d1/yMMQXGmGnGmLMDlaBg8Oi4R0opBRxlUDhZuXNzkehobDExwU6KUkoFVUCDgoiMFpENIrJZRO49xDGXichaEVkjIm8FMj2H4s7N03kUlFKK+vVoPia+MZKmAqOAbGCJiMw2xqytcUwGcB8wzBhTICLNA5Wew3Hn5eFI1aIjpZQKZE5hILDZGLPVGFMFzATG1jrmBmCqb+RVjDF7A5ieQ9LezEopZQlkUGgD7Kixnu3bVtMpwCkiskBEFonI6LpOJCKTRGSpiCzN9bUUakg67pFSSlmCXdHsADKAEVjDabwoIom1D/K1eBpgjBnQrIFv3l6nE29JieYUlFKKwAaFnUDbGutpvm01ZQOzjTEuY8w2YCNWkGg0Og2nUkrtF8igsATIEJEOIhIO/AaYXeuYD7FyCYhIKlZx0tYApukg/o5r2vpIKaUCFxSMMW7gNuALrKG23zHGrBGRKSIyxnfYF0C+iKzFGkrjbmNMfqDSVBftzayUUvsFrEkqgDFmDjCn1raHaiwb4I++V1Bo8ZFSSu0X7IrmoHPn5oLNhj05OdhJUUqpoAv5oODJy8OekozY7cFOilJKBV3IBwV3rvZmVkqpahoUcnO15ZFSSvloUNBxj5RSyi+grY+aOuP14s7P1+ao6qTmcrnIzs7G6XQGOymqEURGRpKWlkZYWNgxfT6kg4KnsBDcbm2Oqk5q2dnZxMXFkZ6ejshJOc268jHGkJ+fT3Z2Nh06dDimc4R08ZH2ZlahwOl0kpKSogEhBIgIKSkpx5UrDPGgoB3XVGjQgBA6jve7Du2gkKdDXCilVE2hHRR03COlGoXdbqdv37707NmTiy66iMLCwkb5uf/6178oLy8/aPvFF19M37596dy5MwkJCfTt25e+ffvy448/1uu8Q4cObeikNhkhHRQ8eXnYoqOxxcQEOylKndSioqLIzMxk9erVJCcnM3Xq1Eb5uYcKCrNmzSIzM5OXXnqJ4cOHk5mZSWZmpv9m73a7D3ve+gaPE1FItz5y5+Zi10pmFUImf7yGtbuKG/Sc3VvH8/BFPep9/JAhQ1i5ciUAW7Zs4dZbbyU3N5fo6GhefPFFunbtyrvvvsvkyZOx2+0kJCQwf/58pk+fzuzZsykvL2fLli1cfPHFPPnkkwB8+eWXPPzww1RWVtKpUydeeeUVXn75ZXbt2sWZZ55Jamoqc+fOPWy6pk+fzgcffEBpaSkej4dPP/2UsWPHUlBQgMvl4tFHH2XsWGtG4djYWEpLS5k3bx6PPPIIqamprF69mlNPPZU33njjhK7DCfGgoNNwKtWYPB4P33zzDddffz0AkyZN4oUXXiAjI4PFixdzyy238O233zJlyhS++OIL2rRpc0BRU2ZmJitWrCAiIoIuXbpw++23ExUVxaOPPsrXX39NTEwMf//733nmmWd46KGHeOaZZ5g7dy6p9SwiXr58OStXriQ5ORm3282sWbOIj48nLy+PwYMHM2bMmINu+CtWrGDNmjW0bt2aYcOGsWDBAk4//fQG+501ttAOCnl5RHTpEuxkKNVojuaJviFVVFTQt29fdu7cSbdu3Rg1ahSlpaX8+OOPXHrppf7jKisrARg2bBgTJ07ksssu45JLLvHvP/vss0lISACge/fubN++ncLCQtauXcuwYcMAqKqqYsiQIceUzlGjRpHsGzHZGMP999/P/Pnzsdls7Ny5kz179tCyZcsDPjNw4EDS0tIA6Nu3L1lZWRoUTlTu3FxiTuAvT6kTRXWdQnl5Oeeeey5Tp05l4sSJJCYmkpmZedDxL7zwAosXL+bTTz/l1FNPZdmyZQBERET4j7Hb7bjdbowxjBo1ihkzZhx3OmNq1C+++eab5ObmsmzZMsLCwkhPT6+z/X9daTqRhWxFs7eiAm9pqbY8UqoRRUdH8+yzz/L0008THR1Nhw4dePfddwHryfznn38GrLqGQYMGMWXKFJo1a8aOHTsOec7BgwezYMECNm/eDEBZWRkbN24EIC4ujpKSkmNKa1FREc2bNycsLIy5c+eyffv2YzrPiSZkg4J/xjUNCko1qn79+tG7d29mzJjBm2++yf/+9z/69OlDjx49+OijjwC4++676dWrFz179mTo0KH06dPnkOdr1qwZ06dPZ8KECfTu3ZshQ4awfv16wKqzGD16NGeeeeZRp/PKK69k6dKl9OrVi9dee42uXbse2wWfYMSaEfPEMWDAALN06dLjPk/58hVsv+IK2r44jdjhwxsgZUo1TevWraNbt27BToZqRHV95yKyzBgz4EifDeGcgnZcU0qp2kI3KPgHw9MmqUopVS10g0JeHths2JOSgp0UpZRqMkI3KOTmYk9JRuz2YCdFKaWajJANCh7tzayUUgcJaFAQkdEiskFENovIvXXsnygiuSKS6Xv9LpDpqcmdm6uVzEopVUvAgoKI2IGpwHlAd2CCiHSv49C3jTF9fa+XApWe2tx5mlNQqrE0taGzJ0+ezH333XfAtszMzMM23X3kkUd46qmnAHjooYf4+uuvDzpm3rx5XHjhhYdNU2ZmJnPmzPGvz549myeeeOKwn2lMgcwpDAQ2G2O2GmOqgJnA2AD+vHozXi/u/HwcqRoUlGoMTW3o7AkTJvD2228fsG3mzJlMmDChXuedMmUKI0eOPKY01Q4KY8aM4d57DypICZpAjn3UBqjZNz0bGFTHceNE5AxgI/AHY8xB/dlFZBIwCaBdu3bHnTBPQQF4PJpTUKHns3th96qGPWfLXnBe/Z90m8LQ2aeccgpJSUksXryYQYOs29I777zDF198wYsvvsi0adOoqqqic+fOvP7660RHRx9wDRMnTuTCCy9k/PjxfP755/z+978nOjr6gIHwfvrpJ+68806cTidRUVG88sordOjQgYceeoiKigp++OEH7rvvPioqKli6dCnPP/88WVlZXHfddeTl5dGsWTNeeeUV2rVrx8SJE4mPj2fp0qXs3r2bJ598kvHjxx/zV3Y4wa5o/hhIN8b0Br4CXq3rIGPMNGPMAGPMgGYNcCPXIS6UCo7qobPHjBkDWMNQPPfccyxbtoynnnqKW265BcA/dPbPP//M7Nmz/Z/PzMzk7bffZtWqVbz99tvs2LGDvLw8/9DZy5cvZ8CAATzzzDPccccdtG7dmrlz59Y5l8KECROYOXMmAIsWLSI5OZmMjAwuueQSlixZws8//0y3bt343//+d8jrcTqd3HDDDXz88ccsW7aM3bt3+/d17dqV77//nhUrVjBlyhTuv/9+wsPDmTJlCpdffjmZmZlcfvnlB5zv9ttv59prr2XlypVceeWV3HHHHf59OTk5/PDDD3zyyScBzVkEMqewE2hbYz3Nt83PGJNfY/Ul4MkApsfPvbe645oGBRVijuKJviE1xaGzL7/8coYOHcrTTz99QNHR6tWreeCBBygsLKS0tJRzzz33kOdYv349HTp0ICMjA4CrrrqKadOmAdaAetdeey2bNm1CRHC5XEdM08KFC/nggw8AuPrqq7nnnnv8+379619js9no3r07e/bsOeK5jlUgg8ISIENEOmAFg98AV9Q8QERaGWNyfKtjgHUBTI+fP6egxUdKNYqmOHR227Zt6dChA9999x3vv/8+CxcuBKyioQ8//JA+ffowffp05s2bd0zX/OCDD3LmmWcya9YssrKyGDFixDGdp1rNaw/kmHUBKz4yxriB24AvsG727xhj1ojIFBEZ4zvsDhFZIyI/A3cAEwOVnpp03COlgqOpDZ09YcIE/vCHP9CxY0f/RDklJSW0atUKl8vFm2++edjr6dq1K1lZWWzZsgXggMBUVFREmzZtAGuqz2qHS9PQoUP9RVpvvvkmw4MwWGdA6xSMMXOMMacYYzoZYx7zbXvIGDPbt3yfMaaHMaaPMeZMY8z6QKanmjs3F1tMDLZalUdKqcBrSkNnX3rppaxZs+aAVkd//etfGTRoEMOGDTvicNmRkZFMmzaNCy64gP79+9O8eXP/vnvuuYf77ruPfv36HTDxzplnnsnatWvp27fvQS2gnnvuOV555RV69+7N66+/zr///e/D/vxACMmhs3f+8Y8416yl0xefN1CqlGq6dOjs0KNDZx8l995c7FrJrJRSBwnNoKC9mZVSqk6hGxS0N7NSSh0k5IKCt6ICb2mp5hSUUqoOIRcUtDezUkodWugFBZ2GUymlDikEg0J1b2bNKSjVWESEq666yr/udrtp1qzZEYeZri09PZ08X26/Psdcd911NG/enJ49e9Z57GOPPUbfvn3p27evf3jvvn378uyzz9YrPb/73e9Yu3btUV1DUxfIYS6aJO3NrFTji4mJYfXq1VRUVBAVFcVXX33l7+0bSBMnTuS2227jmmuuqXP/X/7yF/7yl78AEBsbe9CQG8YYjDHYbHU/P7/0UqNNAdNoQi8o5OaC3Y49KSnYSVGq0f39p7+zfl/DDhzQNbkrfx745yMed/755/Ppp58yfvx4ZsyYwYQJE/j+++8B2LdvH9dddx1bt24lOjqaadOm0bt3b/Lz85kwYQI7d+5kyJAhB4z588Ybb/Dss89SVVXFoEGD+M9//oO91pzrZ5xxBllZWUd1PVlZWZx77rkMGjSIZcuWMWfOHJ544gmWLFlCRUUF48ePZ/LkyQCMGDGCp556igEDBhAbG8udd97JJ598QlRUFB999BEtWrQ4qp/dFIRe8VFeHo7kZKTWPx6lVGD95je/YebMmTidTlauXOmfxwDg4Ycfpl+/fqxcuZK//e1v/if7yZMnc/rpp7NmzRouvvhifvnlF8Dqsfv222+zYMECMjMzsdvtRxyn6Ghs2rSJW265hTVr1tC+fXsee+wxli5dysqVK/nuu+/880HUVFZWxuDBg/n5558544wzePHFFxssPY0pJHMKWsmsQlV9nugDpXfv3mRlZTFjxgzOP//8A/b98MMPvP/++wCcddZZ5OfnU1xczPz58/1DSV9wwQUk+XL433zzDcuWLeO0004DrKG5a447dLzat2/P4MGD/evvvPMO06ZNw+12k5OTw9q1a+ndu/cBnwkPD/fXkZx66ql89dVXDZaexhRyQcGTm6dDXCgVJGPGjOGuu+5i3rx55OfnH/kDh2CM4dprr+Xxxx9vwNTtFxMT41/etm0bTz31FEuWLCEpKYmJEyfidDoP+kxYWBgiAuwf1vtEFHrFR7m5WsmsVJBcd911PPzww/Tq1euA7cOHD/cX/8ybN4/U1FTi4+M544wzeOuttwD47LPPKCgoAKzJdt577z327t0LWHUS27dvD0iai4uLiYmJISEhgT179vDZZ58F5Oc0FSGVUzAeD+59+7T4SKkgSUtLO2CKyWqPPPII1113Hb179yY6OppXX7Vm5n344YeZMGECPXr0YOjQof452rt3786jjz7KOeecg9frJSwsjKlTp9K+ffsDzjthwgTmzZtHXl4eaWlpTJ48meuvv/6o0tynTx/69etH165dadu2rX+Gt5NVSA2d7c7PZ9Ow02nxwAMkX3VlA6dMqaZJh84OPTp0dj1pb2allDq8EAsK2ptZKaUOJ8SCguYUlFLqcEIrKFSPkJqSEuSUKKVU0xRiQSEXW0wMtujoYCdFKaWapNAKCtqbWSmlDiukgoInN087rikVBE116OzvvvuOIUOGHLDN7XbTokULdu3aVedn5s2b50/37NmzeeKJJ+o8LjY29rDpLCws5D//+Y9/fdeuXYwfP/6wn2kMAQ0KIjJaRDaIyGYRufcwx40TESMiR2xDezzcubk4mmtOQanGVnPobKBRh87+/PPPD7l/+PDhZGdnH9Ab+uuvv6ZHjx60bt36iOcfM2YM9957yFvbYdUOCq1bt+a99947pnM1pID1aBYROzAVGAVkA0tEZLYxZm2t4+KAO4HFgUpLNXdeHnbNKagQtvtvf6NyXcMOnR3RrSst77//iMc1xaGzbTYbl112GTNnzuTPf7YGC5w5cyYTJkzgp59+4s4778TpdBIVFcUrr7xCly5dDvj89OnTWbp0Kc8//zzbtm3jiiuuoLS0lLFjx/qPqV4vKCjA5XLx6KOPMnbsWO699162bNlC3759GTVqFLfeeisXXnghq1evxul0cvPNN7N06VIcDgfPPPMMZ555JtOnT2f27NmUl5ezZcsWLr74Yp588skj/u6PRiBzCgOBzcaYrcaYKmAmMLaO4/4K/B04eISpBuQtL8dbVoYjVXMKSgVDUx06e8KECcycOROAyspK5syZw7hx4+jatSvff/89K1asYMqUKdx/hMB35513cvPNN7Nq1SpatWrl3x4ZGcmsWbNYvnw5c+fO5U9/+hPGGJ544gk6depEZmYm//jHPw4419SpUxERVq1axYwZM7j22mv9g/BlZmby9ttvs2rVKt5++2127NhxTNd9KIEc+6gNUDO12cCgmgeISH+grTHmUxG5+1AnEpFJwCTAP/bJ0fI3R9WKZhXC6vNEHyhNdejsAQMGUFpayoYNG1i3bh2DBg0iOTmZHTt2cO2117Jp0yZEBJfLddjzLFiwwH8NV199tT/nYYzh/vvvZ/78+dhsNnbu3MmePXsOe64ffviB22+/HYCuXbvSvn17Nm7cCFiDASYkJADWGFDbt2+nbdu2x3TtdQnagHgiYgOeASYe6VhjzDRgGlhjHx3Lz/MHBS0+UipomurQ2dW5hXXr1jFhwgQAHnzwQc4880xmzZpFVlYWI0aMOOJ5qofOrunNN98kNzeXZcuWERYWRnp6ep1Db9dXRESEfzkQQ3QHsvhoJ1AzfKX5tlWLA3oC80QkCxgMzA5UZbN7r683s1Y0KxU0TXXo7AkTJvDGG2/w7bff+usDioqK/JXh06dPP+I5hg0b5i+GqlmUVVRURPPmzQkLC2Pu3Ln+dMbFxVFSUlLnuWr+PjZu3Mgvv/xyUH1GoAQyKCwBMkSkg4iEA78BZlfvNMYUGWNSjTHpxph0YBEwxhhzbEOgHoHmFJQKvsMNnb1s2TJ69+7Nvffee8DQ2fPnz6dHjx588MEHdQ6d3bt3b0aNGkVOTs5B550wYQJDhgxhw4YNpKWl8b///a/OdHXr1o2YmBjOOuss/wQ799xzD/fddx/9+vWr19P4v//9b6ZOnUqvXr3YuXP/8++VV17J0qVL6dWrF6+99hpdu3YFICUlhWHDhtGzZ0/uvvvA0vNbbrkFr9dLr169uPzyy5k+ffoBOYRACujQ2SJyPvAvwA68bIx5TESmAEuNMbNrHTsPuOtIQeFYh84u+eYbCmfNIu3ZZxFbSHXPUCFOh84OPcczdHZA6xSMMXOAObW2PXSIY0cEMi1xZ59N3NlnB/JHKKXUCU8fmZVSSvlpUFAqBJxoMyyqY3e837UGBaVOcpGRkeTn52tgCAHGGPLz84mMjDzmcwStn4JSqnGkpaWRnZ1Nrm+SKXVyi4yMJC0t7Zg/r0FBqZNcWFgYHTp0CHYy1AlCi4+UUkr5aVBQSinlp0FBKaWUX0B7NAeCiOQCxzrISSpw+GmbTm6hfP2hfO0Q2tev125pb4w54uBvJ1xQOB4isrQ+3bxPVqF8/aF87RDa16/XfnTXrsVHSiml/DQoKKWU8gu1oDAt2AkIslC+/lC+dgjt69drPwohVaeglFLq8EItp6CUUuowNCgopZTyC5mgICKjRWSDiGwWkXuDnZ7GJCJZIrJKRDJFJCDTnTYlIvKyiOwVkdU1tiWLyFcissn3nhTMNAbKIa79ERHZ6fv+M30zIp50RKStiMwVkbUiskZE7vRtD5Xv/lDXf1Tff0jUKYiIHdgIjAKyseaPnmCMWRvUhDUSEckCBhhjQqIDj4icAZQCrxljevq2PQnsM8Y84XsoSDLG/DmY6QyEQ1z7I0CpMeapYKYt0ESkFdDKGLNcROKAZcCvgYmExnd/qOu/jKP4/kMlpzAQ2GyM2WqMqQJmAmODnCYVIMaY+cC+WpvHAq/6ll/F+mM56Rzi2kOCMSbHGLPct1wCrAPaEDrf/aGu/6iESlBoA+yosZ7NMfyyTmAG+FJElonIpGAnJkhaGGNyfMu7gRbBTEwQ3CYiK33FSydl8UlNIpIO9AMWE4Lffa3rh6P4/kMlKIS6040x/YHzgFt9RQwhy1hlpid/uel+/wU6AX2BHODpoKYmwEQkFngf+L0xprjmvlD47uu4/qP6/kMlKOwE2tZYT/NtCwnGmJ2+973ALKzitFCzx1fmWl32ujfI6Wk0xpg9xhiPMcYLvMhJ/P2LSBjWDfFNY8wHvs0h893Xdf1H+/2HSlBYAmSISAcRCQd+A8wOcpoahYjE+CqdEJEY4Bxg9eE/dVKaDVzrW74W+CiIaWlU1TdEn4s5Sb9/ERHgf8A6Y8wzNXaFxHd/qOs/2u8/JFofAfiaYf0LsAMvG2MeC26KGoeIdMTKHYA1/epbJ/u1i8gMYATWsMF7gIeBD4F3gHZYQ69fZow56SpkD3HtI7CKDgyQBdxYo4z9pCEipwPfA6sAr2/z/Vjl6qHw3R/q+idwFN9/yAQFpZRSRxYqxUdKKaXqQYOCUkopPw0KSiml/DQoKKWU8tOgoJRSyk+DglI+IuKpMZJkZkOOpisi6TVHLlWqqXIEOwFKNSEVxpi+wU6EUsGkOQWljsA3H8WTvjkpfhKRzr7t6SLyrW+gsW9EpJ1vewsRmSUiP/teQ32nsovIi76x7r8UkSjf8Xf4xsBfKSIzg3SZSgEaFJSqKapW8dHlNfYVGWN6Ac9j9YwHeA541RjTG3gTeNa3/VngO2NMH6A/sMa3PQOYaozpARQC43zb7wX6+c5zU2AuTan60R7NSvmISKkxJraO7VnAWcaYrb4Bx3YbY1JEJA9rUhOXb3uOMSZVRHKBNGNMZY1zpANfGWMyfOt/BsKMMY+KyOdYE+N8CHxojCkN8KUqdUiaU1Cqfswhlo9GZY1lD/vr9C4ApmLlKpaIiNb1qaDRoKBU/Vxe432hb/lHrBF3Aa7EGowM4BvgZrCmghWRhEOdVERsQFtjzFzgz0ACcFBuRanGok8kSu0XJSKZNdY/N8ZUN0tNEpGVWE/7E3zbbgdeEZG7gVzgt77tdwLTROR6rBzBzViTm9TFDrzhCxwCPGuMKWyg61HqqGmdglJH4KtTGGCMyQt2WpQKNC0+Ukop5ac5BaWUUn6aU1BKKeWnQUEppZSfBgWllFJ+GhSUUkr5aVBQSinl9/8+fE1Ln/SjEQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.17314934730529785 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time()\n",
+    "plt.plot(history2.history['accuracy'])\n",
+    "plt.plot(history2.history['val_accuracy'])\n",
+    "plt.plot(history.history['accuracy'])\n",
+    "plt.plot(history.history['val_accuracy'])\n",
+    "plt.title(\"Model Accuracy\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Accuracy')\n",
+    "plt.legend(['Resnet Train', 'Resnet Validation', 'Model1 Train', 'Model1 Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "english-novel",
+   "metadata": {
+    "papermill": {
+     "duration": 1.519545,
+     "end_time": "2021-04-25T14:40:05.324806",
+     "exception": false,
+     "start_time": "2021-04-25T14:40:03.805261",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Advantages of Resnet :\n",
+    "1. ResNet uses Batch Normalization at its core. The Batch Normalization adjusts the input layer to increase the performance of the network.\n",
+    "2. ResNet makes use of the Identity Connection, which helps to protect the network from vanishing gradient problem.\n",
+    "3. Deep Residual Network uses bottleneck residual block design to increase the performance of the network."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "preceding-beijing",
+   "metadata": {
+    "papermill": {
+     "duration": 1.408952,
+     "end_time": "2021-04-25T14:40:08.350933",
+     "exception": false,
+     "start_time": "2021-04-25T14:40:06.941981",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Limitations of Resnet :\n",
+    "1. Increased complexity of architecture.\n",
+    "2. Deeper network usually requires weeks for training, making it practically infeasible in real-world applications.\n",
+    "3. Implementation of Batch normalization layers since ResNet heavily depends on it.\n",
+    "4. The dimensionality between the different layers which can become a headache while adding skip connections in model.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "average-lindsay",
+   "metadata": {
+    "papermill": {
+     "duration": 1.40261,
+     "end_time": "2021-04-25T14:40:11.159601",
+     "exception": false,
+     "start_time": "2021-04-25T14:40:09.756991",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Resnet vs VGGNet :\n",
+    "\n",
+    "- Even though ResNet is much deeper than VGG16 and VGG19, the model size is actually substantially smaller due to the usage of global average pooling rather than fully-connected layers.\n",
+    "- In a ResNet architecture, removing a couple of layers in a model doesn’t compromise its performance too much — the architecture has many independent effective paths and the majority of them remain intact after we remove a couple of layers.\n",
+    "- In a VGG network has only one effective path, so removing a single layer compromises this one the only path. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fabulous-acrylic",
+   "metadata": {
+    "papermill": {
+     "duration": 1.405095,
+     "end_time": "2021-04-25T14:40:14.498112",
+     "exception": false,
+     "start_time": "2021-04-25T14:40:13.093017",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6.7 Model 3 Machine Learning model (Random Forest with Gridsearch) :\n",
+    "\n",
+    "- In this model we use GridSearchCV for tuning hyperparameter of the classifier to evaluate the best accuaracy for the best max_depth value from [5,10,None] and best number of trees from [50,100,300]."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "received-concrete",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:40:17.691157Z",
+     "iopub.status.busy": "2021-04-25T14:40:17.689348Z",
+     "iopub.status.idle": "2021-04-25T14:40:17.691812Z",
+     "shell.execute_reply": "2021-04-25T14:40:17.692309Z"
+    },
+    "papermill": {
+     "duration": 1.728963,
+     "end_time": "2021-04-25T14:40:17.692457",
+     "exception": false,
+     "start_time": "2021-04-25T14:40:15.963494",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Create the parameter grid based on the results of random search \n",
+    "param_grid = {\n",
+    "    'bootstrap': [True],\n",
+    "    'max_depth': [3,5,10,None],\n",
+    "    'n_estimators': [5,10,50,150,200]\n",
+    "}\n",
+    "# Create a based model\n",
+    "rfc = RandomForestClassifier()\n",
+    "# Instantiate the grid search model\n",
+    "grid_search = GridSearchCV(estimator = rfc, param_grid = param_grid, \n",
+    "                          cv = 3, n_jobs = -1, verbose = 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "precious-trance",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T14:40:20.488443Z",
+     "iopub.status.busy": "2021-04-25T14:40:20.487632Z",
+     "iopub.status.idle": "2021-04-25T15:00:29.420408Z",
+     "shell.execute_reply": "2021-04-25T15:00:29.420900Z"
+    },
+    "papermill": {
+     "duration": 1210.353275,
+     "end_time": "2021-04-25T15:00:29.421075",
+     "exception": false,
+     "start_time": "2021-04-25T14:40:19.067800",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 3 folds for each of 20 candidates, totalling 60 fits\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'bootstrap': True, 'max_depth': None, 'n_estimators': 200}"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grid_search.fit(x_train1,y_train)\n",
+    "grid_search.best_params_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "proof-strain",
+   "metadata": {
+    "papermill": {
+     "duration": 1.397368,
+     "end_time": "2021-04-25T15:00:32.199474",
+     "exception": false,
+     "start_time": "2021-04-25T15:00:30.802106",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Note :**\n",
+    "\n",
+    "- We have test this model using different combinations of maxdepth, n estimators and k-fold cross validation and encounter that we should make these values limited else we face below error of timeout/mermory leak :\n",
+    "\n",
+    "/opt/conda/lib/python3.7/site-packages/joblib/externals/loky/process_executor.py:691: UserWarning: A worker stopped while some jobs were given to the executor. This can be caused by a too short worker timeout or by a memory leak. \"timeout or by a memory leak.\", UserWarning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "concrete-photograph",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:00:35.471923Z",
+     "iopub.status.busy": "2021-04-25T15:00:35.470631Z",
+     "iopub.status.idle": "2021-04-25T15:00:36.078065Z",
+     "shell.execute_reply": "2021-04-25T15:00:36.076933Z"
+    },
+    "papermill": {
+     "duration": 2.461152,
+     "end_time": "2021-04-25T15:00:36.078507",
+     "exception": false,
+     "start_time": "2021-04-25T15:00:33.617355",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "y_pred_rf = grid_search.predict(x_val1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "cosmetic-compensation",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:00:39.075902Z",
+     "iopub.status.busy": "2021-04-25T15:00:39.075141Z",
+     "iopub.status.idle": "2021-04-25T15:00:39.083585Z",
+     "shell.execute_reply": "2021-04-25T15:00:39.083106Z"
+    },
+    "papermill": {
+     "duration": 1.38666,
+     "end_time": "2021-04-25T15:00:39.083710",
+     "exception": false,
+     "start_time": "2021-04-25T15:00:37.697050",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy for random forest: 0.8115\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Accuracy for random forest:',metrics.accuracy_score(y_val,y_pred_rf))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "limiting-fight",
+   "metadata": {
+    "papermill": {
+     "duration": 1.365203,
+     "end_time": "2021-04-25T15:00:41.848257",
+     "exception": false,
+     "start_time": "2021-04-25T15:00:40.483054",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Additional point in Machine Learning model about performance :**\n",
+    "- We can achieve more accuracy in this model if we apply dimensionality reduction techniques (e.g PCA ) on data as we have too many number of features available to predict labels."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "threaded-tucson",
+   "metadata": {
+    "papermill": {
+     "duration": 1.360449,
+     "end_time": "2021-04-25T15:00:44.582041",
+     "exception": false,
+     "start_time": "2021-04-25T15:00:43.221592",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6.8 Model 4 (Simple Neural Network) :\n",
+    "\n",
+    "- In this model we havn't use any convolution or max polling layer in model. We simply use Flatter and Dense in model and trained it with learning rate.\n",
+    "\n",
+    "- We try to create a model on paper below is an overview on a model :\n",
+    "\n",
+    "![](http://www.linkpicture.com/q/0001_33.jpg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "other-subsection",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:00:47.379646Z",
+     "iopub.status.busy": "2021-04-25T15:00:47.378769Z",
+     "iopub.status.idle": "2021-04-25T15:00:47.401697Z",
+     "shell.execute_reply": "2021-04-25T15:00:47.402247Z"
+    },
+    "papermill": {
+     "duration": 1.445742,
+     "end_time": "2021-04-25T15:00:47.402448",
+     "exception": false,
+     "start_time": "2021-04-25T15:00:45.956706",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model4 = keras.Sequential([\n",
+    "    keras.layers.Flatten(input_shape=(28, 28)),\n",
+    "    keras.layers.Dense(128, activation='relu'),\n",
+    "    keras.layers.Dense(5, activation='softmax')\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "marked-clock",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:00:50.423498Z",
+     "iopub.status.busy": "2021-04-25T15:00:50.422596Z",
+     "iopub.status.idle": "2021-04-25T15:00:50.428912Z",
+     "shell.execute_reply": "2021-04-25T15:00:50.428134Z"
+    },
+    "papermill": {
+     "duration": 1.396601,
+     "end_time": "2021-04-25T15:00:50.429096",
+     "exception": false,
+     "start_time": "2021-04-25T15:00:49.032495",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: \"sequential_3\"\n",
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "flatten_4 (Flatten)          (None, 784)               0         \n",
+      "_________________________________________________________________\n",
+      "dense_10 (Dense)             (None, 128)               100480    \n",
+      "_________________________________________________________________\n",
+      "dense_11 (Dense)             (None, 5)                 645       \n",
+      "=================================================================\n",
+      "Total params: 101,125\n",
+      "Trainable params: 101,125\n",
+      "Non-trainable params: 0\n",
+      "_________________________________________________________________\n"
+     ]
+    }
+   ],
+   "source": [
+    "model4.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "corporate-document",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:00:53.331006Z",
+     "iopub.status.busy": "2021-04-25T15:00:53.330072Z",
+     "iopub.status.idle": "2021-04-25T15:00:53.335732Z",
+     "shell.execute_reply": "2021-04-25T15:00:53.335244Z"
+    },
+    "papermill": {
+     "duration": 1.474632,
+     "end_time": "2021-04-25T15:00:53.335850",
+     "exception": false,
+     "start_time": "2021-04-25T15:00:51.861218",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model4.compile(optimizer='adam', loss=\"categorical_crossentropy\", metrics=[\"accuracy\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "linear-export",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:00:56.158471Z",
+     "iopub.status.busy": "2021-04-25T15:00:56.157273Z",
+     "iopub.status.idle": "2021-04-25T15:07:07.304020Z",
+     "shell.execute_reply": "2021-04-25T15:07:07.303372Z"
+    },
+    "papermill": {
+     "duration": 372.554841,
+     "end_time": "2021-04-25T15:07:07.304174",
+     "exception": false,
+     "start_time": "2021-04-25T15:00:54.749333",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/25\n",
+      "375/375 - 16s - loss: 0.9638 - accuracy: 0.5954 - val_loss: 0.7987 - val_accuracy: 0.6725\n",
+      "Epoch 2/25\n",
+      "375/375 - 14s - loss: 0.7897 - accuracy: 0.6775 - val_loss: 0.7196 - val_accuracy: 0.7055\n",
+      "Epoch 3/25\n",
+      "375/375 - 14s - loss: 0.7216 - accuracy: 0.7071 - val_loss: 0.6388 - val_accuracy: 0.7412\n",
+      "Epoch 4/25\n",
+      "375/375 - 16s - loss: 0.6840 - accuracy: 0.7222 - val_loss: 0.6423 - val_accuracy: 0.7298\n",
+      "Epoch 5/25\n",
+      "375/375 - 15s - loss: 0.6638 - accuracy: 0.7320 - val_loss: 0.6154 - val_accuracy: 0.7467\n",
+      "Epoch 6/25\n",
+      "375/375 - 15s - loss: 0.6482 - accuracy: 0.7386 - val_loss: 0.5929 - val_accuracy: 0.7587\n",
+      "Epoch 7/25\n",
+      "375/375 - 15s - loss: 0.6333 - accuracy: 0.7464 - val_loss: 0.5698 - val_accuracy: 0.7782\n",
+      "Epoch 8/25\n",
+      "375/375 - 14s - loss: 0.6237 - accuracy: 0.7496 - val_loss: 0.5572 - val_accuracy: 0.7822\n",
+      "Epoch 9/25\n",
+      "375/375 - 15s - loss: 0.6176 - accuracy: 0.7532 - val_loss: 0.5584 - val_accuracy: 0.7762\n",
+      "Epoch 10/25\n",
+      "375/375 - 16s - loss: 0.6052 - accuracy: 0.7596 - val_loss: 0.5474 - val_accuracy: 0.7922\n",
+      "Epoch 11/25\n",
+      "375/375 - 14s - loss: 0.5994 - accuracy: 0.7606 - val_loss: 0.5561 - val_accuracy: 0.7858\n",
+      "Epoch 12/25\n",
+      "375/375 - 14s - loss: 0.5964 - accuracy: 0.7647 - val_loss: 0.5418 - val_accuracy: 0.7867\n",
+      "Epoch 13/25\n",
+      "375/375 - 16s - loss: 0.5891 - accuracy: 0.7689 - val_loss: 0.5340 - val_accuracy: 0.7970\n",
+      "Epoch 14/25\n",
+      "375/375 - 14s - loss: 0.5889 - accuracy: 0.7674 - val_loss: 0.5406 - val_accuracy: 0.7975\n",
+      "Epoch 15/25\n",
+      "375/375 - 14s - loss: 0.5821 - accuracy: 0.7692 - val_loss: 0.5306 - val_accuracy: 0.8012\n",
+      "Epoch 16/25\n",
+      "375/375 - 15s - loss: 0.5793 - accuracy: 0.7723 - val_loss: 0.5264 - val_accuracy: 0.8040\n",
+      "Epoch 17/25\n",
+      "375/375 - 15s - loss: 0.5747 - accuracy: 0.7740 - val_loss: 0.5190 - val_accuracy: 0.7977\n",
+      "Epoch 18/25\n",
+      "375/375 - 14s - loss: 0.5738 - accuracy: 0.7722 - val_loss: 0.5150 - val_accuracy: 0.8073\n",
+      "Epoch 19/25\n",
+      "375/375 - 16s - loss: 0.5713 - accuracy: 0.7760 - val_loss: 0.5231 - val_accuracy: 0.8017\n",
+      "Epoch 20/25\n",
+      "375/375 - 14s - loss: 0.5681 - accuracy: 0.7769 - val_loss: 0.5151 - val_accuracy: 0.8018\n",
+      "Epoch 21/25\n",
+      "375/375 - 14s - loss: 0.5669 - accuracy: 0.7795 - val_loss: 0.5221 - val_accuracy: 0.8042\n",
+      "Epoch 22/25\n",
+      "375/375 - 16s - loss: 0.5656 - accuracy: 0.7778 - val_loss: 0.5186 - val_accuracy: 0.8080\n",
+      "Epoch 23/25\n",
+      "375/375 - 14s - loss: 0.5633 - accuracy: 0.7790 - val_loss: 0.5154 - val_accuracy: 0.8068\n",
+      "Epoch 24/25\n",
+      "375/375 - 15s - loss: 0.5598 - accuracy: 0.7800 - val_loss: 0.5160 - val_accuracy: 0.8077\n",
+      "Epoch 25/25\n",
+      "375/375 - 16s - loss: 0.5628 - accuracy: 0.7778 - val_loss: 0.5068 - val_accuracy: 0.8067\n",
+      "--- 371.143522977829 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "history4 = model4.fit(datagen.flow(x_train, y_train, batch_size = batch_size), epochs = epochs, \n",
+    "                              validation_data = (x_val, y_val), verbose=2, \n",
+    "                              steps_per_epoch=x_train.shape[0] // batch_size,\n",
+    "                              callbacks = [reduce_lr])\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "balanced-fiction",
+   "metadata": {
+    "papermill": {
+     "duration": 1.391288,
+     "end_time": "2021-04-25T15:07:10.104975",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:08.713687",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Model 4 Evaluation "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "upset-angle",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:07:13.620167Z",
+     "iopub.status.busy": "2021-04-25T15:07:13.619244Z",
+     "iopub.status.idle": "2021-04-25T15:07:14.050227Z",
+     "shell.execute_reply": "2021-04-25T15:07:14.050813Z"
+    },
+    "papermill": {
+     "duration": 2.515469,
+     "end_time": "2021-04-25T15:07:14.051028",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:11.535559",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "188/188 [==============================] - 0s 2ms/step - loss: 0.5068 - accuracy: 0.8067\n",
+      "Loss: 0.5068\n",
+      "Accuracy: 0.8067\n",
+      "--- 0.428117036819458 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "score = model4.evaluate(x_val, y_val)\n",
+    "\n",
+    "print('Loss: {:.4f}'.format(score[0]))\n",
+    "print('Accuracy: {:.4f}'.format(score[1]))\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "upper-mississippi",
+   "metadata": {
+    "papermill": {
+     "duration": 1.405649,
+     "end_time": "2021-04-25T15:07:16.844490",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:15.438841",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Model 4 loss vs no. of epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "played-system",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:07:19.648529Z",
+     "iopub.status.busy": "2021-04-25T15:07:19.647568Z",
+     "iopub.status.idle": "2021-04-25T15:07:19.781062Z",
+     "shell.execute_reply": "2021-04-25T15:07:19.780223Z"
+    },
+    "papermill": {
+     "duration": 1.544665,
+     "end_time": "2021-04-25T15:07:19.781260",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:18.236595",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAAziElEQVR4nO3deXxU9b3/8dcn+x6SEAIkQAATkX0T3BWX1q24K+itUtt6tVftcqtX++uttr3e2/ba29aqba211qWitWqxbq37riyybwIGCFtCIPuefH9/nJMQYiCTkMkkmffz8ZjHzJw5c+ZziM57zvl+z/drzjlEREQAIkJdgIiI9B0KBRERaaVQEBGRVgoFERFppVAQEZFWCgUREWmlUBDxmVmumTkziwpg3QVm9m5v1CXSmxQK0i+ZWYGZ1ZvZ4HbLP/G/2HNDVNpBzOxqv56vHWadNw/3ukhvUihIf/YZML/liZlNAhJCV87BzCwN+B6wJtS1iARKoSD92aPA1W2eXwM80nYFM0s1s0fMrNjMtprZ980swn8t0szuNrO9ZrYFOK+D9/7BzHaZ2Q4z+y8zi+xCff8D3APs7c7OmVmEX+9WMyvy9yPVfy3OzB4zsxIzKzWzxWaW5b+2wMy2mFmFmX1mZld15/MlPCkUpD/7EEgxs2P8L+t5wGPt1vk1kAqMAU7FC5Gv+K99HTgfmAbMBC5t996HgUbgKH+dLwABneYxs1n+Nn/bpT062AL/Ngev/iTgXv+1a/D2awSQAVwP1JhZIl4QneOcSwZOAJYfQQ0SZhQK0t+1HC2cBawDdrS80CYobnfOVTjnCoCfA1/2V7kc+KVzbrtzbh/eL/uW92YB5wLfcs5VOeeKgF/42zss/3PvB250zjUfwb5dBfyfc26Lc64SuB2Y5zeEN+CFwVHOuSbn3FLnXLn/vmZgopnFO+d2Oed0+koCplCQ/u5R4Eq8X9SPtHttMBANbG2zbCuQ7T8eDmxv91qLUf57d/mnZ0qB3wFDAqjpG8BK59yHge3CIQ3n87VHAVl4+/0KsNDMdprZz8ws2jlXBVyBd+Swy8xeMLNxR1iHhBGFgvRrzrmteA3O5wLPtHt5L94v6lFtlo3kwNHELrzTL21fa7EdqAMGO+cG+bcU59yEAMo6A7jIzHab2W68Uzg/N7N7O3lfezs7qL0R2OOca3DO/dA5N97f/vn47SvOuVecc2cBw4D1wO+7+LkSxhQKMhB8FTjd/5XcyjnXBDwF3GVmyWY2CvgOB9odngJuNrMcv6fQbW3euwv4B96XeYrf6DvWzE4NoJ4FwDHAVP+2BPgh8P8O854ov/G45RYNPAF828xGm1kS8N/Ak865RjObY2aT/FNV5Xjh12xmWWZ2gd+2UAdU4p1OEgmIQkH6PefcZufckkO8fBNQBWwB3gX+DDzkv/Z7vFMwK4BlfP5I42ogBlgL7Aeexvv13Vk9pc653S03oB4od86VHeZtvwFq2tz+6Nf5KPA23tFQrb8/AEP9esrx2lLe8teNwAu+ncA+vMb1GzqrWaSFaZIdERFpoSMFERFppVAQEZFWCgUREWmlUBARkVadDhHc1wwePNjl5uaGugwRkX5l6dKle51zmZ2t1+9CITc3lyVLDtX7UEREOmJmWztfS6ePRESkDYWCiIi0UiiIiEirftemICIDR0NDA4WFhdTW1oa6lAEjLi6OnJwcoqOju/V+hYKIhExhYSHJycnk5uZiZqEup99zzlFSUkJhYSGjR4/u1jZ0+khEQqa2tpaMjAwFQg8xMzIyMo7oyEuhICIhpUDoWUf67xk2obCkYB8/fXk9GhVWROTQwiYUVu8o4zdvbqa4oi7UpYhIH1FSUsLUqVOZOnUqQ4cOJTs7u/V5fX39Yd+7ZMkSbr755l6qtPeETUNzflYyABv3VDIkJS7E1YhIX5CRkcHy5csBuPPOO0lKSuK73/1u6+uNjY1ERXX8NTlz5kxmzpzZG2X2qrA5UshrDYWKEFciIn3ZggULuP7665k9eza33norH3/8MccffzzTpk3jhBNOYMOGDQC8+eabnH/++YAXKNdeey2nnXYaY8aM4Z577gnlLhyRsDlSGJwUQ1pCtEJBpI/64fNrWLuzvEe3OX54Cnd8aUKX31dYWMj7779PZGQk5eXlvPPOO0RFRfHqq6/yve99j7/+9a+fe8/69et54403qKio4Oijj+aGG27o9rUCoRQ2oWBm5GUlKxREpFOXXXYZkZGRAJSVlXHNNdfw6aefYmY0NDR0+J7zzjuP2NhYYmNjGTJkCHv27CEnJ6c3y+4RYRMKAPlZSfztk50459QNTqSP6c4v+mBJTExsffyf//mfzJkzh2effZaCggJOO+20Dt8TGxvb+jgyMpLGxsZglxkUYdOmAF5jc0VdI7vLdUm9iASmrKyM7OxsAB5++OHQFtMLwioU8oYc6IEkIhKIW2+9ldtvv51p06b121//XWH97WKumTNnuu5OslNSWceM/3qV7593DF87eUwPVyYiXbVu3TqOOeaYUJcx4HT072pmS51znfahDasjhYykWDISY9TYLCJyCGEVCuC1K+j0kYhIx8IwFJLYVFSpMZBERDoQdqGQl5VMZV0jO8vUA0lEpL2wC4V8DXchInJIYRgKSQBs3K1QEBFpL+xCYVBCDJnJsWpsFhHmzJnDK6+8ctCyX/7yl9xwww0drn/aaafR0iX+3HPPpbS09HPr3Hnnndx9992H/dznnnuOtWvXtj7/wQ9+wKuvvtrF6oMj7EIBvKOFT4t0pCAS7ubPn8/ChQsPWrZw4ULmz5/f6XtffPFFBg0a1K3PbR8KP/rRjzjzzDO7ta2eFpahkDckmU/3VNLcrB5IIuHs0ksv5YUXXmidUKegoICdO3fyxBNPMHPmTCZMmMAdd9zR4Xtzc3PZu3cvAHfddRf5+fmcdNJJrUNrA/z+97/n2GOPZcqUKVxyySVUV1fz/vvvs2jRIm655RamTp3K5s2bWbBgAU8//TQAr732GtOmTWPSpElce+211NXVtX7eHXfcwfTp05k0aRLr168Pyr9JWA2I1yI/K5mahiZ2lNYwIj0h1OWICMBLt8HuVT27zaGT4JyfHPLl9PR0Zs2axUsvvcQFF1zAwoULufzyy/ne975Heno6TU1NnHHGGaxcuZLJkyd3uI2lS5eycOFCli9fTmNjI9OnT2fGjBkAXHzxxXz9618H4Pvf/z5/+MMfuOmmm5g7dy7nn38+l1566UHbqq2tZcGCBbz22mvk5+dz9dVX85vf/IZvfetbAAwePJhly5Zx//33c/fdd/Pggw/2wD/SwcLySKG1sVk9kETCXttTSC2njp566immT5/OtGnTWLNmzUGnetp75513uOiii0hISCAlJYW5c+e2vrZ69WpOPvlkJk2axOOPP86aNWsOW8uGDRsYPXo0+fn5AFxzzTW8/fbbra9ffPHFAMyYMYOCgoLu7vJhheWRQl6bqTnPOCYrxNWICHDYX/TBdMEFF/Dtb3+bZcuWUV1dTXp6OnfffTeLFy8mLS2NBQsWUFvbveuaFixYwHPPPceUKVN4+OGHefPNN4+o1pbhuYM5NHdYHimkxkczNCWOT3WkIBL2kpKSmDNnDtdeey3z58+nvLycxMREUlNT2bNnDy+99NJh33/KKafw3HPPUVNTQ0VFBc8//3zraxUVFQwbNoyGhgYef/zx1uXJyclUVHz+++foo4+moKCATZs2AfDoo49y6qmn9tCeBiYsQwEgLyuJjeqBJCJ4p5BWrFjB/PnzmTJlCtOmTWPcuHFceeWVnHjiiYd97/Tp07niiiuYMmUK55xzDscee2zraz/+8Y+ZPXs2J554IuPGjWtdPm/ePP73f/+XadOmsXnz5tblcXFx/PGPf+Syyy5j0qRJREREcP311/f8Dh9GWA2d3daP/76Wxz/aytofnk1EhGZhEwkFDZ0dHBo6uxvys5KobWhm+/7qUJciItJnBDUUzOxsM9tgZpvM7LYOXh9lZq+Z2Uoze9PMem2W65bG5g0a7kJEpFXQQsHMIoH7gHOA8cB8MxvfbrW7gUecc5OBHwH/E6x62ssb4nVL/bRIw12IhFJ/O4Xd1x3pv2cwjxRmAZucc1ucc/XAQuCCduuMB173H7/RwetBkxwXzfDUOF2rIBJCcXFxlJSUKBh6iHOOkpIS4uLiur2NYF6nkA1sb/O8EJjdbp0VwMXAr4CLgGQzy3DOlbRdycyuA64DGDlyZI8VmKdZ2ERCKicnh8LCQoqLi0NdyoARFxdHTk73z8SH+uK17wL3mtkC4G1gB9DUfiXn3APAA+D1PuqpD8/PSuKDLSU0NTsi1QNJpNdFR0czevToUJchbQQzFHYAI9o8z/GXtXLO7cQ7UsDMkoBLnHOlQazpIHlZydQ3NrO1pIoxmUm99bEiIn1WMNsUFgN5ZjbazGKAecCitiuY2WAza6nhduChINbzOflthrsQEZEghoJzrhG4EXgFWAc85ZxbY2Y/MrOWEaNOAzaY2UYgC7grWPV0pLUHkhqbRUSAILcpOOdeBF5st+wHbR4/DTwdzBoOJzE2ipy0eDaqW6qICBDGVzS3yM9K1pGCiIgv7EMhLyuJLcVVNDQ1h7oUEZGQC/tQyB+STH2T1wNJRCTcKRTUA0lEpFXYh8JRQ5Iw09ScIiKgUCA+JpIRaQl8qiMFERGFAnjDXehIQUREoQB4w118treK+kb1QBKR8KZQAI7OSqax2VGgHkgiEuYUCnjXKoAam0VEFArA2MwkIkzdUkVEFApAXHQkozISNdyFiIQ9hYIvb0gSGxQKIhLmFAq+/KxktpZUU9f4uYnfRETChkLBl5eVRFOzY0uxeiCJSPhSKPgOjIGkU0giEr4UCr4xmYlERpiGuxCRsKZQ8MVGRTIqI0FHCiIS1hQKbeQPSeZTTc0pImFModBG/tBktpZUUdugHkgiEp4UCm3kZyXR7GBzsY4WRCQ8KRTaaOmBpMZmEQlXCoU2cjMSiYowNTaLSNhSKLQRExXB6MGJCgURCVsKhXbys5I1WqqIhC2FQjt5WUls319NTb16IIlI+FEotJOflYxzsEnXK4hIGFIotJOvWdhEJIwpFNoZlZFIdKSxsUihICLhR6HQTnRkBGMzk3StgoiEJYVCB/KyknX6SETCkkKhA/lDkijcX0NVXWOoSxER6VUKhQ7k+cNdqAeSiIQbhUIH1ANJRMJVUEPBzM42sw1mtsnMbuvg9ZFm9oaZfWJmK83s3GDWE6hRGYnEREUoFEQk7AQtFMwsErgPOAcYD8w3s/HtVvs+8JRzbhowD7g/WPV0RWSEMTYzScNdiEjYCeaRwixgk3Nui3OuHlgIXNBuHQek+I9TgZ1Bq6a5GYo3BLx6flYSn+pIQUTCTDBDIRvY3uZ5ob+srTuBfzGzQuBF4KaONmRm15nZEjNbUlxc3L1q3voJ/PYkqN4X0Or5WcnsLKulorahe58nItIPhbqheT7wsHMuBzgXeNTMPleTc+4B59xM59zMzMzM7n3SuPOgqR7WPBPQ6nlDvMZmzdksIuEkmKGwAxjR5nmOv6ytrwJPATjnPgDigMFBqWboZBgyAZY/EdDqB2Zh0ykkEQkfwQyFxUCemY02sxi8huRF7dbZBpwBYGbH4IVCN88PdcIMpsyDHUtg76edrj4iPYG46Ag1NotIWAlaKDjnGoEbgVeAdXi9jNaY2Y/MbK6/2r8DXzezFcATwALnnAtWTUy+HCwCVnR+tBAZYeRnJbN06/6glSMi0tcEtU3BOfeicy7fOTfWOXeXv+wHzrlF/uO1zrkTnXNTnHNTnXP/CGY9JA+FsWfAiie93kidmDtlOMu3l7J6R1lQyxIR6StC3dDc+6bOh/JCKHi701UvmzmChJhIHn6/IPh1iYj0AeEXCkefB7GpATU4p8ZHc8n0HBYt38neyrpeKE5EJLTCLxSi42DiRbBuEdR13rPomhNGUd/UzBMfbeuF4kREQiv8QgFgynxoqIa17TtDfd5RQ5I5OW8wj364lYamztshRET6s/AMhRGzIX1MQL2QAK49cTRFFXW8tHp3kAsTEQmt8AwFM+9ooeAdKO38tNCp+ZnkZiTwx/c+64XiRERCJzxDAWDyFd79iic7XTUiwrjmhFw+2VbK8u2lwa1LRCSEwjcU0kZB7sneKaQArpe7dEYOSbFR/EndU0VkAAvfUADvFNK+zbD9405XTY6L5tIZOfx95U6KKmp7oTgRkd4X3qEwfi5EJ8CKPwe0+jUn5NLQ5Hj8Q3VPFZGBKbxDITYZjvkSrH4WGmo6XX304ETmHJ3J4x9to66xqRcKFBHpXeEdCuCdQqorgw0vBbT6V04czd7KOl5ctSvIhYmI9D6FwuhTICU74GsWTs4bzNjMRP74XgHBHNBVRCQUFAoRkV731E2vQcWeTlc3MxackMvKwjKWbSsNfn0iIr0ooFAws8SWaTLNLN/M5ppZdHBL60VT5oNrglVPBbT6xdNzSI6L0uipIjLgBHqk8DYQZ2bZwD+ALwMPB6uoXpeZD9kzvJFTAzgllBgbxRUzR/DSql3sLlP3VBEZOAINBXPOVQMXA/c75y4DJgSvrBCYMh+K1sDulQGtfvXxuTQ5x2Mfbg1yYSIivSfgUDCz44GrgBf8ZZHBKSlEJl4CkTEBzbMAMDIjgTOPyeLPH2+jtkHdU0VkYAg0FL4F3A4868+zPAZ4I2hVhUJCOuSfDav+Ak0NAb3lKyfksq+qnudX7AxycSIivSOgUHDOveWcm+uc+6nf4LzXOXdzkGvrfVOvhOq9sOnVgFY/fmwG+VlJ6p4qIgNGoL2P/mxmKWaWCKwG1prZLcEtLQSOOhMSBsPywIa98LqnjmbtrnIWF+wPcnEiIsEX6Omj8c65cuBC4CVgNF4PpIElMhomXQYbX4bqfQG95aJp2aTGR/Pw+5prQUT6v0BDIdq/LuFCYJFzrgEYmOdLps6HpnpY/deAVo+PiWTerBG8smYPO0o7Hz9JRKQvCzQUfgcUAInA22Y2CigPVlEhNXQyDJkQ8LAXAF8+bhTOOR79QN1TRaR/C7Sh+R7nXLZz7lzn2QrMCXJtoWHmHS3sWArFGwN6S05aAl+cMJSFi7dRU6/uqSLSfwXa0JxqZv9nZkv828/xjhoGpkmXg0V06WhhwQm5lFY38LflO4JYmIhIcAV6+ughoAK43L+VA38MVlEhl5wFY8+AlU9Cc2C//GeNTueYYSnqnioi/VqgoTDWOXeHc26Lf/shMCaYhYXc1PlQvgM+ezug1c2Mr5yYy4Y9Fby1sTjIxYmIBEegoVBjZie1PDGzE4GB3dXm6PMgNrVLp5DmThlObkYCtz69UvM4i0i/FGgoXA/cZ2YFZlYA3Av8a9Cq6gui42DChbDueairDOgtcdGR/PbLMyivbeDGP39CQ1NzcGsUEelhgfY+WuGcmwJMBiY756YBpwe1sr5gyjxoqIb1fw/4LeOGpvCTiyfz8Wf7+OlL64NYnIhIz+vSzGvOuXL/ymaA7wShnr5lxHEwaCSsWNilt104LZtrjh/Fg+9+xgsrNZeziPQfRzIdp/VYFX1VRIQ3Vednb0F5177c/99545k+chC3PL2CTUUVQSpQRKRnHUkohEe/y8nzwDV7Q2p3QUxUBPdfNYOEmEiue3QpFbWBDcctIhJKhw0FM6sws/IObhXA8M42bmZnm9kGM9tkZrd18PovzGy5f9toZqXd35UgGXyUN1XnysDmb25raGocv54/na0l1dz69EpdvyAifd5hQ8E5l+ycS+ngluycizrce80sErgPOAcYD8w3s/Httv9t59xU59xU4NfAM0e0N8EyeR7sWQV71nT5rcePzeA/zj6al1bv5sF3NJKqiPRtR3L6qDOzgE3+xW71wELggsOsPx8I/KKA3jTxYoiI6nKDc4uvnzyGcyYO5Scvr+eDzSU9XJyISM8JZihkA9vbPC/0l32OP+rqaOD1Q7x+Xcu4S8XFIbhaOHGwNwHPqr8EPOxFW2bGzy6dzKiMBG56Yhm7y3Rhm4j0TcEMha6YBzztnOvwG9c594BzbqZzbmZmZmYvl+abfAVU7Ap42Iv2kuOi+d2/zKC6vol/+/My6ht1YZuI9D3BDIUdwIg2z3P8ZR2ZR189ddTi6HMgNsUbJK+b8rKS+dmlk1m6dT///eK6HixORKRnBDMUFgN5ZjbazGLwvvgXtV/JzMYBacAHQazlyEXHw/gLYO0iqK/q9mbOnzycr540moffL+C5TzTMtoj0LUELBedcI3Aj8AqwDnjKObfGzH5kZnPbrDoPWOj6Q3/NKfOgoQrWv3BEm7ntnHHMyk3n9mdWsX73wJzATkT6J+sP38VtzZw50y1ZsiQ0H97cDL+aDIPz4ctH1nu2qKKW8+95l4SYSBbddBIpcdE9VKSIyOeZ2VLn3MzO1usrDc39Q0QETL4ctrwBFbuPaFNDkuO476rpFO6v4TtPLqeuUdN4ikjoKRS6qnXYi6ePeFPH5qbzn+eP59V1RVxw73us26VTSSISWgqFrsrMh+HTjqgXUlvXnJDLQwtmsreynrn3vstv3txMU3P/OqUnIgOHQqE7Js+D3SuhqGe6lZ4+Lot/fPsUzhqfxU9fXs8Vv/uAbSXVPbJtEZGuUCh0x8RLwCK7PexFR9ITY7jvyun84oopbNhTwdm/epsnPt6mQfREpFcpFLojKROOOsMf9qLnrkw2My6alsMr3zqFqSMGcfszq/jqn5ZovmcR6TUKhe6afAWU74CCd3p808MHxfPYV2dzx5fG896mvXzxF2/z0irN4CYiwadQ6K5x50FMco81OLcXEWF85cTRvHDzSeSkJXDD48v4zpPLKavRZD0iEjwKhe5qHfbib1AfvEbho4Yk88w3TuCbZ+TxtxU7OeeXb/Pepr1B+zwRCW8KhSMx5Qqor4QNLwb1Y6IjI/j2Wfn89YYTiIuO5KoHP+J7z65SW4OI9DiFwpEYdRKk5PRoL6TDmTpiEC/cfDJfOTGXJxdv59Sfvcndr2ygXPM/i0gPUSgciYgImHwZbH4dKot65SPjYyK540sTePU7p3Lm+CzufWMTp/zsDR54ezO1DRoqQ0SOjELhSE2eB64JVv+1Vz929OBEfj1/Gn+/6SSm5Aziv19cz2n/+yYLP95GY5Mm8BGR7lEoHKkh42DYlF47hdTexOxU/nTtLJ74+nEMGxTHbc+s4gu/eJsXV+3ShW8i0mUKhZ4weR7sWg7FG0JWwvFjM3jmhhN44MsziIwwvvH4Mube+x7vfqqeSiISOIVCT5h4CVhEyI4WWpgZX5gwlJe/dQp3XzaFfVX1/MsfPuLK33/I8u2lIa1NRPoHhUJPSM6Csaf3+LAX3RUZYVw6I4fXv3sqPzh/PBt2V3Dhfe/x9UeWsHanhucWkUNTKPSUyfOgbDtsfS/UlbSKjYrk2pNG89atc/j2mfl8uKWEc+95h288vpSNeypCXZ6I9EFRoS5gwBh3HsQkwcqFMPrkw6/b1OCNm1S63QuSiCiYeKnXxTUIkmKj+OaZeSw4IZc/vLuFh94r4KXVu/nS5OF888w8xmYmBeVzRaT/0RzNPenZG2D93+GbK6Cq2P/S33bgy7/lvmKXN3tbWxMuhot+B1ExQS9zf1U9D7yzhYffK6CusYkLp2Vz8+l55A5ODPpni0hoBDpHs0KhJ215Ex654PPLLRJSsyF1JAwaAakj2tyPhHXPw6t3eO0SVzwGMb3z5by3so7fvbWZRz7YSmOz49LpOdx4+lGMSE/olc8Xkd6jUAiF5mZ47xfeUUDqSO8Lf9AISB4GEZGHf+8nj8Gim2D4dLjqL5CQ3js1A0Xltdz/5mb+/PE2mpsdlx87ghvnHMXwQfG9VoOIBJdCoT9a93d4+lpIy4UvP+sdXfSiXWU13P/GZhYu3oZhXH5sDpdMz2HqiEGYWa/WIiI9S6HQX332DjwxH+IHecEwOK/XSyjcX819b2zi6aWFNDQ5hqXGcfbEoZw7aRgzRqYREaGAEOlvFAr92a4V8Ngl3mmoq56G7OkhKaOspoHX1u3hpdW7eWtjMfWNzWQmx3L2hKGcM2kos3LTiYpUr2aR/kCh0N+VbIZHL4TqfTDvzzDm1JCWU1nXyOvri3h59S5eX19EbUMz6YkxfHFCFudMHMbxYzOIVkCI9FkKhYGgfBc8djGUbIJLHvRmeusDqusbeWtDMS+t3s1r6/ZQVd9Eanw0Z43P4vRxQ5gyYhDDU+PUDiHShygUBorqffDEPChcDOf/AmYsCHVFB6ltaOKdT/fy0upd/HPtHipqGwEYnBTD5JxBTM5JZYp/n5EUG+JqRcKXQmEgqa+Cp66BTf+EM34AJ30H+uCv8PrGZtbtKmdlYSkrCstYsb2UTcWVtPwnlpMW3xoQk3MGMSknlaRYXVQv0hsUCgNNUwM8d4M36N5x/wZf+K+gDYvRkyrrGlm9o6w1KFYWlrJ9Xw3g5drYzCTOnjCUq44bybBUXRchEiwKhYGouRlevg0+/p03VtLce3rt6ueetK+qnhWFpazcXsaSrft4d9NeIsz44oQsrj4+l9mj09UeIdLDFAoDlXPw7v/Baz+GzHFwxaMhuZahJ23fV81jH25l4eLtlNU0cHRWMlefMIoLp2aTqNNLIj1CoTDQbX4d/vo1aKyDub+GiReHuqIjVlPfxPMrdvLw+wWs3VVOclwUl80YwZePH8VoDdYnckQUCuGgrBD+8hUo/BhmXw9n/bhXRlkNNuccy7bt50/vb+XFVbtobHacmp/JghNyOTU/U1dUi3RDnwgFMzsb+BUQCTzonPtJB+tcDtwJOGCFc+7Kw21TodBOY703wuqH90P2TLjsYW8QvgGiqLyWJz7ezuMfbaWooo6R6QlcOXsks0anM35YCnHRnQw0KCJAHwgFM4sENgJnAYXAYmC+c25tm3XygKeA051z+81siHOu6HDbVSgcwprn4G83QmQ0XPJ7OOrMUFfUoxqamnl59W4e+aCAxQX7AW/a0aMyk5iYncqk7BQmZqcyfngKCTFqhxBpry+EwvHAnc65L/rPbwdwzv1Pm3V+Bmx0zj0Y6HYVCoexdxM8dTUUrYVTb4VT/6PzIbv7oZ2lNazaUcbqHWWt93sr6wGIMBiTmcSk7FQmZqcycXgKE7J1PYRIoKEQzP9TsoHtbZ4XArPbrZMPYGbv4Z1iutM593IQaxrYBh8FX3sVXvgOvPVT2P6xNzxG4uBQV9ajhg+KZ/igeL44YSjgtUHsKa9rDYjVO8p4b9Nenv1kB+BdDzE8NZ6hqXEMTYljSEosQ1PiyGq9xZKVEqeeTiKEfo7mKCAPOA3IAd42s0nOudK2K5nZdcB1ACNHjuzlEvuZmAS48Dcw8nh48Rb47cleO8PI9nk8cJiZ94WfGsdZ47NalxeV17J6ZxmrCsv5bG8le8rrWLe7nDc31FJV3/S57STHRnmBkRpHVnIc44encNyYDI4ZlkKkGrclTIT69NFvgY+cc3/0n78G3OacW3yo7er0URfsWuGdTior9HomHXdDnxweIxQq6xrZXVZLUXktu8tr2VNex57yWvb4z3eVevcAyXFRzMpN57gxGcwe4zVwa8hw6W/6QptCFF5D8xnADryG5iudc2varHM2XuPzNWY2GPgEmOqcKznUdhUKXVRTCs99Aza8ABMugrn3QmxSqKvqF3aV1fDRln189FkJH27Zx2d7qwDviGJmbpofEhlMHK6QkL4v5KHgF3Eu8Eu89oKHnHN3mdmPgCXOuUXmjWXwc+BsoAm4yzm38HDbVCh0g3Pw3q/gtR/C4KPhise89gfpkj3ltXy4pYSPPtvHh1tK2FLshURSbBQzRqUxY1QaCTGRRJgRYRARYVjLY//ee35gWWpCNNNHpJGaEB3ivZOBrk+EQjAoFI7Alje9i92aG+Gi38K480JdUb9WVFF70JHEpqLKbm8rb0gSM3PTmDEqnZmj0hiVkaDxn6RHKRSkY6Xb4Mkvw67lcMotcNrtA7LbaihU1zfS0ORwztHsoNk5nOOg5y3Lmv1lu8pqWLZ1P0u27mfp1v0HzUcxY1QaM0elM31UGhOzU4iN0t9Juk+hIIfWUAsvfhc+eRTGnuF1W01ID3VVYa+52fFpUSVLtu5jaYEXFNv2VQMQExXBlJxUZoxKZ2xmIkNS4hiSHMuQ5FjSEmI09Id0SqEgnVv6sNdtNXmY184wbHKoK5J2iipqvSMJPyTW7Cyjoeng/2ejIozM5Fgy/ZDITPYDIyWWzCTvGozcwYmkxqvdIpwpFCQwhUu800k1++BLv4Ip80JdkRxGbUMTe8prKaqoo6i8jqKKWoor6rznFXUUlXvPS6rqP/fezORYxgxOZOyQJMZmJjE2M5GxmUlkD4rXkUYYUChI4CqL4emvQME7MOs6+MJdA2K01XDW0NRMSWU9RRW17C6r5bO9VWwurmRzcRWbiiopq2loXTc2KoLR7cIiJy2euOhIYqMiiY2K8B5HRxAbFUFMZIQawfshhYJ0TVOjN9rqB/fCiNlw2Z8gZVioq5IgcM6xr6qezcVVbCmubA2LzcWVbN9XTXMnXwlmHAiKqAhioyKJi44gJS6a9MQYMpJiGZwUc+BxYgzpSTFkJMaSlhCtazpCRKEg3bP6GW+01dgkLxhGHR/qiqQX1TU2sbWkmp2lNdQ1Nnu3hiZq/fu6Nve1Lc/9x2U1DZRU1lNSVc++qroOw8UMBsVHk5EUS0ZiDFkpcQzzhygZmuLdD0uNJzM5VkOL9DCFgnRf0TpYeBXs2wJHnwuz/xVGn6IhMiRgzc2O0poG9lXVsbeynpLK+gOPq+rYV1XP3op6dvvDitQ3Nh/0/sgIIzMp1g+JuNbwyEyOJSEmkviYKO8+OpLEWP9xTCQJ0ZE6EjkEhYIcmdoy7yropQ9DdQkMGe+Fw6TLvUH3RHqIc4791Q3sKqthd5kXErvLatlV5o1FtavMe15Z1xjQ9mIiI7yAaAmKmEgSoqOI80MjISbyoMfxMVHER0eQEBPVuv6ghGjSErxTYClx0QOiIV6hID2joQZW/xU+/C3sWQXxaTD9Gjj2awNqhjfp+ypqvdNT1fVNVNc3+vdN1DR4j2v8597jtq9769e0Pm5qfVzT0ERnX4ERBmkJMaQlxpCeEENaotd2Miih5XkMGUkxZPtDugdj7o6W4IyJiuj29hUK0rOcg63vw0e/hfV/95aNO98beXXk8Tq1JP2Sc47ahubW4KhtaKKqronSmgb2V9Wzr6qe/dXt7qsa2F/tPW9/zQhAanx0a0DkpMW3Ps5Oi2f4oDgyk2IP6r1VUdvAnnKvO/Geilp2l9X53Y690Xt3l3ndjOubmvmfiycxf1b3pg/oC5PsyEBiBrknerfSbbD4QVj6J1i3CIZOgtnXw8RLITru8NtpboaGau9WXwWNdZA+GqJie2c/RNowM+L900zpiV3rhu2co7Kukf1VDRRX1rKjtJYd+2vYWVrDjtIatu+r5sMtJZ877RUTFUH2oHgMb5DFw83tkZUSx6zR6a2TQc0YlXYkuxsQHSlI99VXw6qnvFNLxesgIQNyT4bGWu8Lv6HaW6ehyr/3b+3Fp8Gky2DqVTBsSs8fddSWe4MAaigPCYGymgYvKPZ7YbGztIbC0hpwkJUSx9BU78t/SHJwZwHU6SPpPc7BZ2/Dxw9A8XqIToCYRP8+AaIT/fu2yxO9m0XCxpdh/QvQVAdZE71wmHz5kU0jWrLZ2+7Gl73TXhhMuwpO+jak5fbUnov0GwoF6V9q9nsN2p88DjuXQUQU5J/tBUTeWRDZybg9TY2w/SPY+BJsfAX2bvSWZx4D+V+EunL45DFobvKG8jj53yFjbPD3S6SPUChI/1W0DpY/DiuehKoiSMyEyVd4AZE1/sB6Nfth02ve0cCn/4TaUoiIhtyT4OhzIO8LXntFi/KdB7rZNtXDxEvg5O/CkHG9vYcivU6hIP1fUwNsetX7hb/xZa9dYPg0b7jv7R95p4Vck9eWkfdFOPpsGDMH4lIOv92KPd5wHov/4LVxjJ/rzS0xdFLv7JdICCgUZGCp2gur/uKdXtqzCoZM8EIg/2zIntG9iYKqSuDD+722kLpy7+rtU26B7Ok9X79IiCkUZOCqq4DY5J7bXk0pfPQ7LyBqS+GoM+GUW2Hk7J77DJEQUyiIdFVtuXf9xQf3ekN7DM73TkeNneO1U/RUEDkHZYXeKbDGWsg/BxIzembbIoegUBDprvoq7zRVS3fWxhqvN1T2TC8gxszxTllFBtiXvLEedq/yQmD7R7D9Y6jYeeB1i4Qxp8HEi72rxOMHBWOvJMwpFER6QkMtFH4Mm9+ALW/AzuWAg9gU7+ih5Ugi46gDF91VlXjv2fahFwA7l3lHBACpI73TUiNmw4hZ3rI1z3pDlpdu9XpPHXWmFxBHn9Ozp8kkrCkURIKhep93od6WN2DLm7C/wFuekgPDp3oX75Vs8pZFRHtXaLcEwIhZkDK84+0654XH6me8kCjfAVFx3jUaEy/xeldpdFo5AgoFkd6w77MDAbFrJQw5xg+A47yQiI7v+jabm70jjdXPwNrnoHKPd1X40WfDhIu98afigz8GjgwsCgWRgaC5Cba+5wXEukVeAzhAfLp3RXb6GEgf2+bxGLVJSIcUCiIDTVMDFLwLe1Z7Yzvt2wwlW6C88OD1EjLaBIV/P/K4Q5+6krCgobNFBprIaK9Re+ycg5c31HhtGy1BsW+L9/izt2HFEwfWSx/jNY7nnuLdpwzr1fKlf1AoiPR30fFeW8aQYz7/Wn21Nzjg1veh4B1Y8zdY9oj3WsZRfkic7N0nDw1+rZXFXhvM5tdhx1Jvmtexp3u3npzJzzlvv7d94B1hpeZA6gjvM+JSe+5zBiCdPhIJJ81N3jUTBe96IbH1fW+ID4CMPBjtB8SI2ZA8HCIijuzzGuu8rrmbX/duu1d6y+PTIWcm7F594JqNjLwDAZF7Yte647bs19b3vTaYbR9C9d6O141N8QIiNccLiZbAaAmNpKzuDZvSx6lNQUQ619wEu1b4IfGu96VaX+G9FhUHg0Z5I82mjT5wn5YLaaM6ni2v5Rd6SwgUvOsNOhgR5fXIGjsHjjoDhk7xAsc5KN7grbvljXbrz/ZPl50Ow6Ye/EXdWAc7lvkB8AFs++hA3YNGwagTYdQJ3i0mCcq2e7fS7d7V5K2Pt3tDm7QVEeUFYkrbW/bB90lZgV+82EcoFESk65oaYfcK7wt3f4F32/cZ7P+s3ax55n1BprcJif0F3kV+5Tu8Vbrzy7+xzrvquyVUdq3wlseneVd9DxoFhYuhcIk3KRN4c2a0BMDI4yE1u2v7XFfhBUVLSJRt94ZZL9/p7Uv5zgMXH7bufgQkDT0QGomDvVF8mxr8W73/vN573vZxUwM0N3hHJuPO8269cOpOoSAiPcc5qCo+EBBtw2J/gXctRVyq98U99nTvSu+0UUf+uVV7vWtANvvtEJV7vAsC24ZAsKdZdc6bu6MlIFrv2zyuLvEuVoyM8Y4gImP85y23GO++ZVlElHcqbd8WwCDnWDjmfG+YkyBN/qRQEJHeU1/tnU4K5rl457xf2x2dtuqPnPMmlFr/d1j3/IH2liHjvXA45nwYOrnH5ixXKIiI9Cf7t3pzla//u9dO4pph0EgvIMad711rcgShq1AQEemvKou9+cbXPe+dPmuqh4TBcPZPYPJl3dpkoKFwhP3NOi3ibDPbYGabzOy2Dl5fYGbFZrbcv30tmPWIiPQLSZkw/Wq46i9wy2a49CEYfUrXG9G7IWh9qswsErgPOAsoBBab2SLn3Np2qz7pnLsxWHWIiPRrcSneSLkTL+mVjwvmkcIsYJNzbotzrh5YCFwQxM8TEZEjFMxQyAa2t3le6C9r7xIzW2lmT5tZh9e5m9l1ZrbEzJYUFxcHo1YRESHIbQoBeB7Idc5NBv4J/KmjlZxzDzjnZjrnZmZmZvZqgSIi4SSYobADaPvLP8df1so5V+Kc8y9L5EFgRhDrERGRTgQzFBYDeWY22sxigHnAorYrmFnbsXvnAuuCWI+IiHQiaL2PnHONZnYj8AoQCTzknFtjZj8CljjnFgE3m9lcoBHYBywIVj0iItI5XbwmIhIG+sTFayIi0r/0uyMFMysGtnbz7YOBQ8y8ERbCef/Ded8hvPdf++4Z5ZzrtPtmvwuFI2FmSwI5fBqownn/w3nfIbz3X/vetX3X6SMREWmlUBARkVbhFgoPhLqAEAvn/Q/nfYfw3n/texeEVZuCiIgcXrgdKYiIyGEoFEREpFXYhEJns8ANZGZWYGar/NntBvzl4Gb2kJkVmdnqNsvSzeyfZvapf58WyhqD5RD7fqeZ7Wgzw+G5oawxWMxshJm9YWZrzWyNmX3TXx4uf/tD7X+X/v5h0abgzwK3kTazwAHzO5gFbkAyswJgpnMuLC7gMbNTgErgEefcRH/Zz4B9zrmf+D8K0pxz/xHKOoPhEPt+J1DpnLs7lLUFmz/A5jDn3DIzSwaWAhfijakWDn/7Q+3/5XTh7x8uRwqaBS6MOOfexhtgsa0LODBfx5/w/mcZcA6x72HBObfLObfMf1yBN+pyNuHztz/U/ndJuIRCoLPADVQO+IeZLTWz60JdTIhkOed2+Y93A1mhLCYEbvRnOHxooJ4+acvMcoFpwEeE4d++3f5DF/7+4RIK4e4k59x04Bzg3/xTDGHLeedMB/550wN+A4wFpgK7gJ+HtJogM7Mk4K/At5xz5W1fC4e/fQf736W/f7iEQqezwA1kzrkd/n0R8Cze6bRws6dlUif/vijE9fQa59we51yTc64Z+D0D+O9vZtF4X4iPO+ee8ReHzd++o/3v6t8/XEKh01ngBiozS/QbnTCzROALwOrDv2tAWgRc4z++BvhbCGvpVe1mOLyIAfr3NzMD/gCsc879X5uXwuJvf6j97+rfPyx6HwH43bB+yYFZ4O4KbUW9w8zG4B0dgDfT3p8H+r6b2RPAaXjDBu8B7gCeA54CRuINvX65c27ANcgeYt9Pwzt14IAC4F/bnGMfMMzsJOAdYBXQ7C/+Ht559XD42x9q/+fThb9/2ISCiIh0LlxOH4mISAAUCiIi0kqhICIirRQKIiLSSqEgIiKtFAoiPjNrajOS5PKeHE3XzHLbjlwq0ldFhboAkT6kxjk3NdRFiISSjhREOuHPR/Ezf06Kj83sKH95rpm97g809pqZjfSXZ5nZs2a2wr+d4G8q0sx+7491/w8zi/fXv9kfA3+lmS0M0W6KAAoFkbbi250+uqLNa2XOuUnAvXhXxgP8GviTc24y8Dhwj7/8HuAt59wUYDqwxl+eB9znnJsAlAKX+MtvA6b527k+OLsmEhhd0SziM7NK51xSB8sLgNOdc1v8Acd2O+cyzGwv3qQmDf7yXc65wWZWDOQ45+rabCMX+KdzLs9//h9AtHPuv8zsZbyJcZ4DnnPOVQZ5V0UOSUcKIoFxh3jcFXVtHjdxoE3vPOA+vKOKxWamtj4JGYWCSGCuaHP/gf/4fbwRdwGuwhuMDOA14AbwpoI1s9RDbdTMIoARzrk3gP8AUoHPHa2I9Bb9IhE5IN7Mlrd5/rJzrqVbapqZrcT7tT/fX3YT8EczuwUoBr7iL/8m8ICZfRXviOAGvMlNOhIJPOYHhwH3OOdKe2h/RLpMbQoinfDbFGY65/aGuhaRYNPpIxERaaUjBRERaaUjBRERaaVQEBGRVgoFERFppVAQEZFWCgUREWn1/wFlXIwM9jjmNgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.1468501091003418 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "plt.plot(history4.history['loss'])\n",
+    "plt.plot(history4.history['val_loss'])\n",
+    "plt.title(\"Model 4 Loss\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Loss')\n",
+    "plt.legend(['Train', 'Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "least-intellectual",
+   "metadata": {
+    "papermill": {
+     "duration": 1.401272,
+     "end_time": "2021-04-25T15:07:22.625160",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:21.223888",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Model 4 Accuracy vs no. of epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "efficient-thompson",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:07:25.741883Z",
+     "iopub.status.busy": "2021-04-25T15:07:25.711618Z",
+     "iopub.status.idle": "2021-04-25T15:07:25.846859Z",
+     "shell.execute_reply": "2021-04-25T15:07:25.847765Z"
+    },
+    "papermill": {
+     "duration": 1.806593,
+     "end_time": "2021-04-25T15:07:25.847933",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:24.041340",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEWCAYAAAB1xKBvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAA6N0lEQVR4nO3dd3xV9f348dc7ewFJSJgJhL1EVgAViyAO6gC3oBawinu2tVW/tlqrv6/tl1Zrq1YUJ2rqRKziQETBUZmizISwwsgge6/P74/PCVxCxk3IzU1y38/H4zzuved+zrmfkwvnfT9bjDEopZRSjfHzdgaUUkq1DxowlFJKuUUDhlJKKbdowFBKKeUWDRhKKaXcogFDKaWUWzRgKJ8hIgkiYkQkwI2080RkdWvkS6n2QgOGapNEZLeIlItITK39G5ybfoKXsnYMEZnj5Od6N9K+JCKVItKzNfKmVEvTgKHasl3A7JoXIjISCPNedo4lIlHA/cBmN9KGA5cCecA1Hs5a7c9utESllDs0YKi27FVgjsvrucArrglEpIuIvCIimSKyR0QeEBE/5z1/EVkgIlkikgqcX8exi0TkoIjsF5FHRMS/Cfn7X+BJIMuNtJcCucDDznW45iNaRF4UkQMikiMiS1zemykiG0UkX0R2ish0Z/9uETnLJd1DIrLYeV5T9XadiOwFVjj73xKRQyKSJyJficgIl+NDReSvzt8wT0RWO/s+FJHba+V3k4hc3IS/k+ogNGCotuw7oLOIDHNu5LOAxbXS/APoAvQHzsAGmGud9+YDFwBjgETgslrHvgRUAgOdNOcAjVYtAYjIBOec/3LzWuYCbwBJwFARGefy3qvYktMIoBvwuMtnvALcA0QCk4Hdbn4e2L/HMOBc5/UyYJDzGeuB11zSLgDGAacB0cBvgWrgZVxKRCIyCugNfNiEfKiOwhijm25tbsPeGM8CHsD+kp8OfAYEAAZIAPyBcmC4y3E3Aiud5yuAm1zeO8c5NgDoDpQBoS7vzwa+cJ7PA1bXkzd/YC1wivN6JXB9A9fSB3vzHe28/gT4u/O8p/NeVB3HPQs83tDfx+X1Q8Bi53mCc539G8hTpJOmC/aHYwkwqo50IUAOMMh5vQB42tv/PnTzzqYlDNXWvQpchb2Bv1LrvRggENjjsm8P9hcwQC9gX633avR1jj0oIrkikou9QXdzI0+3AJuMMd+5dwn8AthqjNnovH4NuEpEAoF4INsYk1PHcfHATjc/oy5Hrt2pnnvMqdbK52hJJcbZQur6LGNMKfBv4Bqnqm829jtRPkgbw1SbZozZIyK7gPOA62q9nQVUYG/+W5x9fYD9zvOD2JsuLu/V2IctYcQYYyqbmK1pwBkicp7zOhoYIyKjjTG31ZF+DtBHRA45rwOArs41fQ9Ei0ikMSa31nH7gAH15KGIYzsA9KgjjetU1FcBM7Gltt3YkkUOINi/Y6nzWT/UcZ6XsUFiNVBsjPm2njypDk5LGKo9uA440xhT5LrTGFMFvAk8KiKdRKQv8CuOtnO8CdwhInFOj6Z7XY49CHwK/FVEOouIn4gMEJEz3MjPPGzbwGhnWwv8Efif2glF5FTsjXiCS/qTgNeBOU4+lgFPi0iUiASKyGTn8EXAtSIyzclfbxEZ6ry3EZjlpK+rfaa2TtgAeRgbaP6fy9+iGngB+JuI9HJKI6eKSLDz/rfYarO/oqULn6YBQ7V5xpidxpi19bx9O/bXdir2F/Dr2JsfwHPY9oIfsI2879Y6dg4QhC2d5ABvY9sUGstPrjHmUM2GbUfJN8bk1ZF8LvC+MebHWsf8HbhARKKxVVYVwDYgA7jL+ZzvsQ34j2O7436JLU0B/B4biHKwwer1RrL9CrZKbr9zvbWr034D/AisAbKBP3Ps/eEVYCTHdzpQPkSM0QWUlFINE5E5wA3GmNO9nRflPVrCUEo1SETCsA39C72dF+VdGjCUUvUSkXOBTCCdxqu9VAenVVJKKaXcoiUMpZRSbukw4zBiYmJMQkKCt7OhlFLtyrp167KMMbHupO0wASMhIYG1a+vreamUUqouIrKn8VSWVkkppZRyiwYMpZRSbtGAoZRSyi0dpg2jLhUVFaSlpVFaWurtrHQYISEhxMXFERgY6O2sKKVaWYcOGGlpaXTq1ImEhARExNvZafeMMRw+fJi0tDT69evn7ewopVpZh66SKi0tpWvXrhosWoiI0LVrVy2xKeWjOnTAADRYtDD9eyrluzp0lZRSSrWI3L2wcwUUZ0N4rMsWYx+Dwho/R0Mqy6A0H0rzoLIEQiIhNAqCwqEN/UjTgOFBhw8fZtq0aQAcOnQIf39/YmPtgMrvv/+eoKCgeo9du3Ytr7zyCk8++WSr5FWpFldZDl/+GXZ9BSddAqNmQ2ikt3PlnooS2PM1pHxut6ztDacPDD8aPFwDSVi0DQZlTjAozTsaGErzju6vrKea1z8IQqPteUKj7BYWXWtfNHTuBb3HtvzfoZYOM/lgYmKiqT3Se+vWrQwbNsxLOTrWQw89REREBL/5zW+O7KusrCQgoP3F7Lb0d1VtVFYyvHM9HNwIXQfC4RQIDIORl8P466Hnyd7O4bGMsXlMWW633avtTdw/GBImwcCz7NYlDoqynC3TbsW1XhdlHk1TXWHP7x8MIV2crfPR58Euz2u2gGAoyYWSHCjJtqWakhy7FWcf3VdzboDe42D+imZduoisM8YkupO2/d2t2rl58+YREhLChg0bmDRpErNmzeLOO++ktLSU0NBQXnzxRYYMGcLKlStZsGAB//nPf3jooYfYu3cvqamp7N27l7vuuos77rjD25ei1PGMgfUvw8f32RvfFa/C8BlwYCOsXQSb3rTvx02ACfNh+EybzhvKCmzppyZI5O61+7sOgnHX2gDR97Tjq5uCwiGq7/Hnq80YW4LwD4bAkJbNuzFQXnQ0eLRStZXPBIw/frCZLQfyW/Scw3t15sELRzT5uLS0NL755hv8/f3Jz89n1apVBAQEsHz5cu6//37eeeed447Ztm0bX3zxBQUFBQwZMoSbb75Zx0Kopss/CPvXwYH1cPAHiEqAU2+F6P4nfu6iw7D0dtj+IfSfAhc9Y6tKAHqNhhn/gLMfho1vwJrn4d358PG9MHaOvUG7cxNujupqyN0DGVshY4vzuNVWM1VXQlAE9DsDJt0FA6fZv0lLELElBk8QgeAIu0X28cxn1MFnAkZbcvnll+Pv7w9AXl4ec+fOJTk5GRGhoqKizmPOP/98goODCQ4Oplu3bqSnpxMXF9ea2VbtTXE2HNhgg8N+57HgoH1P/CF2iP2FvfYF+0t/0l32xt4cKcthyS222uScR+GUW8Cvjk6YoVFw6i0w8SbY9aUNHF//HVY/AYOn2+qqAWfWfWxjjIH8AzYYZG49GiAyt0NF8dF0XfpAt2EwZDr0nwrxEyGg/vZEdZRHA4aITMcudu8PPG+MeazW+32Al4FIJ829xpiPnPfuA64DqoA7jDGfnEhemlMS8JTw8PAjz3//+98zdepU3nvvPXbv3s2UKVPqPCY4+Gix3d/fn8rKSk9nU7UnFaW2vWD/Oti/3gaH7NSj73cdCAk/sw2jvcdBj5EQGGpLHP99Bta+CJvfsyWDSXfZR3eqOSpKYflD9hyxQ+Gad+y5G+PnBwOm2i0vDda9BOtehh3LIKof9DkFqqvAVNlSQHUVmGqXfS6P1VVQVQaHU6Es7+hnRHS3gWHcPPsYO8wGyZDOTfjDKlceCxgi4g88BZwNpAFrRGSpMWaLS7IHgDeNMc+IyHDgIyDBeT4LGAH0ApaLyGBjTJWn8usteXl59O7dG4CXXnrJu5lR7Ud1NWRshp1fQOoXsOdb2x0ToHNv6DUGxlwDvcba5/X1Turc01YT/ezXNmh89zS8ehH0HA2T7rQlDz//uo9N32wbtjO2wIQb7HkCQ5t+LV3i4MwHYPJvYetSm4/dX9ugIv7288Uf/ALq2OdvSwdBYTDyMhsYug23j2HRTc+LapAnSxgTgBRjTCqAiCQBMwHXgGGAmnDfBTjgPJ8JJBljyoBdIpLinO9bD+bXK377298yd+5cHnnkEc4//3xvZ0e1ZXn7bXDY+YWtzinKtPtjh8K4udBvsi09dOrR9HOHdIHT74JTboYfkuCbJ+Hta+2v/dNuh9FXHQ0G1dXw/bPw2YP21/pVb8Hgc078+gKC7E1/5GUnfi7lER7rVisilwHTjTHXO69/AUw0xtzmkqYn8CkQBYQDZxlj1onIP4HvjDGLnXSLgGXGmLdrfcYNwA0Affr0Gbdnz7HrgGj3T8/Qv2srKSuw3TtrShFZO+z+8G62ymjAVPtY07DckqqrYNuH8PUTtporPBYm3gjDZtgeUDs/t20OM/4JEW4t1qbaqPbUrXY28JIx5q8icirwqoic5O7BxpiFwEKw4zA8lEelTkxWir3ZVxTbvv0VJXY75nmJbQ+oSVN82PZiqq6EgFA7FmDsXBsguo/wfDdKP3/bHXbYhTZoff0ErHjEbgGhcP5fIfG6NjUKWXmeJwPGfiDe5XWcs8/VdcB0AGPMtyISAsS4eaxSbZsx8O0/baNwdT2dFPwC7YC2wBAICDn6PCgCTrvDliLiJ3pvrIII9PuZ3Q79ZEsdIy6yjcfK53gyYKwBBolIP+zNfhZwVa00e4FpwEsiMgwIATKBpcDrIvI3bKP3IOB7D+ZVqZZVkgNLbrVjEobNgNPvtgO+AkPtL/TAEPvo7+1CfhP0OMluymd57F+rMaZSRG4DPsF2mX3BGLNZRB4G1hpjlgK/Bp4TkbuxDeDzjG1U2Swib2IbyCuBWztiDynVQe1fD2/NtV1Wp//Z1v1r1Y3qADz688YZU/FRrX1/cHm+BZhUz7GPAo96Mn9KtShj7EC0T+63YwB++THEudWWqFS70I7Kw0o1oLIMPrjLzhJ6ys2e6TnUkNJ8+OAOO/ht8HQ7LYaOA1AdTIdfQMnbpk6dyiefHDtI/YknnuDmm2+uM/2UKVOomXX3vPPOIzc397g0Dz30EAsWLGjwc5csWcKWLUeHvPzhD39g+fLlTcx9O2EMvH8b/PC6bWR+4mR4/1bI3NE6n3/oR1g4BbYshbP+CLPe0GChOiQNGB42e/ZskpKSjtmXlJTE7NmzGz32o48+IjIyslmfWztgPPzww5x11lnNOleb9+Vf4Mc37Wjh29fbQWw/vg1PTYCkq2HfGs98rjF2Oovnz7LdYed9aAe/NWceJKXaAf2X7WGXXXYZH374IeXl5QDs3r2bAwcO8MYbb5CYmMiIESN48MEH6zw2ISGBrKwsAB599FEGDx7M6aefzvbtRxdzee655xg/fjyjRo3i0ksvpbi4mG+++YalS5dyzz33MHr0aHbu3Mm8efN4+2077vHzzz9nzJgxjBw5kl/+8peUlZUd+bwHH3yQsWPHMnLkSLZt2+bJP03L2PQWrPx/MOoq+NlvILqfHSNw108w+Td2DMGis+DF82DHp/Ym3xLKi+C9m2w1VJ9T4MZV0PfUljm3Um2U77RhLLvXVh20pB4j4eePNZgkOjqaCRMmsGzZMmbOnElSUhJXXHEF999/P9HR0VRVVTFt2jQ2bdrEySfXvajMunXrSEpKYuPGjVRWVjJ27FjGjRsHwCWXXML8+fMBeOCBB1i0aBG33347M2bM4IILLuCyy46dZqG0tJR58+bx+eefM3jwYObMmcMzzzzDXXfdBUBMTAzr16/n6aefZsGCBTz//PMn+EfyoL3fwfu3QN/T4cK/H9sTKSLWljgm3QXrX4Fvn4LXL7fzDE26E066FPybOT18xjbbCypzO0y53wam+uZbUqoD8Z2A4UU11VI1AWPRokW8+eabLFy4kMrKSg4ePMiWLVvqDRirVq3i4osvJizMLuQyY8aMI+/99NNPPPDAA+Tm5lJYWMi5557bYF62b99Ov379GDx4MABz587lqaeeOhIwLrnkEgDGjRvHu+++e6KX7jnZqZB0FXSJhytfrX966uAIO532hPm2murrv8N7N9oRy6featdiCAq3y4keWTIzt/6lNEvzYOsH9pg5S+zIa6V8hO8EjEZKAp40c+ZM7r77btavX09xcTHR0dEsWLCANWvWEBUVxbx58ygtrWdN30bMmzePJUuWMGrUKF566SVWrlx5QnmtmUa9TU+hXpIDr19pp7u++i33Gpj9A2H0bDj5Skj+1E518fG9sPyP9v2amV7rI37Ocpqd7RoK5//VzvSqlA/xnYDhRREREUydOpVf/vKXzJ49m/z8fMLDw+nSpQvp6eksW7as3nUwACZPnsy8efO47777qKys5IMPPuDGG28EoKCggJ49e1JRUcFrr712ZKr0Tp06UVBQcNy5hgwZwu7du0lJSWHgwIG8+uqrnHHGGR65bo+oqoA350D2LvsLv+uAph3v52cXzhkyHfb+Fza/a4NJSBcIiXRZY7nWustBEdqYrXyeBoxWMnv2bC6++GKSkpIYOnQoY8aMYejQocTHxzNpUp1jF48YO3YsV155JaNGjaJbt26MHz/+yHt/+tOfmDhxIrGxsUycOPFIkJg1axbz58/nySefPNLYDRASEsKLL77I5ZdfTmVlJePHj+emm27yzEW3NGPgP3fbVeIu+hcknH5i5+sz0W5KKbd4bHrz1paYmGhqxi/U0Gm4PaNJf9eqCtj3X7tc5pDzoEvv5n/w6idg+YMw+R7boK2UOmHtaXpz1REVZUHyZ5D8CaSsOLps5rLf2ZlOT7kV4sY17ZxbltpgMeIS2zNJKdXqNGCoE2eMXbsh+VPY8YldcAdj51MafiEMOhdiBsOGV20X15/esVN2n3IzDL2w8Rlb96+Dd2+AuPFw0dPalqDavepqQ0FpJbkl5eQWV5BbUkFucTl5JRWUV1bTt2s4A7tF0Cc6DH+/tjNxZYcPGMYYRGcKbTFHqjDLCiB1pQ0QyZ9B4SFAoPdYmHKfXbKzx6hjb+7nPgpT7oWNr8N3z8Bb82y32Ak32O6tda07nbsP3phtx1XMer15a0Yrn5dbXM7mA/lsPpDH5gP5bDmQz6G8UnpGhhAXFUZcVKizhR15jAoLdPveUVlVTXZRORkFZWTWbIX2Maf4aFDIKy63jyUVbo0hDfL3o39sOAO6RTAwNoKB3ezWLyackMDWH/vTodswdu3aRadOnejatasGjRZgjOFwVhYFO1bTb8UNUFVuexANmGpLEYPOhohu7p2sugp2fGwDx+5VEBgOY66GiTcd7flUmg8vTIe8fXDdZ9BtqOcuTnUIxhgO5pUeFxz25x7tNt2zSwgjenWmV2Qoh/JKScspIS2nmPzSY7uRhwX5Hwke8c6jn58cExAy8kvJKizjcFF5nQGgU0gA0eFBRIYG0iXMPkaGBR7/OiyQLqFBRIYF4i9CalYROzMKScksJCXDbvtyio98hp9AfHTYkSAyMq4LF5zcvAk3m9KG0aEDRkVFBWlpac0e46COF1Kwl7jlNxA4+gq7fGefU5s/YrrGwR/gu3/Bj2/ZlekGT4dTboJv/gk7V8A1b8OAM1vmAlS7VFpRRX5JBfmlFeSVVB55nu/8Ws8uqmB7ug0OOcUVgB343z8mnOG9ujCiV2dG9OrM8J6d6RpR9+qFeSUVpOUUOwGk5Njn2cUUlNmAEugvxEYEE9upZgs58rxbzT7n/ZYsBZRWVJGaWeQSRApIyShkV1YRo+Mjeeum05p1Xg0YyjP2fAsvnQejr4KZT7X8+QvS7XoSaxfZNa0BLngCEq9t+c9SbU5GQSmrdmSxKjmTPdnFTlCoPFKv35DQQH8Gdos4Ghh6dWFYz06EBbVcrXtecQVVxhAZGohfG2pXqKyqJq+kot5A2BgNGKrllebDvybZEc83rYbgTp77rIpSW9ow1XbmWdUhlVVWsXZ3Dl/tyOTLHZlsO2THEMVEBDG0R2e6hAbSOTSAzqGBdA4JdF4H0jkk4MjzLqGBdAoJIDhA5/JqLu1Wq1rex/dCXhpc+7FngwXY9a7H/sKzn6HqVVJeRVpOMfucKpl92cXsyy5hX04x6fllxEQE0Sc6jD7RYfTtGkZ8dBh9u4bTOzKUoID6e7AZY9iZWcRXOzJZlZzJd6nZlFRUEegvJPaN5nfTh/KzQTEM79m5Tf2CV0dpwFCN27IUNr5mpw/XkdEdQmlFFZvS8tiZWWgDglNnvy+7hKzCsmPSBgf4ERcVSnx0GCf16kJWYRm7sor4ckcmZS5VRX4CPbuEHgkmfbraRxFYnZzFquSsI43P/WLCuSIxjsmDYzmlf1fCg/VW1B7ot6QaVnAIPrgTeo62XWJVu5SeX8q6PTms3Z3Dur05bN6fR2W1rY729xN6RYYQHxXGtKHdiI+2wSEuKpT4qDBiIoLr/MVfXW3ILCxjb3Yxew4Xsze7mH3Zxew5XMTn2zKOCTydggM4bWBXbpk6gMmDYomPDmu1a1ctRwOGqp8xdqnTihK45LkT7w2lWkVlVTXbDhWwfm/OkSBR88s+OMCPUXGRXP+z/iT2jWJIj0707BJCgH/TB0P6+QndO4fQvXMI4xOOnzG4qKySfTnFlFZUM6JXZwKb8RmqbdGAoeq35nlIWQ7nLYDYwd7OTbuVX1pBdbWhS6j7A8HcYYwhu6icfU47Q3J6Aev25rBxby5F5VUAdOsUTGJCFNdOSiAxIZrhPTs32M7QksKDAxjao3OrfJZqHRowVN0yd8CnD8DAs2D89d7OTbuzK6uI5VvS+WxrOmt3Z1NtICTQ78gv8h6dQ+jRxfV5MN07h9CtU8gxN/SC0oojDc77souPjA+o2VfsBAawbQjDenbm0nFxjOsbxbi+UfSODNVBq6rFaMBQx6ssh3fnQ2CYHW+hN5xGVVUbNu7L4bMtGSzfmk5KRiEAQ3t04pYpA4kMC+RQXimH8ktJzy9lw74c0jeXHTe+QAS6hgcRHR5ERkEZuc4gtBrhQf7ER9ueSacN7Ep8VNiR9oa+XcNadNyBUrXpvy51vC//DAc3wpWLoVMPb+emzSour2R1chafbUlnxbYMDheVE+AnnNK/K9dM7MO0Yd0bbNw1xpBbXMGhfCeQuASUw4XljE+IPqbxOT66afMbKdXSNGCoY+39L6z+G4y+xk79oY6RkV/Kim0ZfLYlndUpWZRVVtMpJICpQ7px1vDunDE4li6h7nUOEBGiwoOICg9iWE+t61dtnwYMdVRZAbx3g51B1otroLclxhh+2p/P59tsKWJTml3bo3dkKLMn9OHs4d0ZnxDdag3JSnmTBgx11Mf3Qu5euHaZ50dzt2HF5ZV8nXKYFU6QSM8vQwTGxEdyz7lDOHNoN4b26KRVQ8rnaMBQ1tb/wIbF8LNfQ59TvJ2bVrc/t4QV2zJYsTWdb3YepqyymojgACYPjuHMod2ZOiS22ZO7KdVRaMBQdpbYD+6AnqPgjI45mrussorc4gqyi8rJKS4np6iCnOJy0nJKWLk948jEd32iw7hqYh/OGqZVTUrVpgHD19WM5i4vsqO5A4K8naNmKSyr5L31aezMLCKnuJzsovIjASK3uPzIQLba/P2EcX2juP+8oZw5tDsDYsO1qkmpemjA8HXfPgUpn8HP/w9ih3g7N012uLCMl7/Zzcvf7iGvpOLoCmdhQcREBDGoW4TtiRQW6Dw6W3gg0WE2nZYilHKPBgxfZQysfAy+fAyGnA8T5ns7R02SllPM86t2kbRmL2WV1Zw7vAc3TRnA6PhIb2dNqQ5LA4YvqqqAD+6CjYvteIsLn2g3o7m3Hyrg2S938v4PB/ATuGh0b248YwADu0V4O2tKdXgaMHxNaT68NdeulT3lPjjjd+0iWKzbk80zK3eyfGsGYUH+zDstgetO70evyFBvZ00pn6EBw5fkH4TXLoeMLTDjn21+VTtjDCu3Z/LMyp18vzubqLBA7j5rMHNO7UtUePtsnFeqPdOA4SsytsLiy6A0F65+085C2wbZZTwLWZ2cRdKafWw7VECvLiE8eOFwrhwfr5PrKeVFHv3fJyLTgb8D/sDzxpjHar3/ODDVeRkGdDPGRDrvVQE/Ou/tNcbM8GReO7RdX0HSNRAYCtd+ZMdbtCEH80r4OuUw36RksToli4wCu1LbkO6d+Ovlo5gxupcuvqNUG+CxgCEi/sBTwNlAGrBGRJYaY7bUpDHG3O2S/nZgjMspSowxoz2VP5+x6S1YcjNE94dr3obIPt7OEXklFXyXepivU7L4OiWLnZlFgJ3W+9QBXTl9YAyTBsboMp5KtTGeLGFMAFKMMakAIpIEzAS21JN+NvCgB/PjW4yB1Y/D53+EvqfDrMUQGuWVrJSUV7Fhbw5f78xidcphfkzLpdpAaKA/E/tHM2t8HyYNjGFoj051rh2tlGobPBkwegP7XF6nARPrSigifYF+wAqX3SEishaoBB4zxiyp47gbgBsA+vTx/i/nNqOqEpb9FtYugpMug4uehoDWmwcps6CMdXuyWbM7h7V7cti8P4/KaoO/nzA6PpLbzhzE6QNjGB0fqYPmlGpH2koL4izgbWOM6/wNfY0x+0WkP7BCRH40xux0PcgYsxBYCJCYmGhaL7ttWHkRvH0d7FgGk+6CaQ+Cn+duyraRuoi1u22AWLcnm92HiwEICvBjdFwkN0zuT2JCFOMToukU4t5aEUqptseTAWM/EO/yOs7ZV5dZwK2uO4wx+53HVBFZiW3f2Hn8oeqI4mx47TI4sAHOW+Cx0ds/7c9jdUoWa50AkeMsIxodHkRi3yiumtiHcX2jOal3Z4ID/D2SB6VU6/NkwFgDDBKRfthAMQu4qnYiERkKRAHfuuyLAoqNMWUiEgNMAv7iwby2f1UV8OYcOPQTXPkaDD2vxT9iX3Yxjy3bxoc/HgSgf0w4Zw/vTmLfaBITougXoxP3KdWReSxgGGMqReQ24BNst9oXjDGbReRhYK0xZqmTdBaQZIxxrVIaBjwrItWAH7YNo77GcgXwyf/A7lVw8bMtHiyKyip5ZuVOFq5KxU/g7rMGc/UpfYjR9SGU8ily7H26/UpMTDRr1671dja8Y/2rsPQ2OPU2OPfRFjttdbXhvQ37+csn20jPL+Oi0b343c+H0rOLTsehVEchIuuMMYnupG0rjd6qufatgQ9/Bf2nwll/bLHTrtuTw8P/2cIP+3IZFdeFp68ex7i+3umWq5RqGzRgtJbcfVBRArGDW+6c+Qfh39dA515w2Qvgf+Jf54HcEv788Tbe33iAbp2C+evlo7h4TG8dH6GU0oDRKoyBN2ZD5ja48O8w5uoTP2dFKfz7aigrgF+8B2HRJ3S6kvIqnv1qJ//6cifVBm6bOpCbpwwgPFj/iSilLL0btIaDGyH9R+jUC96/xc4We/bD4NfMLqfG2Gqo/evgysXQfXizs2aMYekPB/jzsm0cyCvl/JE9uffnQ3VaDqXUcTRgtIYNiyEgBG5aDSv/F779J2Qlw6XPQ0jnpp/vv8/CxtfgjHth2IXNylJ1teHzbRn8Y0Uym9LyGNGrM49fOZqJ/bs263xKqY5PA4anVZTAj2/BsBkQ3hXOXwDdhsJHv4VF58DsNyC6n/vnS10Jn9wPQy+wix81UVW14aMfD/LUFylsO1RAfHQof7n0ZC4dF4e/tlMopRqgAcPTtn0IpXkw5pqj+8ZfD10H2YF2z50JV74KCac3fq6c3fDWPIgZDBf/q0lTflRUVfP+xgM8/UUKqVlFDIgN5/ErR3Hhyb0I0KnDlVJu0IDhaRtetVOKJ/zs2P39z4D5K+D1K+GVmXD+32Dc3PrPU1YIb1wFphpmvQbBndz6+LLKKt5el8YzK3eSllPCsJ6defrqsZw7ooeWKJRSTaIBw5Ny90LqlzDl3rpLA10HwPXL4e1r4YM7bC+qs/90fPdYY2xjeeZWuPpte1wjSsqreOP7vSz8KpVD+aWMio/koQtHMG1YN52+QynVLBowPGnjG/Zx9HFTaB0VGglXvQWf/g989zRk7bBjKkK6HE2zagFseR/OeQQGTmvwIwtKK1j83V6eX5XK4aJyJvaLZsHlo5g0sKsGCqXUCdGA4SnV1bBxsa16amyVO/8A+PmfIXYofPQbeP4smJ1kSxLbl8GKR+DkK+3UH/UwxvDWujQe/XAreSUVTB4cy21TBzKh34mNz1BKqRoaMDxl9ypbJTWtCYsIJl4LXQfCm7+A56fZqT4++R/oOdoO+KunhJBXXMH9S37kw00HmdAvmv85bxij4iNb5DKUUqqGBgxP2bDYVisNPb9px/X7Gcz/At6YZds1wmNtI3dg3RP+fb8rm7v/vZH0/FLuOXcIN50xQBuzlVIeoQHDE0pyYetS25W2nht9g6L7wXWfwZd/hpMuhS5xxyWprKrmyc+T+ecXKcRHh/H2zacxWksVSikP0oDhCT+9A5Wlx469aKqQzvVOVb4vu5g7kzawfm8ul46N448zRxChcz4ppTxM7zKesGExdD/Jtj20sPc37ueB934CgSdnj2HGqF4t/hlKKVUXDRgtLX0zHFgP0x+rt5G6OQpKK3jw/c28u2E/iX2jeGLWaOKidIJApVTr0YDR0ja8Bn6BMPKKljvl3hzuTNpIWk4xd581mFunDtDpPJRSrU4DRkuqLIdNSXZN7fATn/W1qtrwzMoUHl+eTI/OIbx546kkJui4CqWUdzQaMETkQuBDY0x1K+SnfdvxMRQfhtEn0NjtKCqr5PqX1/Jt6mFmjOrFIxefROeQwBbIpFJKNY879RpXAski8hcRGerpDLVrG1+DTj1hwJkndJryympuWryO73dn83+XnczfZ43WYKGU8rpGA4Yx5hpgDLATeElEvhWRG0TEvelSfUX+QUj+FEbNPqG1taurDb99+wdWJWfxv5eM5PLEeJ0DSinVJrjVcmqMyQfeBpKAnsDFwHoRud2DeWtfNiXZqcdPZOwF8NjH21iy8QD3nDuEKxLjWyhzSil14hoNGCIyQ0TeA1YCgcAEY8zPgVHArz2bvXbCGDv2os9pbk09Xp/nV6Wy8KtU5p7al1umNP88SinlCe7UnVwKPG6M+cp1pzGmWESu80y22pl9/4XDKXD6r5p9ivc37ueRD7dy3sge/OHCEVoNpZRqc9wJGA8BB2teiEgo0N0Ys9sY87mnMtaubHgVgiJg+MxmHb4qOZPfvPUDp/SP5m9XjNbJA5VSbZI7bRhvAa5daqucfQrs0qk/vQcjLobgiCYf/mNaHje9uo4BsREsnJNISKC/BzKplFInzp2AEWCMKa954TwP8lyW2pktS6CiCMb8osmH7jlcxLUvfU9kWBAv/3KCdp1VSrVp7gSMTBGZUfNCRGYCWZ7LUjuzYTF0HQTxE5p0WGZBGXNe+J6qasMr102ge+cQD2VQKaVahjttGDcBr4nIPwEB9gFzPJqr9iIrBfZ+a1fGa0IjdWFZJde+9D0Z+WW8Pn8iA2KbXpWllFKtrdGAYYzZCZwiIhHO60KP56q92LgYxB9GzXL7kPLKam5evI6tBwt4bs44xvSJ8mAGlVKq5bg1JFlEzgdGACE13T2NMQ97MF9tX1Ul/JAEg86GTj3cOqS62nCPM4r7/y47mTOHdvdwJpVSquW4M3DvX9j5pG7HVkldDvT1cL7avp0roOBgk0Z2/++yrbzvjOK+XEdxK6XaGXcavU8zxswBcowxfwROBQZ7NlvtwIZXISwGBp3rVvKXv9nNc6t2Me+0BB3FrZRql9wJGKXOY7GI9AIqsPNJ+a6iLNi+zLZdBDTew7iwrJIFn25n8uBYfn/BcB3FrZRql9xpw/hARCKB/wPWAwZ4zpOZavN+SILqChh9tVvJk77fS0FpJb8+e7CO4lZKtVsNBgwR8QM+N8bkAu+IyH+AEGNMXmtkrk2qroa1iyD+FOg+vNHk5ZXVLFq9i1P7d2VUfKTn86eUUh7SYJWUs8reUy6vy5oSLERkuohsF5EUEbm3jvcfF5GNzrZDRHJd3psrIsnONtfdz/S41C8gOxXGX+9W8g9+OMDBvFJuPKO/hzOmlFKe5U6V1OcicinwrjHGuHtiEfHHBpuzgTRgjYgsNcZsqUljjLnbJf3t2IWaEJFo4EEgEVsFts45Nsfdz/eYtS/Yxu7hMxpNaozh2a92MrRHJ84YHNsKmVNKKc9xp9H7Ruxkg2Uiki8iBSKS78ZxE4AUY0yqM/9UEtDQdK6zgTec5+cCnxljsp0g8Rkw3Y3P9Ky8NNj+EYydAwHBjSb/YnsGO9ILufGM/trQrZRq99wZ6d3cpVh7Y6cRqZEGTKwroYj0BfoBKxo4tncz89Fy1r1kF0tKvNat5P/6MpVeXUK44ORens2XUkq1gkYDhohMrmt/7QWVTtAs4G1jTFVTDhKRG4AbAPr06dOC2alDZTmsexkGnwuRjX/W+r05fL8rm99fMJxAf7dWwlVKqTbNnTaMe1yeh2CrmtYBZzZy3H7AdThznLOvLrOAW2sdO6XWsStrH2SMWQgsBEhMTHS7faVZtn0ARRluN3Yv/DKVLqGBzBqvI7qVUh2DO1VSF7q+FpF44Ak3zr0GGCQi/bABYBZwVe1EIjIUiAK+ddn9CfD/RKRmZr5zgPvc+EzPWbMIIvvCgGmNJk3NLOSTLYe4dcpAwoPdmq5LKaXavObUlaQBwxpLZIypBG7D3vy3Am8aYzaLyMOu62tgA0mSaw8sY0w28Cds0FkDPOzs846MrbDnaxh/Hfg1/id7btUuAv39mHtagufzppRSrcSdNox/YLu2gg0wo7EjvhtljPkI+KjWvj/Uev1QPce+ALzgzud43JpF4B8MoxufaDCjoJR31qdx+bg4Yjs13pNKKaXaC3fqS9a6PK8E3jDGfO2h/LQ9ZQV2KpARF0N410aTv/zNbiqqqpn/Mx2op5TqWNwJGG8DpTU9mETEX0TCjDHFns1aG7HpTSgvcKuxu7Cskle/3cPPT+pBQkx4K2ROKaVajzttGJ8DoS6vQ4HlnslOG2OMrY7qcTLEJTaaPOn7veSXVnLjZJ2+XCnV8bgTMEJcl2V1nod5LkttyN7vIGOzLV00MlK7ZpLBU/pH6ySDSqkOyZ2AUSQiY2teiMg4oMRzWWpD1i6C4C4w8rJGkx6dZFBLF0qpjsmdNoy7gLdE5AB2idYe2CVbO7bCTNi8xHalDWq4PaJmksEh3TsxRScZVEp1UO4M3FvjDK4b4uzaboyp8Gy22oANr9hFkhKvazTpyu2Z7Egv5G9XjNJJBpVSHVajVVIicisQboz5yRjzExAhIrd4PmteVF0Fa1+EfpMhtvHly//15U56dQnhwlE6yaBSquNypw1jvrPiHgDOdOPzPZajtiD5U8jb51ZX2g17c/jvrmx+eXo/nWRQKdWhuXOH8xeXehZnYaQgz2WpDVizCDr1hCHnNZr02S9T6RwSwKwJHp4tVymlvMydgPEx8G8RmSYi07CLHC3zbLa8KDsVUpbDuHngH9hg0ppJBn9xal8idJJBpVQH585d7nfYNSducl5vwvaU6pjWvgjiZ1fVa0TNJIPzTuvXChlTSinvarSEYYypBv4L7MauhXEmdvbZjqeiBDa8CkPPh84NN2DXTDJ4mU4yqJTyEfWWMERkMHad7dlAFvBvAGPM1NbJmhdsXgIlOW41duskg0opX9NQldQ2YBVwgTEmBUBE7m6VXHnLmueh6yDbnbYBNZMMTh/Rg346yaBSykc0VCV1CXAQ+EJEnnMavDvuqLQDG2H/Wrfmjfrox4Pkl1Yyf7KWLpRSvqPegGGMWWKMmQUMBb7AThHSTUSeEZFzWil/rWftIggMg1GzGk265UA+YUH+jI6L9Hy+lFKqjXCn0bvIGPO6s7Z3HLAB23Oq4yjJhU1v2UkGQyMbTZ6cUcCgbhH4+XXcApdSStXWpKHJxpgcY8xCY8w0T2XIK354AypL3Jo3CiA5vZCB3Tp5OFNKKdW26FwWxtjG7rjx0Gt0o8nziivIKChjcPcIz+dNKaXaEA0YObugKNOtrrRgq6MABmnAUEr5GJ3PIro//Gob+Ln3p9iRbhcfHKRVUkopH6MBAyDI/RVnkzMKCA30p3dkaOOJlVKqA9EqqSZKTi9kUHftIaWU8j0aMJooOaOAgd20/UIp5Xs0YDRBXkkF6fllDO6u7RdKKd+jAaMJUmp6SGkJQynlgzRgNEFNDyktYSilfJEGjCZITi/UHlJKKZ+lAaMJahq8tYeUUsoXacBogh3pBdp+oZTyWRow3FTTQ2qQtl8opXyUBgw3aQ8ppZSv04DhpmTtIaWU8nEaMNy0I72QkEA/4qK0h5RSyjdpwHCT9pBSSvk6DRhuSk4vZLBOaa6U8mEaMNyQX1rBofxSBuqiSUopH+bRgCEi00Vku4ikiMi99aS5QkS2iMhmEXndZX+ViGx0tqWezGdjjjR4awlDKeXDPLaAkoj4A08BZwNpwBoRWWqM2eKSZhBwHzDJGJMjIt1cTlFijBntqfw1RYouy6qUUh4tYUwAUowxqcaYciAJmFkrzXzgKWNMDoAxJsOD+Wm2oz2k3F+ZTymlOhpPBozewD6X12nOPleDgcEi8rWIfCci013eCxGRtc7+i+r6ABG5wUmzNjMzs0Uz7yo5o5ABsRH4aw8ppZQP8/aa3gHAIGAKEAd8JSIjjTG5QF9jzH4R6Q+sEJEfjTE7XQ82xiwEFgIkJiYaT2UyOb2AU/p39dTplVKqXfBkCWM/EO/yOs7Z5yoNWGqMqTDG7AJ2YAMIxpj9zmMqsBIY48G81qugtIKDeaW6LKtSyud5MmCsAQaJSD8RCQJmAbV7Oy3Bli4QkRhsFVWqiESJSLDL/knAFrwgOUOnBFFKKfBglZQxplJEbgM+AfyBF4wxm0XkYWCtMWap8945IrIFqALuMcYcFpHTgGdFpBob1B5z7V3VmlKcLrU66aBSytd5tA3DGPMR8FGtfX9weW6AXzmba5pvgJGezJu7dqQXEBzgR3y09pBSSvk2HendCO0hpZRSlgaMRiSnFzBYB+wppZQGjIYUlFZwIK9UV9lTSik0YDQoJUMbvJVSqoYGjAboKntKKXWUBowGJGdoDymllKqhAaMBO9K1h5RSStXQgNGAlIxCndJcKaUcGjDqUVhWyf7cEm2/UEophwaMetT0kNJJB5VSytKAUY8d6XaVPS1hKKWUpQGjHikZhQQF+NFHe0gppRSgAaNeO9ILtIeUUkq50IBRj+T0Qh3hrZRSLjRg1KHoSA8pDRhKKVVDA0YdjvaQ0gZvpZSqoQGjDkd7SGkJQymlamjAqIP2kFJKqeNpwKjDjvQC+seEE+Cvfx6llKqhd8Q67Egv1AF7SilViwaMWmp6SGmXWqWUOpYGjFqOrLKnJQyllDqGBoxako8EDC1hKKWUKw0YtSSnFxDk70df7SGllFLH0IBRS3JGIf1jtYeUUkrVpnfFWnakF2j7hVJK1UEDhovi8krScrSHlFJK1UUDhouaHlI6JYhSSh1PA4aL5HSddFAppeqjAcPFjowCAv2FhK7aQ0oppWrTgOEiJb2Q/jER2kNKKaXqoHdGFzsyCnTAnlJK1UMDhqOmh5ROOqiUUnXTgOHYmVGEMWiXWqWUqocGDEdyhl1lTwftKaVU3TRgOHakFxLoL/TVHlJKKVUnDRiO5PQC+sdEEKg9pJRSqk4evTuKyHQR2S4iKSJybz1prhCRLSKyWURed9k/V0SSnW2uJ/MJdtLBgdpDSiml6hXgqROLiD/wFHA2kAasEZGlxpgtLmkGAfcBk4wxOSLSzdkfDTwIJAIGWOccm+OJvJaUV7Evp5hLx8Z54vRKKdUheLKEMQFIMcakGmPKgSRgZq0084GnagKBMSbD2X8u8JkxJtt57zNguqcyujOz0PaQ0hKGUkrVy5MBozewz+V1mrPP1WBgsIh8LSLficj0JhzbYnak2x5SOumgUkrVz2NVUk34/EHAFCAO+EpERrp7sIjcANwA0KdPn2ZnIjmjpodUeLPPoZRSHZ0nSxj7gXiX13HOPldpwFJjTIUxZhewAxtA3DkWY8xCY0yiMSYxNja22RlNTi+gX0y49pBSSqkGePIOuQYYJCL9RCQImAUsrZVmCbZ0gYjEYKuoUoFPgHNEJEpEooBznH0ekZxRyCCd0lwppRrksYBhjKkEbsPe6LcCbxpjNovIwyIyw0n2CXBYRLYAXwD3GGMOG2OygT9hg84a4GFnX4srKa9ib3axNngrpVQjPNqGYYz5CPio1r4/uDw3wK+crfaxLwAveDJ/AEXllVx4ci8S+0Z7+qOUUqpd83ajt9fFRATz5Owx3s6GUkq1edrKq5RSyi0aMJRSSrlFA4ZSSim3aMBQSinlFg0YSiml3KIBQymllFs0YCillHKLBgyllFJuETvYuv0TkUxgzwmcIgbIaqHstDd67b7Ll6/fl68djl5/X2OMW7O3dpiAcaJEZK0xJtHb+fAGvXbfvHbw7ev35WuH5l2/VkkppZRyiwYMpZRSbtGAcdRCb2fAi/TafZcvX78vXzs04/q1DUMppZRbtIShlFLKLRowlFJKucXnA4aITBeR7SKSIiL3ejs/rU1EdovIjyKyUUTWejs/niQiL4hIhoj85LIvWkQ+E5Fk5zHKm3n0pHqu/yER2e98/xtF5Dxv5tFTRCReRL4QkS0isllE7nT2d/jvv4Frb/J379NtGCLiD+wAzgbSsOuHzzbGbPFqxlqRiOwGEo0xHX4Ak4hMBgqBV4wxJzn7/gJkG2Mec34wRBljfufNfHpKPdf/EFBojFngzbx5moj0BHoaY9aLSCdgHXARMI8O/v03cO1X0MTv3tdLGBOAFGNMqjGmHEgCZno5T8pDjDFfAdm1ds8EXnaev4z9j9Qh1XP9PsEYc9AYs955XgBsBXrjA99/A9feZL4eMHoD+1xep9HMP2Q7ZoBPRWSdiNzg7cx4QXdjzEHn+SGguzcz4yW3icgmp8qqw1XJ1CYiCcAY4L/42Pdf69qhid+9rwcMBacbY8YCPwdudaotfJKx9bO+Vkf7DDAAGA0cBP7q1dx4mIhEAO8Adxlj8l3f6+jffx3X3uTv3tcDxn4g3uV1nLPPZxhj9juPGcB72Go6X5Lu1PHW1PVmeDk/rcoYk26MqTLGVAPP0YG/fxEJxN4wXzPGvOvs9onvv65rb8537+sBYw0wSET6iUgQMAtY6uU8tRoRCXcawRCRcOAc4KeGj+pwlgJznedzgfe9mJdWV3OzdFxMB/3+RUSARcBWY8zfXN7q8N9/fdfenO/ep3tJAThdyZ4A/IEXjDGPejdHrUdE+mNLFQABwOsd+fpF5A1gCnZa53TgQWAJ8CbQBzs9/hXGmA7ZMFzP9U/BVkkYYDdwo0udfochIqcDq4AfgWpn9/3YuvwO/f03cO2zaeJ37/MBQymllHt8vUpKKaWUmzRgKKWUcosGDKWUUm7RgKGUUsotGjCUUkq5RQOGUo0QkSqXGT03tuSsxiKS4Dp7rFJtWYC3M6BUO1BijBnt7Uwo5W1awlCqmZy1RP7irCfyvYgMdPYniMgKZ1K3z0Wkj7O/u4i8JyI/ONtpzqn8ReQ5Z62CT0Uk1El/h7OGwSYRSfLSZSp1hAYMpRoXWqtK6kqX9/KMMSOBf2JnDAD4B/CyMeZk4DXgSWf/k8CXxphRwFhgs7N/EPCUMWYEkAtc6uy/FxjjnOcmz1yaUu7Tkd5KNUJECo0xEXXs3w2caYxJdSZ3O2SM6SoiWdgFayqc/QeNMTEikgnEGWPKXM6RAHxmjBnkvP4dEGiMeUREPsYueLQEWGKMKfTwpSrVIC1hKHViTD3Pm6LM5XkVR9sWzweewpZG1oiItjkqr9KAodSJudLl8Vvn+TfYmY8BrsZO/AbwOXAz2OWBRaRLfScVET8g3hjzBfA7oAtwXClHqdakv1iUalyoiGx0ef2xMaama22UiGzClhJmO/tuB14UkXuATOBaZ/+dwEIRuQ5bkrgZu3BNXfyBxU5QEeBJY0xuC12PUs2ibRhKNZPThpFojMnydl6Uag1aJaWUUsotWsJQSinlFi1hKKWUcosGDKWUUm7RgKGUUsotGjCUUkq5RQOGUkopt/x/saA9dCMyNdQAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.1431427001953125 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "plt.plot(history4.history['accuracy'])\n",
+    "plt.plot(history4.history['val_accuracy'])\n",
+    "plt.title(\"Model 4 Accuracy\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Accuracy')\n",
+    "plt.legend(['Train', 'Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "binding-cross",
+   "metadata": {
+    "papermill": {
+     "duration": 1.45802,
+     "end_time": "2021-04-25T15:07:28.702825",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:27.244805",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6.9 Model 1 (CNN) v/s Model 4 (Simple Neural Network)\n",
+    "\n",
+    "#### Loss v/s no. of epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "standard-comment",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:07:31.602595Z",
+     "iopub.status.busy": "2021-04-25T15:07:31.574052Z",
+     "iopub.status.idle": "2021-04-25T15:07:31.729268Z",
+     "shell.execute_reply": "2021-04-25T15:07:31.729909Z"
+    },
+    "papermill": {
+     "duration": 1.607241,
+     "end_time": "2021-04-25T15:07:31.730131",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:30.122890",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAEWCAYAAABi5jCmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAABRGElEQVR4nO3dd3hUVfrA8e+ZkkkmvQcSSugQSiiKUhQFXEHALuJaEMvay+66lt2fuu6quy7Wta0dy4qslLUroEhRV0CR3gkQIBVIL1PO7487GTIhlWRSmPfzPPeZO/feuXNuBuad096rtNYIIYQQVUxtXQAhhBDtiwQGIYQQPiQwCCGE8CGBQQghhA8JDEIIIXxIYBBCCOFDAoMQDVBKdVdKaaWUpRHHzlRKrWyNcgnhLxIYxElFKZWhlKpUSsXV2P6z58u9exsVrUkBRoi2JIFBnIz2ADOqniilBgH2tiuOEB2LBAZxMnoHuLra82uAt6sfoJSKVEq9rZTKVUrtVUr9SSll8uwzK6VmK6XylFK7gfNqee3rSqlDSqkDSqm/KqXMzSmwUqqzUuojpdRhpdROpdQN1fadqpRao5QqVEplK6We8mwPVkq9q5TKV0odVUqtVkolNqccQoAEBnFy+gGIUEr193xhXw68W+OYfwKRQA/gTIxAcq1n3w3AFGAoMAK4pMZr3wKcQC/PMecA1zezzHOBTKCz5/0eU0qd7dn3LPCs1joC6AnM82y/xnMNXYBY4CagrJnlEEICgzhpVdUaJgJbgANVO6oFi/u11kVa6wzgSeAqzyGXAc9orfdrrQ8Dj1d7bSIwGbhLa12itc4Bnvac74QopboAo4F7tdblWut1wGscq/U4gF5KqTitdbHW+odq22OBXlprl9Z6rda68ETLIUQVCQziZPUOcAUwkxrNSEAcYAX2Vtu2F0j2rHcG9tfYV6Wb57WHPM03R4F/AQnNKGtn4LDWuqiO8lwH9AG2epqLpni2vwN8CcxVSh1USj2hlLI2oxxCABIYxElKa70XoxN6MrCgxu48jF/b3apt68qxWsUhjOaZ6vuq7AcqgDitdZRnidBapzWjuAeBGKVUeG3l0Vrv0FrPwAg+fwc+VEqFaq0dWus/a60HAKMwmr+uRohmksAgTmbXAWdrrUuqb9RauzDa6R9VSoUrpboBv+VYP8Q84A6lVIpSKhq4r9prDwFfAU8qpSKUUialVE+l1JlNKJfN03EcrJQKxggA3wGPe7YN9pT9XQCl1JVKqXittRs46jmHWyl1llJqkKdprBAj2LmbUA4haiWBQZy0tNa7tNZr6th9O1AC7AZWAv8G3vDsexWjieYX4CeOr3FcDQQBm4EjwIdApyYUrRijk7hqORtjeG13jNrDQuAhrfUSz/HnApuUUsUYHdGXa63LgCTPexdi9KN8i9G8JESzKLlRjxBCiOqkxiCEEMKHBAYhhBA+JDAIIYTwIYFBCCGEjw6X5TEuLk537969rYshhBAdytq1a/O01vGNObbDBYbu3buzZk1dIxCFEELURim1t+GjDNKUJIQQwocEBiGEED4kMAghhPDR4foYhBBN43A4yMzMpLy8vK2LIlpBcHAwKSkpWK0nnmhXAoMQJ7nMzEzCw8Pp3r07Sqm2Lo7wI601+fn5ZGZmkpqaesLnkaYkIU5y5eXlxMbGSlAIAEopYmNjm107lMAgRACQoBA4WuKzDpzAkL0Jlj4CpYfbuiRCCNGuBU5gOLwbVjwJBZltXRIhAk5WVhaXX345PXv2ZPjw4UyePJnt27eTkZGBUop//vOf3mNvu+023nrrLQBmzpxJcnIyFRUVAOTl5VEz80F+fj7p6emkp6eTlJREcnKy93llZWWDZVuzZg133HFHi13rySBwAkNIjPFYmt+25RAiwGitufDCCxk3bhy7du1i7dq1PP7442RnZwOQkJDAs88+W+eXuNls5o033qh1H0BsbCzr1q1j3bp13HTTTdx9993e50FBQQA4nc46Xz9ixAiee+65ZlzhySdwAoM91ngsk6YkIVrTN998g9Vq5aabbvJuGzJkCGPHjgUgPj6e8ePHM2fOnFpff9ddd/H000/X++Vem5kzZ3LTTTcxcuRI/vCHP/Djjz9y+umnM3ToUEaNGsW2bdsAWLZsGVOmTAHg4YcfZtasWYwbN44ePXoEbMDw23BVpdQbGDcnz9FaD6znuFOA7zFuV/ihv8qDvarGIIFBBK4/f7yJzQcLW/ScAzpH8NDUtDr3b9y4keHDh9d7jnvvvZdJkyYxa9as4/Z17dqVMWPG8M477zB16tQmlS0zM5PvvvsOs9lMYWEhK1aswGKxsGTJEh544AHmz59/3Gu2bt3KN998Q1FREX379uXmm29u1pyAjsif8xjeAp4H3q7rAM9NzP+OcXN1/wqJNh4lMAjR7vTo0YORI0fy73//u9b9999/P+effz7nnXdek8576aWXYjabASgoKOCaa65hx44dKKVwOBy1vua8887DZrNhs9lISEggOzublJSUpl1QB+e3wKC1Xq6U6t7AYbcD84FT/FUOL7MVbJHSxyACWn2/7P0lLS2NDz9suDHggQce4JJLLuHMM888bl/v3r1JT09n3rx5TXrv0NBQ7/r//d//cdZZZ7Fw4UIyMjIYN25cra+x2WzedbPZ3OQmrJNBm/UxKKWSgQuBlxpx7I1KqTVKqTW5ubkn/qb2aOljEKKVnX322VRUVPDKK694t61fv54VK1b4HNevXz8GDBjAxx9/XOt5/vjHPzJ79uwTLkdBQQHJyckA3lFPonZt2fn8DHCv1trd0IFa61e01iO01iPi4xt1n4na2WOlxiBEK1NKsXDhQpYsWULPnj1JS0vj/vvvJykp6bhj//jHP5KZWfuQ8rS0NIYNG3bC5fjDH/7A/fffz9ChQwOyFtAUSmvtv5MbTUmf1Nb5rJTaA1RN0YsDSoEbtdaL6jvniBEj9AnfqOfdS6AkF37z7Ym9XogOaMuWLfTv37+tiyFaUW2fuVJqrdZ6RGNe32ZJ9LTW3gxPSqm3MALIIr++qT0Wcrf59S2EEKKj8+dw1feBcUCcUioTeAiwAmitX/bX+9bLHiN9DEII0QB/jkqa0YRjZ/qrHD7sMVBZDM4KsNgaPl4IIQJQ4Mx8hmppMaTWIIQQdQmswCBpMYQQokEBFhgkkZ4QQjQksAKDNCUJ0Sb8mXYb4KyzzuLLL7/02fbMM89w880311mmcePGUTX0ffLkyRw9evS4Yx5++OEGJ9UtWrSIzZs3e58/+OCDLFmypN7XtHeBFRiqmpKkxiBEq/F32m2AGTNmMHfuXJ9tc+fOZcaMxo2B+eyzz4iKimrUsTXVDAyPPPIIEyZMOKFztRcBFhg8NQbpYxCi1bRG2u1LLrmETz/91BtcMjIyOHjwIGPHjuXmm29mxIgRpKWl8dBDD9X6+u7du5OXlwfAo48+Sp8+fRgzZow3NTfAq6++yimnnMKQIUO4+OKLKS0t5bvvvuOjjz7innvuIT09nV27djFz5kxvbqilS5cydOhQBg0axKxZs7w1n+7du/PQQw8xbNgwBg0axNatWxv752wVbTbBrU1YbBAUJk1JInB9fh9kbWjZcyYNgkl/q3N3a6TdjomJ4dRTT+Xzzz/n/PPPZ+7cuVx22WUopXj00UeJiYnB5XIxfvx41q9fz+DBg2s9z9q1a5k7dy7r1q3D6XQybNgwb9kvuugibrjhBgD+9Kc/8frrr3P77bczbdo0pkyZwiWXXOJzrvLycmbOnMnSpUvp06cPV199NS+99BJ33XUXAHFxcfz000+8+OKLzJ49m9dee63ev1FrCqwaAxj9DBIYhGhXGpN2+x//+Adud92p1ao3J1VvRpo3bx7Dhg1j6NChbNq0yafZp6YVK1Zw4YUXYrfbiYiIYNq0ad59GzduZOzYsQwaNIj33nuPTZs21XtN27ZtIzU1lT59+gBwzTXXsHz5cu/+iy66CIDhw4eTkZFR77laW2DVGMBoTpI+BhGo6vll7y+tlXb7/PPP5+677+ann36itLSU4cOHs2fPHmbPns3q1auJjo5m5syZlJeXn9B1zJw5k0WLFjFkyBDeeustli1bdkLnqVKV3rs9pvYOvBqDpMUQolW1VtrtsLAwzjrrLGbNmuWtLRQWFhIaGkpkZCTZ2dl8/vnn9Zb1jDPOYNGiRZSVlVFUVORTlqKiIjp16oTD4eC9997zbg8PD6eoqOi4c/Xt25eMjAx27twJwDvvvFNr0GuPAjAwxEpTkhCtqDXTbs+YMYNffvnFGxiGDBnC0KFD6devH1dccQWjR4+u9/XDhg1j+vTpDBkyhEmTJnHKKcfuIfaXv/yFkSNHMnr0aPr16+fdfvnll/OPf/yDoUOHsmvXLu/24OBg3nzzTS699FIGDRqEyWTy6YBvz/yadtsfmpV2G+CzP8Avc+H+fS1XKCHaMUm7HXiam3Y7MGsMFQXgqv1+r0IIEegCMDBUzWU40rblEEKIdirwAkNItPEo/QxCCFGrwAsMkhZDCCHqFYCBQdJiCCFEfQIwMEiNQQgh6hN4gUFSbwvR6pRSXHnlld7nTqeT+Ph4pkyZ0qTzVE9219hjXC4XQ4cOrfW9br31VtLT0xkwYAAhISGkp6eTnp7eqJnaUHe67o4u8FJiBNnBEiI1BiFaUWhoKBs3bqSsrIyQkBAWL15McnJyq7z3s88+S//+/SksLDxu3wsvvAAY2VinTJnCunXrfPY7nU4slrq/Jj/77LMWLWt7EXg1BvCkxZDhqkK0psmTJ/Ppp58C8P777/vcK+Hw4cNccMEFDB48mNNOO43169cDkJ+fzznnnENaWhrXX3891Sfkvvvuu5x66qmkp6fzm9/8BpfLddx7ZmZm8umnn3L99dc3upzLli1j7NixTJs2jQEDBgBwwQUXMHz4cNLS0nxSe1TVTjIyMujfvz833HADaWlpnHPOOZSVlTXtD9SOBF6NASSRnghYf//x72w93LK5//vF9OPeU+9t8LjLL7+cRx55hClTprB+/XpmzZrlzZf00EMPMXToUBYtWsTXX3/N1Vdfzbp16/jzn//MmDFjePDBB/n00095/fXXAWNm7wcffMCqVauwWq3ccsstvPfee1x99dU+73nXXXfxxBNP1JrLqD4//fQTGzduJDU1FYA33niDmJgYysrKOOWUU7j44ouJjY31ec2OHTt4//33efXVV7nsssuYP3++T/NZRxKYgUFSbwvR6gYPHkxGRgbvv/8+kydP9tm3cuVK5s+fDxhJ9/Lz8yksLGT58uUsWLAAgPPOO4/oaGMe0tKlS1m7dq03l1FZWRkJCQk+5/zkk09ISEhg+PDhTc6Eeuqpp3qDAsBzzz3HwoULAdi/fz87duw4LjCkpqaSnp4OtM9U2k0RmIHBHgtZ69u6FEK0usb8svenadOm8fvf/55ly5aRn3/itXatNddccw2PP/54ncesWrWKjz76iM8++4zy8nIKCwu58soreffddxs8f2hoqHd92bJlLFmyhO+//x673c64ceNqTd1dlUYbjFTaHbkpKXD7GKQpSYhWN2vWLB566CEGDRrks33s2LHeVNbLli0jLi6OiIgIzjjjDO/Nez7//HOOHDH6BsePH8+HH35ITk4OYPRR7N271+ecjz/+OJmZmWRkZDB37lzOPvvsRgWFmgoKCoiOjsZut7N161Z++OGHJp+jownMGkNIDJQdBbcLTOa2Lo0QASMlJYU77rjjuO0PP/wws2bNYvDgwdjtdu/9nx966CFmzJhBWloao0aNomvXrgAMGDCAv/71r5xzzjm43W6sVisvvPAC3bp1a/Eyn3vuubz88sv079+fvn37ctppp7X4e7Q3fku7rZR6A5gC5GitB9ay/9fAvYACioCbtda/NHTeZqfdBvjhZfjiXrhnN4TGNny8EB2YpN0OPO057fZbwLn17N8DnKm1HgT8BXilnmNblqTFEEKIOvktMGitlwN1fvNqrb/TWldNJvgBSPFXWY5TFRikn0EIIY7TXjqfrwPqvBmrUupGpdQapdSa3Nzc5r+bpMUQQog6tXlgUEqdhREY6hxHp7V+RWs9Qms9Ij4+vvlvKon0hBCiTm06KkkpNRh4DZiktW69b2npYxBCiDq1WY1BKdUVWABcpbXe3qpvHhQG5iCpMQghRC38FhiUUu8D3wN9lVKZSqnrlFI3KaVu8hzyIBALvKiUWqeUauYY1CYVTtJiCNGK2mva7Tlz5vgk8wPIy8sjPj6eioqKWs//1ltvcdtttwHw8ssv8/bbbx93TEZGBgMHHjdK/7hjqibvAaxZs6bWOR5twW9NSVrrGQ3svx5ofMrDlmaPlQyrQrSS9pp2+8ILL+R3v/sdpaWl2O12AD788EOmTp3qk+KiLjfddFODx9SlKjBcccUVAIwYMYIRIxo1zcDv2rzzuc1IWgwhWlV7TLsdERHBmWeeyccff+zdNnfuXGbMmMHHH3/MyJEjGTp0KBMmTCA7O/u41z/88MPMnj0bgLVr1zJkyBCGDBnivc8DGAFg7NixDBs2jGHDhvHdd98BcN9997FixQrS09N5+umnWbZsmbdWU9ffo2qG+Lhx4+jRowfPPfdcI/7yTReYKTEAQqIhd1tbl0KIVpX12GNUbGnZtNu2/v1IeuCBBo9rr2m3Z8yYwXvvvcf06dM5ePAg27dv5+yzz6awsJAffvgBpRSvvfYaTzzxBE8++WSd57n22mt5/vnnOeOMM7jnnnu82xMSEli8eDHBwcHs2LGDGTNmsGbNGv72t78xe/ZsPvnkEwCfDLB1/T0Atm7dyjfffENRURF9+/bl5ptvxmq1Nvj3b4rADQz2WKkxCNGK2mva7fPOO49bbrmFwsJC5s2bx8UXX4zZbCYzM5Pp06dz6NAhKisrfdJw13T06FGOHj3KGWecAcBVV13F558bU7McDge33XYb69atw2w2s317w2Nt6vp7VJXXZrNhs9lISEggOzublJSWnR8cwIHBcxc3txtMgduiJgJLY37Z+1N7TLsdEhLCueeey8KFC5k7dy5PPfUUALfffju//e1vmTZtGsuWLePhhx8+obI+/fTTJCYm8ssvv+B2uwkODj6h81Spmd7b6XQ263y1CdxvRHssaBdUFLR1SYQIGO017faMGTN46qmnyM7O5vTTTweMdNtVHeRV2V7rEhUVRVRUFCtXrgTwXkvVeTp16oTJZOKdd97x9oWEh4fX2cRV19+jtQRuYJC0GEK0uvrSbq9du5bBgwdz3333+aTdXr58OWlpaSxYsKDWtNuDBw9m4sSJHDp06ITLNXHiRA4ePMj06dNRSnnLdOmllzJ8+HDi4uIaPMebb77JrbfeSnp6uk8n+S233MKcOXMYMmQIW7du9d4EaPDgwZjNZoYMGcLTTz/dqL9Ha/Fb2m1/aZG02wDbv4J/XwrXLYEupzT/fEK0U5J2O/C057Tb7ZukxRBCiFpJYJCRSUII4SNwA4P0MYgA0tGajMWJa4nPOnADQ3AkKLM0JYmTXnBwMPn5+RIcAoDWmvz8/GYPiQ3ceQxKSVoMERBSUlLIzMykRW5yJdq94ODgZk94C9zAAJJhVQQEq9Va76xdIWoK3KYk8KTFkMAghBDVBXhgiJE+BiGEqEECg/QxCCGEj8AODFV9DDJaQwghvAI7MNhjwe2AirpztQshRKAJ8MAgaTGEEKKmAA8Mscaj9DMIIYRXYAcGb1qMI21bDiGEaEcCOzBU1RikKUkIIbwCPDBIhlUhhKgpsANDcCSgZPazEEJUE9iBwWSGkGipMQghRDWBHRhA0mIIIUQNfgsMSqk3lFI5SqmNdexXSqnnlFI7lVLrlVLD/FWWetljpcYghBDV+LPG8BZwbj37JwG9PcuNwEt+LEvdQmJkuKoQQlTjt8CgtV4O1NdGcz7wtjb8AEQppTr5qzx1khqDEEL4aMs+hmRgf7XnmZ5tx1FK3aiUWqOUWtPid6GyRxt9DJJITwghgA7S+ay1fkVrPUJrPSI+Pr5lT26PBWc5OEpb9rxCCNFBtWVgOAB0qfY8xbOtdXnTYsjIJCGEgLYNDB8BV3tGJ50GFGitD7V6KSSRnhBC+LD468RKqfeBcUCcUioTeAiwAmitXwY+AyYDO4FS4Fp/laVeknpbCCF8+C0waK1nNLBfA7f66/1rOlh8kEU7F3Hj4BuxmKpdtjQlCSGEjw7R+dwStuRv4aVfXmJ55nLfHd6mJAkMQggBARQYzuxyJon2RD7Y9oHvjpBo41GakoQQAgigwGAxWbi0z6V8d/A7Mgoyju0wW4wsq9L5LIQQQAAFBoCL+1yMRVmYt32e746QGGlKEkIIj4AKDHEhcUzoNoFFOxdR5iw7tkPSYgghhFdABQaA6X2nU1RZxBd7vji2UVJvCyGEV8AFhuGJw+kV1Yv3t76PrsqPZI+VpiQhhPAIuMCglGJ63+lsObyFjXmeW0VIH4MQQngFXGAAmNJjCnaLnbnb5hob7DHgKAFHedsWTAgh2oFGBQalVKhSyuRZ76OUmqaUsvq3aP4TFhTG1J5T+WLPFxwtPyppMYQQoprG1hiWA8FKqWTgK+AqjDu0dVjT+06n0l3Jop2LJC2GEEJU09jAoLTWpcBFwIta60uBNP8Vy/96R/dmeOJwPtj2Ae6q2c8yZFUIIRofGJRSpwO/Bj71bDP7p0it5/K+l5NZnMmqUs+N5KQpSQghGh0Y7gLuBxZqrTcppXoA3/itVK1kfNfxxAbH8sGBb40NUmMQQojGpd3WWn8LfAvg6YTO01rf4c+CtQar2crFfS7m1fWvcsBiJrn0SFsXSQgh2lxjRyX9WykVoZQKBTYCm5VS9/i3aK3j0j6XopTiP1ExUmMQQgga35Q0QGtdCFwAfA6kYoxM6vCSQpMYlzKOBaEhVJbmtXVxhBCizTU2MFg98xYuAD7SWjsA7bdStbLp/aZzxARflext66IIIUSba2xg+BeQAYQCy5VS3YBCfxWqtZ3W6TS6YeUDl9QYhBCiUYFBa/2c1jpZaz1ZG/YCZ/m5bK3GpExMD+rMOpOTrYe3tnVxhBCiTTW28zlSKfWUUmqNZ3kSo/Zw0pgW0Ydgt2bu1rltXRQhhGhTjW1KegMoAi7zLIXAm/4qVFuIDE1kckkJn+3+lMLKk6aVTAghmqyxgaGn1vohrfVuz/JnoIc/C9bq7DFMLyyizFXOx7s+buvSCCFEm2lsYChTSo2peqKUGg2U1XN8x2OPYUClg8GRvZm7de6xm/gIIUSAaWxguAl4QSmVoZTKAJ4HfuO3UrUFeywA05NGkVGYwY9ZP7ZxgYQQom00dlTSL1rrIcBgYLDWeihwtl9L1sK+25nH+S+soqDMUfsBntTbvwpLJdIWyQfbPmjF0gkhRPvRpDu4aa0LPTOgAX7b0PFKqXOVUtuUUjuVUvfVsr+rUuobpdTPSqn1SqnJTSlPUwQHmfll/1G+2ZpT+wGeGoOtvJCLel3E1/u+Jrsk21/FEUKIdqs5t/ZU9e5Uygy8AEwCBgAzlFIDahz2J2CepwZyOfBiM8pTr/SUKBLCbXy5Kav2A6rdxe3Svpfi1m7m75jvr+IIIUS71ZzA0FDv7KnATs8opkpgLnB+LeeI8KxHAgebUZ566eIifndgGcu3ZFHucB1/gDUErHYoPUyX8C6MSR7Dh9s/xOGuo+lJCCFOUvUGBqVUkVKqsJalCOjcwLmTgf3Vnmd6tlX3MHClUioT+Ay4vY5y3Fg1uS43N7eBt61d8bfLGfz1fG5c/QErt9dxjpAY7+09L+93OblluXy97+sTej8hhOio6g0MWutwrXVELUu41rpR93JowAzgLa11CjAZeMdzv4ea5XhFaz1Caz0iPj7+hN4ocuoUom+6mXP2rSb/madrP8h+LPX26M6jSQ5L5vUNr1PqKD2h9xRCiI6oOU1JDTkAdKn2PMWzrbrrgHkAWuvvgWAgzl8FSrzzdjYPH8/gFR+R+0YtE7ftMd7be5pNZn47/LdsO7KN3yz+jcyGFkIEDH8GhtVAb6VUqlIqCKNz+aMax+wDxgMopfpjBIYTaytqBKUU9nvuY2XnQeQ98QQFH9UoTojvzXrO6X4OT575JBvzN3Ldl9eRXyY38hFCnPz8Fhi01k7gNuBLYAvG6KNNSqlHlFLTPIf9DrhBKfUL8D4wU/t5yvEZ/ZN4euRVZPccyMEH/kjx8uXHdtpjvX0MVSZ0m8DzZz9PRkEGM7+YSVZJHaOahBDiJOHPGgNa68+01n201j211o96tj2otf7Is75Zaz1aaz1Ea52utf7Kn+UBCLVZGNUvib+MnImtd28y77iT0p9/NnbaY6C8AFxOn9eMTh7Nvyb+i7yyPK7+/Gr2Fe7zdzGFEKLN+DUwtFfnpCWxqxRKH5mNJSGB/TfdTMXOnZ5JbhrKjx73mmGJw3j9V69T7iznmi+uYfuR7a1ebiGEaA0BGRgm9E/EpODLQw66vv4aKsjKvutvwFFiNg6o0ZxUZUDsAN469y1MmLj2i2vZkLuhFUsthBCtIyADQ0xoEKemxvDlpiyCunSh66uv4i4uZt9j7+KsUD4d0DX1iOrBnElziAiK4Pqvrmd11upWLLkQQvhfQAYGgHMGJLE9u5g9eSUE9+tHl5dexJF9mP3LY3EfOVTva1PCU5gzaQ6dQjtx85KbWZ65vN7jhRCiIwncwJCWCMBXntxJ9lNOIfnRByg/bCXzsdfQlZX1vj7BnsCb575Jz6ie3Pn1nXyx5wu/l1kIIVpDwAaGlGg7A5MjfJLqhf9qCp1GFFCyfg8HH/gj2u2u9xzRwdG8fs7rDI4fzB+W/4H52yXpnhCi4wvYwADwqwFJ/LTvKDmF5caGoFCi+jiJnzKQwk8+Iefvf2/wTm5hQWG8PPFlRiWP4uHvH2bOpjmtUHIhhPCfwA4MA5MA+Gqz574LSoE9ltgx8URffRWH57xN/quvNXieEEsI/zzrn0zsNpHZa2bzwIoHOFBcM/uHEEJ0DAEdGHonhNE91n4sMACExKDKjpB4331ETJlC7lNPcXThogbPZTVbeeKMJ7hu4HV8mfElUxZO4a8//JXcUr9l+BBCCL8I6MCglOJXaUl8vyuPwnLPfRfsRuptZTLR+bFHCR11Oof+9CeKV6xo8HwWk4W7ht/Fpxd9yoW9LmT+9vlMXjCZp9Y8xdFaJs0JIUR7FNCBAYxZ0A6XPnbLz2oZVlVQEMnPPYetTx8y77yLsg2Nm9CWFJrEg6c/yEcXfMSEbhN4a9NbnLvgXF5a9xLFlcX+uhQhhGgRAR8YhnapcctPe6zPBDdzWBhdX/kXluho9v/mJir3NT5PUpeILjw+9nEWTFvA6Z1O58VfXmTSgkm8ufFNypxlLX0pQgjRIgI+MJhMiokDElm2Lde45WdIDJQdgWpDVS3x8XR59VVwu9l3/Q0485uWfrtXdC+ePutp5p43l7TYNJ5a+xTnLTiP97e+j8Mltw4VQrQvAR8YwGhOKq10sWpnnlFj0O7jEunZeqTS5eWXcObksP83N+EuKWny+6TFpfHyxJd581dv0iW8C4/97zGmLprKwh0LpYlJCNFuSGAATu8RS3iwxWhOsscYG8uOHHdcSHo6yU89RfnmzWTefTfacWK/9kckjeCtc9/ipQkvEWmL5MHvHmTs3LHM/GImr214jc35m3Hr+ifXCSGEvyg/3xenxY0YMUKvWbOmxc9759yfWbEjj9WXuTG/fxlctxi6nFrrsUf+8x+y/u9BIi+8kE6PPYpS6oTfV2vN2uy1rDq4ilUHVrHl8BYAYoJjGN15NKOSRzGq8yhigmNO+D2EEEIptVZrPaIxx1r8XZiO4ldpSfx33UE2F4QwCOpMvQ0QfemlOLNzyHv+eSyJCSTcddcJv69SihFJIxiRNII7h91JXlke3x38jlUHVrHiwAo+3v0xCsWA2AGMTh7NmOQxDIobhMUkH50Qwj/k28XjzD7xBFlMfLPP4QkM9Xcwx916C87sbPJf/hfWxESiZ8xokXLEhcQxrec0pvWchsvtYsvhLaw8sJLvDn7Haxte45X1rxBuDWdE0ggGxw9mcNxg0uLSCLWGtsj7CyGEBAaPUJuFsb3i+GRHFneAdy5DXZRSJD30IM68PLIe+QvmuDgiJk5s0TKZTWYGxg1kYNxAbhpyEwUVBfzv0P9YdXAVa7PX8s3+bwAwKRM9o3oyOG4wg+IGMTh+MD0ie2A2mVu0PEKIwCB9DNXMW72fP8z/hT0h16BG3w4THm7wNe6yMvbNvJbyrVvp+uYb2IcN80vZanO0/Cgb8jawIW8D6/PWsyF3A4WVhQDYLXYGxg1kUNwgBsUPYnDcYOLt8a1WNiFE+yJ9DCdofP8ETEpRaokgtJ4+hupMISGkvPwSe2dcwf6bb6H7e+9i69XLzyU1RAVHMTZlLGNTxgJGR/bewr1GoMhdz4a8DczZNAendgLGjOy02DQGxg0kLTaNtLg0IoIiWqWsQoiOQwJDNbFhNk7pHkNediihDTQlVWeJjqbLa6+SMWMG+264kbibb0KXleEqKcFdUoK7tLT2x5JS3MWFUFlK2FnjibpsBvaRI1HmE2sCUkrRPbI73SO7M7XnVAAqXBVsyd/C+tz1bMzfyKa8TSzdt9T7mm4R3bzBYmDcQPrF9CPEEnJC7y+EODlIU1INb6zcQ9pXlzMkJYrgG79s0mvLN29m7zUzcRcVebcpmw2T3Y4pNPTYY9W63Y5p72LcR3Moyo7BXVqBJSmJyPPPJ/KC87Glprb05QFQUFHApvxNbMrbxMa8jWzM30hOqZEryqzM9Izq6a1VdIvoRkp4Con2RBkJJUQH1pSmJAkMNew/XMqmp6dxasRhYu75qcmvdxUX4y4q8n7xK6u17oN/fg/+ewuYrLi7n01x/LUcXbSIkhUrwe0mJD2dyAsuIGLyJMwR/m3yyS3NZWPeRjblb/LWLI5WHPXutygLncI6kRKWQkq4ZwlLITk8mZSwFCJtkX4tnxCieSQwNNMXj1/GSMePRD+Y4b83KTsKz4+AmB6QMADWz4N7M8AShCMnh8KPP6Fg0UIqduxEBQURPmE8kRdeSOioUSfc1NQUWmuySrLYX7SfzOJMMos8i2f9SIXvzPDwoHBSwlLoHNaZmOAYooOjiQmOITY41rseHRxNlC1Kah5CtAHpfG6muPhOhO0vJKewjIQIP7W3L3vcmCtx5XwoyIS1b8L+HyD1DKwJCcReN4uYWddSvnETBYsWUfjJJxR+9jmW+Hgiz59GxNRp2Pr0btas6/oopegU1olOYZ04leNngBdXFnOg+IA3WFQFkIyCDH7O+ZmjFUdrTeuhUETaIokJjvEGi5TwFHpH9aZXVC9SI1MJtgT75ZqEEI3j18CglDoXeBYwA69prf9WyzGXAQ8DGvhFa32FP8vUGF27dMGa6WLZ+l1cNmZgy79B1kb48RUYMQs6DYHoVDBZYOdSSD3De5hSipBBAwkZNJCEe/9A8bJlFCxcRP6bb5H/2utYu3YlfPx4wieMJyQ9vVVqElXCgsLoG9OXvjF9a93vcrsoqCzgSPkRDpcf9lmqb9txZAfL9i/D4TbyTpmUia7hXekV1YueUT3pFd2L3lG96RrRFaupnmY5IUSL8VtTklLKDGwHJgKZwGpghtZ6c7VjegPzgLO11keUUgla65z6ztsaTUn653dR/72V33d+m9k3nt/CJ9fw1nmQswVuX3ssad+b50F5Ady8ssFTOPPyKFqylKKlSyn54QdwODDHxBB21jjCx08gdNTpmII7zq9up9vJvqJ97Dyyk51HjWXHkR3sK9rnrXVYTBZSI1ONgBHZkwR7AlG2KKKDo71LuDXcbzUoITq69tKUdCqwU2u921OoucD5wOZqx9wAvKC1PgLQUFBoLcoeC8CefXspLHcQEdyCv1Q3zoe9q2Dqs8eCAkCvs2HpI1CUBeFJ9Z7CEhdH9OXTib58Oq7iYkqWL6do6dcUffkVBfMXoEJCCBszhrDxZxN25plYoqNbrvx+YDFZ6BHZgx6RPTiHc7zbK1wVZBRksOPoDm/QWJ+7ns/3fF77eZSFqOAoomxRxATH+ASOyKBIQiwh3iXYEuxdt1vsPs9lxrgIdP4MDMnA/mrPM4GRNY7pA6CUWoXR3PSw1vqLmidSSt0I3AjQtWtXvxTWhycwhLuL+GZrDuenJ7fMeSuK4Ks/QeehMPQq3329JhiBYdfXkN741jRzWBgRkycTMXkyurKSkh9XU/z1UiNQLF4MZjP2ESMIH3824ePHY01uoWtpBTazrdbmqjJnGUfKjxhLxZFa149WHGX7ke0crThKQUUBmsbXjK0mKyGWEKJsUcTb40kISSDOHkdCSILx3J5AfIjxaLfaW/qyhWhzbd35bAF6A+OAFGC5UmqQ1vpo9YO01q8Ar4DRlOT3UoUYv+S7hpTx8S+HmDakc8s0UXz7BBQdgunvQs1fpYmDIDTe6GdoQmCoTgUFETZmNGFjRpP4pz9RvmkTRUuXUrx0KdmPPU72Y48TnJZG+MSJhE+cgK1nz+ZfUxsIsYQQEhZC57DOjTre5XZR7CimzFlGqbOUMmcZ5c5yypxlxxaH59F17PnRiqPklOawMX8juftzKXeVH3duu8VuBAp7PHHBcVjNRu1SYfx7UUqhUN7H6tvACEKxIbHEhcQRFxJnrAfHERMSI30qos34MzAcALpUe57i2VZdJvA/rbUD2KOU2o4RKFb7sVwN8zTxjOtiZtaWbH437xceu2gQwdZmNDHkbocfXoShV0JKLc18JhP0PBt2LAa36/jA0UTKZCJk0CBCBg0i4a67qMzIoGjpUoq+WkzuM8+Q+8wzBPXo4QkSEwlOG3DSts+bTWYibZHNmmuhtabYUUxuaS45ZTnkluaSW5ZrPC/NIa8sj035m3C6nd7aiUajtTaea89zz7aq/ZWuSoodtd+9L9oWTWxI7LHAEWwEjwhbBMHmYJ8msWBLMMHmYJ/nQaagk/YzFf7lz85nC0bn83iMgLAauEJrvanaMedidEhfo5SKA34G0rXWdea8bo3OZ9xu+EssesxveZ7LeXLxdgYlR/Kvq4bTOeoEhq9qDe9cAAd/htt/gtC42o9bPw8W3AA3fA3Jw5t1CfVxZGdTtGQJRYuXULp6NbhcWDp3IsITJEKGDm3VEU6BrsJVQX5ZPnlled6l6nl+ue/2CldFo89rUiZvsAgPCifcGm48epYIWwQRQRG1bg+1hGI2mTEr87FHz2JSJkzKJEGng2kXnc9aa6dS6jbgS4z+gze01puUUo8Aa7TWH3n2naOU2gy4gHvqCwqtxmSCkGhU2WFun9Kb/p0iuPuDdUz950pe/PUwRvaIbdr5tnwMu5fBpH/UHRQAepxlPO70b2CwJiYS8+tfE/PrX+M8coTib5ZRtHgxR96fy+E5b2OOjSX87LMJnzCe4MGD233ndUdnM9voHNa5waYxrTUljhKKHcWUOkspd5Z7lzJX2bHnrnJvc1m5s5xSZynFjmKKKosorCwkqzSLosoiiiqLmhRoavIGC5MRLKwmKzazzaitmIMINgdjM9uwWWzYTMajd5tne/UBACFWz6Pl2GOIJQS71Vi3mqwSjFqJzHyuyz9HQGIaXDYHgJ05xdz4zhr25Zfy4NQBXHVat8b9I60shRdOheBIuPFbMDcQi/91JliC4bqm5WlqCa7iEkpWLKdo8WKKl32Lu7QUAHNcHMF9emPr3QdbH8/SqyemEEm219FVuCq8AaMqWBRWFFLiLMHlduHSLlxuF27tNtZ1Lds8xzncDipcFVQ4Kyh3lVPpqqTcVX7882rHNIVZmQm2BGMxWbAoC2aTGavJilmZsZiM5xZlMfabLD7brcrqrfkct7/GNrPJTJApyBvgbGab97HmevXndosdu9WOSZn88lm53C7cuE+476ld1Bg6PHusz13ceiWEsejW0dw9dx0P/ncTGw8U8JcLBmKzNNDksvIpKNgPF73ScFAA6DUeVj5jzGkIbt38Q+awUCImTSJi0iTcFRWUrV1L+bbtVGw3liNz56IrPL8wlcLatQvBffpUCxi9jVFPLhfa6US7XGiHw3hefd3pRDtd4HSgXS7M0dEEdelSf14p4Rc2sw1biI24kHpqsn6itabCVeEdEFA1AMD73LOUOnyfO91OXNrlfXS4HbjcLp/tTu3E6XZS7iw/tt2zrXogq1r3eW21fqITUVXjsVvt2C12Qq2hhFhDCLWE+mwzKdPxAyFcx/4OVTW/qmMqXBVcP+h67hx2Zwt+CrWTwFAXewwc3eezKSLYyqtXj+CZJdt57uudbM8u5uUrh5MUWcdksvxdsOpZGHQZdBvVuPftNQFWPAm7v4UB05p5ESfOZLMROmoUoaOOlVu7XFTu20fF9h1U7NjhDRhFS782+mWaw2IhKCWFoNRUglJTsfVI9a6bo6MbVTtzV1TgOHjQZ3EePIjjwEHclZUE9+1LcFoawWkDsPXpg8lma16ZRbMopYxO83aWAkVrjVM7qXRVUuGq8D7WtV7pqvQJYiWOEkqdpZQ6jfUyRxkF5QUcch46ts9Rilu7febPhFhCjEEF1hDi7fHeAQbVl2GJrXMjMGlKqst/bzWGjv5ua627v9iYxe/mrcNus/DylcMY3i3m+IP+PR0yVhoznBuYtOblcsDfU2HgRTDtuWZcQOtxl5dTsXMXFdu348zJQVktYDajLFaUxYyyWMBsQVksKIsZLBaU2bNuNuPMzaVyTwaVe/YYS0aGUbvwMEVGYks9FiiCUpJxHjlyXBBw5eb5FsxkwpKUiLVzZ5TFSvmWLbgLCox9Fgu23r0JHtCf4LQ0QtLSsPXt26FmjIuOq+p7tzX7TKQpqSWExEDpYWNEUS0f3rkDk+gRP5ob317D5a/8wCPnD2TGqdUm3237ArZ/Aef8tfFBAcBshR5nGhPd6njv9sYUHEzIwDRCBqa1yPm0y4Xj4EFvoKjYs4fK3XsoWbmSgoULvcepoCCsnTphTe6M7cwzsXbujLVzZ4KSk7F27owlMdEISlXn1RrHgYOUb9rkXYqXfk3B/AXGAWYztp49jVrFgAHYevbAkpSEJSERc1hoi1xbde7SUtwVFZijoqRTNcC0989bagx1Wfk0LHkY7j8AtrA6DysodXDH3J/5dnsuV4zsysNT0wjSlfDiaWAOgptXGV/2TbHmDfjkbrj1R4ivPUldoHIVF+M4cBBLTDTm2FiUqXkdfVprnIcOUbZpE+WbN3sCxmZc+b6D40xhYUbtIzHJ9zEpCUtiEtakREwREejKSlx5eTjz8nDm5+PMzcOZl4uraj0/H2deHq68PG/nvslux9q1K0FduxLUtcux9S5dsCQlydBh0SKkxtASPGkxKDtcb2CItFt5Y+YpzP5qGy8t28X2rCJeT/2GyCN74KpFTQ8KAD3HG487l0pgqMEcFoa5b58WO59SylvTiJg4EfAEi5wcHPv24cjKxpmd5fNYsWMHztxco0ZX/VxWq08TmE+5IyMxx8dhiYsnZNAgLHFxmONiMQUFUZl5AMe+fVTs3EnxN9/4nENZrVhTUrB27UJQ125GsEhIwBQehjk8HFNYOObwMEzh4Sibrd3/EhUdgwSGunjSYlCaD1H152cymxT3ntuPtM4RPP2fpQRlPcOa0DMocw9ktFtjMjXxP2t0N4jtDbuWwum3nOAFiBOllMKamIg1MbHOY7TDgTMvD0dWFs7sbBxZWbjy8jCFhWOJj8McG4slLh5LXCyWmBhUUFCj3lu7XDizs6nct4/Kfftw7N9P5d59VO7fT9nqNd5aRq2sVsyhoZjCw43AERaOKTwcc3i4UY6EBCwJiZ7HBCwJ8ZgaWS5/0C6X1IbaKQkMdamqMZQebvRLpvSNYEKvhZj3mniofAabXv+RHnGhXHV6Ny4entK0LK29xsPat8BRBlaZL9DeKKvV6N/o1Kllz2s2e2swoaed5rNPa43r8GGcefm4i4twFRXhLir2rBu3lHUVe7YVFRnNbvv3U15UhCsvr9bajDkqyggSiYlYEuKxJCRgTUjAHBdn1EhCwzCFhXpqJ2GNrpXoykocOblGLetQ1nGPjuwsXHn5mOx2LElJRpNcVRNdJ8/zxESsnToZ71vHe7rLy3Hm5hpLTu6x9WqLrqw8do/16vde996D3e57H3bPugoJObYtJAQVHBwwNTIJDHWpSondmMDgcsBPb8OyvxFckgO/epwFp0znsw2HmPPdXv788Wb+8eU2LhyazNWnd6dvUnjD5+w5Hv73Muz9zggSIuAppbDExmKJbeLMezxB5ehRnDk5PosjO9v4Qs3JoWLbNpx5efUPPbZYjFpJWFi1JRRzWDi6ssLnS79mU5u3nyapE7Z+fbEmJOAqKsaZlYUjO9sY1ZaXd/zrvMEjEVNkJK7DR7xf+u6iouPLaDZjiYvDEh9vjEiz2XCXleIuKcGRk40uKcVVWoIuKa2/BlaTUkaAqBYsTJ7goYKDjXK73Wi32/gbajfaZaxr7Qa3NubxeI4zhYRgTU42mgpTkglKScGakoIlIaHZfWfNJYGhLtX7GOqiNWz91Oikzt8BXU+Hy/8NXU7BBlw4NIULh6awPvMob3+/l/+szeS9/+1jZGoM14zqzsQBiVjNdfwD6D4azDajn0ECg2gmpRSW6GgjvUnfuvuttMuFMz8fV14eruJi3MUluEuKcRcXH3te7KmleNZdeflUZmSgLFasSUnGl35iEtZOno75TklYkpIwh9XdV+d9f4cDZ26u0USXZfTpOLIO4czKxpGdhePAQcwxMdh69SL09NOxxMcbS0K8d90cHd3oL1btdqPLyowRYqVG8HCXlOAuK8Nd6tleZuzTPtvKPNs8rzt8GEwKpUxGSh2TQpnMYDJySimTGawmn/3u4hJKvvsOZ47vbWiU1WrUGlNSvIEjKMXz2K0b5kj/T3yVwFCX4Cjjsa4aw77/weL/g/3/g7g+cPn70HdSrcNLB6dEMfvSKB6Y3J95a/bzzvd7ueW9n0iKCObXI7ty+aldiQ+vMdkqKBS6nW70M4jmqSg2Zp8n9G/rkrR7ymzG6mlOapP3r/pS7Ny4lOrNfj+TCRUaiim05YcjN5Z3YmbmARwHMnFkZhoDEjIzKd+0CdfRo95jY669lsR7/+D3MklgqIvZYgSH0ho5/fJ2GDWErZ9AWKJxJ7b0KxuV7iImNIibzuzJDWN78PXWHN7+PoMnF2/n2aU7GNUrjkkDkzhnQCKxYZ4g0WuCcWOfgkyITGnxSwwYn/4WNi2EuzZCeN0dykK0BZPNhi01FVtqaq37XcUlRsA4cKDVAqYEhvrYY441JRXnwLK/GR3C1hA4649w+q3GL/smMpsUEwckMnFAIrtyi5m3ej+fb8zi/gUb+OPCDZyaGsPkQZ2YnDSGODCak4Zf05JXFjhythrpzNHw89twxj1tXSIhmsQcFoq5b1+C62kCbGkywa0+r00A5bmBzqrnwFUBw6+FM++FsPgWfSutNZsPFfLFxiw+23CIXbklKKVZE3IHBXFDCZrxDinRchvJJpt3DexcAvH9jPtp37W+2TdBEqIjkgluLSUkBnZ8afQjDDgfxj8Esf65HaZSirTOkaR1juR35/RlR3YRn2/MYs3/hnF69iqG/n0JaSkxnDswiUkDO5Ea13Ztoh3GofWweRGc8QdIGgTzroLtX0K/yW1dMiHaNQkM9an6AjnjHuhySqu+de/EcHonhkPiFfDhYv5xupM5++GJL7bxxBfb6JcUzjkDEpk4IImByREBM766SZY9bqQuP/1WCAqD8E6w5nUJDEI0QAJDfYbPNJa21GMcKBMXRWzlotsu4sDRMr7YmMWXm7J4/pudPPf1TjpFBnv7LEamxhJkadsx0O3CgbWw7TM4608QEmVsG3YNfPt3OLwHYmrv6BNCSB9Dx/DaBNBu417Q1RwuqWTplmwWb85m+Y5cyh1uwoMtnNU3gYkDEhnXN57wpsy2Ppm8ezEc+MnoU7B5JhQWHoSnB8Ko22DiI21bPiFamfQxnGx6jjd+6ZYePjYjG2P466UjunDpiC6UVbpYuTOPxZuzWLolh49+OYjVrDitRyznpCUxsX9i3TcUOtns+8HocJ74yLGgABDR2WhG+ukdGPcAWAPk7yFEE0mNoSPYvxpenwCXvAEDL27wcJdb89O+IyzebNQm9uSVAJASHUKP+DB6xIXSMz7UWI8PJSniJMsB89YUyN0Gd/4CQTVGcu36Bt65AC58BYZMb5PiCdEWpMZwskkeZky227m0UYHBbFKc0j2GU7rHcP+kfuzKLWbx5hy2HCpkd14xazMOU1Lp8h5vDzKTGhfqDRo94kPpGR9GalwoobYO9k9k97eQsQLO/dvxQQEg9UyI6Wl0QktgEKJWHex/fYAymaHnWUZgaOJd3ZRS9EoIp1fCsSYVrTXZhRXszi1mV14Ju3OL2Z1bwrr9R/hk/UGfHGYp0SH0TQynT1I4fRPD6ZsUTo/4UGyWdjgXQGv45lEI72zMN6mNyQQjZsFXf4SsDcYwViGEDwkMHUXP8UZah+xNkDSwWadSSpEUGUxSZDCjesX57Ct3uNibX2oEjdxitmUXsz2riG+35+J0GxHDbFKkxoUaASMxnL5JYfRJDKdbbCjmpt57oiXtXGrMOTnvqfr7D9KvgK//Aqtfh6nPtFrxhOgoJDB0FD3PNh53LW12YKhPsNVM36Tw41KDVzrdZOSXsC2ryFiyi9h4sIDPNh7y1jBsFhO9Eowg0SshjN6e9S4xdv8HDK3hm78aN1UaelX9x9pjjCa59fOMDurgCP+WTYgORgJDRxGZDAkDjF/Fo+9s9bcPspjo46khTB1ybHtppZOdOcU+AeOH3fks/PmA9xibxUTP+DB6Jx4LGn0Sw+nakgFj2+dw8GeY9jxYGnFXshHXwbr3YP0HcOoNLVMGEZjcLiPRZVTXJjXztmcSGDqSnmfDj69AZckJJe/zB3uQhcEpUQxOifLZXlTuYEdOMTuzi9meXcSOnGJW7znMf9cd9B4T5AkYPeNDPZ3eRod3anxo0+5253YbfQsxPWDIjMa9JnkYdBoCa96AU64/af5Di1aitTFPZsN/YNMCKM6GyK7Qf6qxdDm1Q+fk8mtgUEqdCzwLmIHXtNZ/q+O4i4EPgVO01gE2FrUJek2A75+HjJXQ51dtXZp6hQdbGdY1mmFdo322F5U72JlTbASNHCNorM8s4LMNh3BX6/SOC7PRIy7UM1rq2GPXmNDjZ3Zv+S9kb4SLXm1U+nPACAQjroOP7zDmPXQ7vZlXLAJC7nYjGGz4DxzZA+Yg6H0OdBsFe5bD6lfhhxcgNAH6nWcEidQzwNyxJpr6bR6DUsoMbAcmApnAamCG1npzjePCgU+BIOC2hgJDQM5jqOIoh793h2FXweR/tHVpWlSF08W+/FJ255WwxzNSao9nPa+40nucSUFKtJ34cBsxoUHE2c38btdMzCYTy8YvIibMTmxoEDGeJdhaz6+2yhJ4sj/0ngiXvN4KVyk6pIIDsHG+EQyy1gPK+LIfdKnxxV+VcgWgvBB2LobNH8GOxeAoMfJ19Z1sHNvz7Da7h3t7mcdwKrBTa73bU6i5wPnA5hrH/QX4OyCJ8htiDYbUsUY/w0nGZjEfSxxYQ0Gpgz35JezJM4bVZuSXkldUwb78UpIyFhPnzuCWyjv4bN7G414bGmQmJiyIhPBgusXY6R4XSrdYO6lxoXSPCyUifYYxOqn4by2eSl10YKWHYfN/YcOHsHcVoKHzMPjV45B2IUR0qv11wRHGwIaBF4OjzJhQueVjI2/XL++DNRR6T4D+04xav+34f+/tgT8DQzKwv9rzTGBk9QOUUsOALlrrT5VSdQYGpdSNwI0AXbt29UNRO5Ce42HHVwGVCC7SbiXdHkV6lyjfHS4nvHAn2prGY1f/kd+XOjlcUkl+SSWHPUt+cSWHSyrIKizn+935LKjWKQ4w3N6P+W4Hn8x5gt39bvQGjW6xoUSGdKzqv2gBxTnw2T3GvdzdDojtDePuh0GXND3lvjXESMHSbzK4HEYT8JaPYMsnRtAJ7wxXLWiXt5xts85npZQJeAqY2dCxWutXgFfAaEryb8nauV7jjcddSyHm+rYtS1v75X04vBt1+ftEhQYTFQo9GvjRXzVPIyO/hIy8EjLyu7Jp62CG5S7ijv1n4OZY/0WI1UxEiIWIYCsRIVYigi1EhlStW332RXq2xYQFEdtQE5ZonzJWwoezoLwARv7GaCrqNKRlBiaYrcYk1Z5nweTZxnstuBHeOBd+/WGrp/VviD8DwwGgS7XnKZ5tVcKBgcAyT56eJOAjpdQ06YCuR2wvY1jcts9h+CxjJm8gclbCt08Y1fu+kxr9slrnaWy8Gz68lq1XW8iIHcOePCNo5JdUUlDqoLDcWPKKK9mdV0JBmYPCModPZ3lNYTYLsZ4gERtmIy7M6POIDbURGxZEXJjxGGMPIiLE2vhA4nYbj4H6ufuD2w2rnoav/2qMbLtygV/nCmEyQ48z4bov4Z0L4e1pcNk7RhNTO+HPwLAa6K2USsUICJcDV1Tt1FoXAN5pt0qpZcDvJSg0QCmjjXPVs/DSKDjj98bzDjw07oT8/DYU7IMpTzf/F12/KRCWSNDPb9Ln15PoU0s/R01aa0oqXRSWGUGjoNRBQZnD25SVX1xJfkkF+cWV7D9cyrr9RzlcUomrjmgSZDEREWzUQMI9tZOatZI4UzG/+uk3hFTkU9TrfNyDLiUidQTBQTLq/ISVHjZ+ue9cbPQLTH229dr9o7vDrC+NFPHvT4cL/2U0WbUDfvsXpbV2KqVuA77EGK76htZ6k1LqEWCN1vojf733SW/8Q5A0GJb/A+ZfZ9ypbOzvYNBljR+u2ZE5ymH5k9Bl5LGmteawBMGwq2H5bDiyF6K7NfgSpRRhNgthNgudadwoE7dbU1DmIL+kgrziY/0fheVOisqdRs2kzEFhuZPCMgcHj5Z5123OIt4LepQQdYCV7oGM2fAWto2vscvdiU8Zyyr72VSEd/XWTGJCq9VSwmzEhgYRHSrNXD72/Q8+vBZKcuG8J43hy609nyUsAWZ+Au9fAfOvNwLVyBtbtwy1kLTbHZnbbXRmLZ8N2RsgqhuM/S0MuaJxs387qh9egi/ug2s+NoYNtoSCTHhmEIy+CyY81DLnbCkVRbjfPh91aD1Zk9/gYPxYCg7nELbrU5L3f0JywVoAdgQN4EvzmXzkPJXdJcHe3FY12YPM3uG8VUv1wBETaiMm9Fi/SZOaujoCreH7F2DJQxCRDJfNgc5D27ZMjnLjR97WT+DMe40O7xYOUk0ZriqB4WSgNWz/wmhzP/gTRKTAmLuMnEEn081o3C6j027+dRDfz/il1ZLenwGZq+HuTWCxtey5T1RlCbx7iZEc8LK3of+U4485uh82fmjkfsrZDCYLuud4yvpdRHan8eRXmn1GanlHbJVUcsS7XkG5w11nMYIsJiK9nezHOuGrgkdkiJXo0CDiw20keJZoexCmulKeZK6BpY8YtbOhV0PKiNb5tV52BBbdCts+NZoQz3/Bdx5CW3I54ZM74ed3jdn4k55o0SZiCQyBSmtjtNK3/4D9P0BYEoy+w0hBXdu9CcAYa30kAw7vhvxdxuPh3cZw2OJsY2p/v/OMCTqNaGJpcVobX9Yb5xvZZYuzwRYJVy+E5OEt+147lxjtvRe/3j7aeh1l8O/pxv0lLn6tUffiIGsjbJhnjL8vPABBYcYXYO+J0H0shCfW+dKyShf5JRXewFFY7vR2tHv7Usocnm2efeV1d8RbTIq4MBsJETbiPY+JoRbOynmLQbtfwxUcg9lRjMlZRllUb/L7TCe/5wVU2mLRGtxa49YarfE+NylFlN1qdNyHBjUt/fuBn+A/M42/y8S/wGk3t79UKFobNZlVz0LaRUa/QwvV/iUwBDqtjS+Tb58wHu1xxn2OY3rC4V3HvvgP7zb+k1QXEmOMzIjpASHRsOdbyN1q7EscaASIfpOhU7r//lNpbaS42PAhbFxgdDKbbcaEoIEXG4/+mD3qdsM/h0F4J5j1ecufvymclfDBr43Zsxe8BOmNzAFVxe02JmZtmGeMmS8vMLbH9YHuYzzLWKONu5ncbk1xpZMjJZXkFFWQU1hBblG5sV5UQa7n0V64iwcdzzLEtJv5rrE87LgGDUwx/8B08zKGmnZSqc0scQ9nnutMlruH+Awfrk2YzUKMTzNYkM/M99iwIEKtZpK2v0uX1Y/iDIlj//gXqUgajtmkMJvApBRmk8KkFCaTwqwUJs92hfFoUgpVY5tSVfvwvrbFrHoOFv8f9DgLpr8LtrBmn1ICgzhm7/dGJ/WuarOl7XHGZJ2qABDTw5gsVxUMasrfZczc3PqZURPRbqNttu8kI1B0H9syv2ryd3mCwYeQtx2U2UghMPBio9bSGumxVz0Lix+Em7+HxAH+f7/auBzGL9utn8CUZ2BEHTcdavT5nEYqh4wVRlPc3u+hssjYF9e3WqAY0yKB4jhut5FDaPGDaKudgvH/ILPTRHKLKnC5NSYTKBShhTvovPtDEvcsxFpxhAp7Erk9Lyav16U4IrthUuB0aY6UOjy1mopaJjMaS6XLjcJNPAX8n/Udppp/4GtXOr913MxRWn7UkVIQGWI9LjBVDQSoGawaVdv5+T346HbonG7Mdah2v/cTK6MEBlFTzhZwVhgBIDjyxM9TkgfbvzQCxc6l4CwDW4SR4K/fecZIIWUyggfaeNRuoxbgXa/23O2APSuMYHDoF0BBt9Ew8CIYcAGExrbQH6Cx15cPT/U3RimdN7t13xuMfpQFNxhNZ5OeMCZatTSXE7J+Mf7uGSth3/dQWWzsi+9nBIjUM4zPtLlZfAsPwqJbYPc3RrK5af+E8KT6X+OshO2fG23tO5cY/066jzX6zPpPBWe5MUO5ONsYUVSc7XmeAyU56OJsdHEOqiQPpV1oZSJj8G/J6H8Dbq1wuY0mKpcbXFrjdmvvtqrtRhOWxq3xPlY1a7mrtuN57tY4XG5vwKreHHek1FHnEOUQq5lQm4XwYAuhNjOhQVXrxhJuszCweBWTtt5PiT2FNWNep2tq71rTxjSGBAbROhxlsHuZkT5g+xfGf9IT1XmY0a6fdiFEdG6xIp6QBTcataPfbW2RKnyjud3w31vhl38bNxBqrftuuJxGUM5YfqxG4SgBq91otku7yOijaGrz3YYP4dPfGjWgXz1q9HU1tfmx4IDx9/j5XaMvrC4mK4QlGvmuQhOMmk9YgrGty0jjV3cbcLs1heUOb82mqlZzpLSSo6WVFFe4KKlwUuxZSmo8ljvcnKq28FrQbIqw81n6i9xw4bknVBYJDKL1uV3GSJOczUaNQZmMLwHvumeBGtuUcQOipuah8af9P8LrE2Hs743O++bUsBpLa/jkblj7Jox7AMbd6//3rIvLYdQiNi0y+idK84xO7L6TjMDda0L9o7bKjsCnvzNqPSmnGB2ozf18q/pMMlYYzZ2h8Z5A4AkAwVHtryO5BThdbkoqXFRkriNm4QwqBlxK6NTHT+hcEhiEaA6tYc5U40vIZDF+cfaeCL0mQmJay38BaQ1f3A//ewnG/BbGP9h+vuRcTti70hgEsOVjKDtsNB32O88IEj3O8u1f2vW1MRy0JAfG3Qej7w6MSZetoeCA0Qx3gkNYJTAI0VwuJ2T+aIwK2rkYsjYY28M7G7Ote0+EHuOaX5vQGpY8DKuegdNugV891n6CQk0uhzFKbdNCI0iUFxjX328qpF1g/K1+/JfRoX3Rv9p+0pjwIYFBiJZWlGV0hO74CnYtg4qCY7WJXhOMQJE4sOlf6sv+ZqQ0GXGdkZahvQaFmpyVRv/SpgVGH1NFobF95M3GzPE2uhmNqJsEBiH8yeUwJt3VrE2EJhi/oL0jr1y1jMaqtrjdRoBJv9IYrdNRM6Y6K4wgYY+DlBaedChajAQGIVpT4SGjNpGxElwVxvyLmp3uJtPx25QZorrAyJsCLzuuaHXt5daeQgSGiE7GfbiHXdXWJRGiRXTQuqsQQgh/kcAghBDChwQGIYQQPiQwCCGE8CGBQQghhA8JDEIIIXxIYBBCCOFDAoMQQggfHW7ms1IqF9h7gi+PA/JasDgdTSBffyBfOwT29cu1G7ppreMb86IOFxiaQym1prFTwk9GgXz9gXztENjXL9fe9GuXpiQhhBA+JDAIIYTwEWiB4ZW2LkAbC+TrD+Rrh8C+frn2JgqoPgYhhBANC7QagxBCiAZIYBBCCOEjYAKDUupcpdQ2pdROpdR9bV2e1qSUylBKbVBKrVNKnfS3v1NKvaGUylFKbay2LUYptVgptcPzGN2WZfSXOq79YaXUAc/nv04pNbkty+gvSqkuSqlvlFKblVKblFJ3erYHymdf1/U3+fMPiD4GpZQZ2A5MBDKB1cAMrfXmNi1YK1FKZQAjtNYBMclHKXUGUAy8rbUe6Nn2BHBYa/03zw+DaK31vW1ZTn+o49ofBoq11rPbsmz+ppTqBHTSWv+klAoH1gIXADMJjM++ruu/jCZ+/oFSYzgV2Km13q21rgTmAue3cZmEn2itlwOHa2w+H5jjWZ+D8R/mpFPHtQcErfUhrfVPnvUiYAuQTOB89nVdf5MFSmBIBvZXe57JCf7BOigNfKWUWquUurGtC9NGErXWhzzrWUBiWxamDdymlFrvaWo6KZtSqlNKdQeGAv8jAD/7GtcPTfz8AyUwBLoxWuthwCTgVk9zQ8DSRvvpyd+GesxLQE8gHTgEPNmmpfEzpVQYMB+4S2tdWH1fIHz2tVx/kz//QAkMB4Au1Z6neLYFBK31Ac9jDrAQo2kt0GR72mCr2mJz2rg8rUZrna21dmmt3cCrnMSfv1LKivGl+J7WeoFnc8B89rVd/4l8/oESGFYDvZVSqUqpIOBy4KM2LlOrUEqFejqiUEqFAucAG+t/1UnpI+Aaz/o1wH/bsCytqupL0eNCTtLPXymlgNeBLVrrp6rtCojPvq7rP5HPPyBGJQF4hmg9A5iBN7TWj7ZtiVqHUqoHRi0BwAL8+2S/dqXU+8A4jJTD2cBDwCJgHtAVI237ZVrrk66Tto5rH4fRjKCBDOA31drcTxpKqTHACmAD4PZsfgCjnT0QPvu6rn8GTfz8AyYwCCGEaJxAaUoSQgjRSBIYhBBC+JDAIIQQwocEBiGEED4kMAghhPAhgUEID6WUq1oGynUtmYVXKdW9esZTIdozS1sXQIh2pExrnd7WhRCirUmNQYgGeO5n8YTnnhY/KqV6ebZ3V0p97UlOtlQp1dWzPVEptVAp9YtnGeU5lVkp9aonV/5XSqkQz/F3eHLor1dKzW2jyxTCSwKDEMeE1GhKml5tX4HWehDwPMYMeoB/AnO01oOB94DnPNufA77VWg8BhgGbPNt7Ay9ordOAo8DFnu33AUM957nJP5cmROPJzGchPJRSxVrrsFq2ZwBna613e5KUZWmtY5VSeRg3RnF4th/SWscppXKBFK11RbVzdAcWa617e57fC1i11n9VSn2BcXOdRcAirXWxny9ViHpJjUGIxtF1rDdFRbV1F8f6+M4DXsCoXaxWSknfn2hTEhiEaJzp1R6/96x/h5GpF+DXGAnMAJYCN4NxW1mlVGRdJ1VKmYAuWutvgHuBSOC4WosQrUl+mQhxTIhSal21519orauGrEYrpdZj/Oqf4dl2O/CmUuoeIBe41rP9TuAVpdR1GDWDmzFukFIbM/CuJ3go4Dmt9dEWuh4hToj0MQjRAE8fwwitdV5bl0WI1iBNSUIIIXxIjUEIIYQPqTEIIYTwIYFBCCGEDwkMQgghfEhgEEII4UMCgxBCCB//DwKxRagDGsY4AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.17621469497680664 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "plt.plot(history.history['loss'])\n",
+    "plt.plot(history.history['val_loss'])\n",
+    "plt.plot(history4.history['loss'])\n",
+    "plt.plot(history4.history['val_loss'])\n",
+    "plt.title(\"Model Loss\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Loss')\n",
+    "plt.legend(['CNN Train', 'CNN Validation', 'Model4 Train', 'Model4 Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dependent-northeast",
+   "metadata": {
+    "papermill": {
+     "duration": 1.508922,
+     "end_time": "2021-04-25T15:07:34.681496",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:33.172574",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Accuracy v/s no. of epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "protective-sarah",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:07:37.930621Z",
+     "iopub.status.busy": "2021-04-25T15:07:37.929613Z",
+     "iopub.status.idle": "2021-04-25T15:07:38.097244Z",
+     "shell.execute_reply": "2021-04-25T15:07:38.096468Z"
+    },
+    "papermill": {
+     "duration": 1.656316,
+     "end_time": "2021-04-25T15:07:38.097448",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:36.441132",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAABQdklEQVR4nO3dd3xUVdrA8d+ZkknvhZDQeydSLChVEVFBbMCqC+rqirK2V3ctq6Lrrq5rWVldFStrQ9aCoCgCit2VIr2DARJCSK8zmXbeP+5kSCCBBDJJYJ7vx/nMzL137pybkfvce8pzlNYaIYQQAsDU0gUQQgjRekhQEEII4SdBQQghhJ8EBSGEEH4SFIQQQvhJUBBCCOEnQUGIo1BKdVRKaaWUpQHbTldKfdcc5RIiUCQoiFOGUipTKeVUSiUetvwX34m9YwsVrVHBRYiWJEFBnGp+BaZWv1FK9QPCW644QpxcJCiIU82bwG9rvJ8G/KfmBkqpGKXUf5RSeUqpPUqpPyulTL51ZqXUk0qpfKXUbuDCOj77qlIqRymVrZR6VCllPpECK6XaKqUWKqUKlVI7lVI31Fg3VCm1SilVqpTKVUo97VseqpR6SylVoJQqVkqtVEqlnEg5hAAJCuLU8xMQrZTq5TtZTwHeOmybfwExQGdgBEYQuda37gbgIiADGAxcfthn3wDcQFffNmOB351gmecBWUBb3/f9TSk12rfuWeBZrXU00AWY71s+zXcM7YAE4CbAfoLlEEKCgjglVd8tnAdsAbKrV9QIFPdqrcu01pnAU8A1vk2uBP6ptd6ntS4EHqvx2RRgPHC71rpCa30QeMa3v+OilGoHDAP+pLV2aK3XAq9w6G7HBXRVSiVqrcu11j/VWJ4AdNVae7TWq7XWpcdbDiGqSVAQp6I3gd8A0zms6ghIBKzAnhrL9gBpvtdtgX2HravWwffZHF+VTTHwEpB8AmVtCxRqrcvqKc/1QHdgq6+K6CLf8jeBJcA8pdR+pdQTSinrCZRDCECCgjgFaa33YDQ4jwc+PGx1PsZVdocay9pz6G4iB6NKpua6avuAKiBRax3re0RrrfucQHH3A/FKqai6yqO13qG1nooReP4OvK+UitBau7TWD2utewNnYVR5/RYhTpAEBXGquh4YrbWuqLlQa+3BqJf/q1IqSinVAbiTQ+0O84FblVLpSqk44J4an80BvgCeUkpFK6VMSqkuSqkRjSiXzddIHKqUCsU4+f8APOZb1t9X9rcAlFJXK6WStNZeoNi3D69SapRSqp+vOqwUI9B5G1EOIeokQUGckrTWu7TWq+pZ/QegAtgNfAe8A7zmW/cyRrXMOmANR95p/BYIATYDRcD7QGojilaO0SBc/RiN0YW2I8Zdw0fAQ1rrZb7txwGblFLlGI3OU7TWdqCN77tLMdpNvsaoUhLihCiZZEcIIUQ1uVMQQgjhJ0FBCCGEnwQFIYQQfhIUhBBC+J10GRsTExN1x44dW7oYQghxUlm9enW+1jrpWNuddEGhY8eOrFpVX09DIYQQdVFK7Tn2VlJ9JIQQogYJCkIIIfwkKAghhPCToCCEEMJPgoIQQgg/CQpCCCH8JCgIIYTwO+nGKQjRKnm9ULgb3HbwusHrMZ49rtrvvW7wug69T+wOaae1dOlPjMcFG/4LCd2g3ZCWLo04QRIUhDhe9iLY9RXs+AJ2LIXK/MbvQ5nhN/Oh27lNX75A83ph4/vw1V+hKBNMFhj3OAz5HSjV0qUTx0mCghANpTXkbjoUBPb9D7QHwuKg67nQaQSExRonR5MFTGYwWQ97bzn0QMMH18P838K1i6HtwBY+wAbSGrZ9Bl8+Cgc3QUo/uPJN+OUtWHwXHFgP458Ei62lSyqOw0k3yc7gwYO1pLkQzaaqHH79+lAgKPVN5dymP3QbC93Ph7RBxgn/eJQdgFfOBXcV/G4ZxHU49mda0q/fwvJHIOtniO8Mo+6HPpeCyWRUiX31V/j2KWh3uhEoolJausStjterKXe6qahyY3d6sLs8OFwe7E4vdpfvvW+53eXB7vStd3m4qH9bhnaKP67vVUqt1loPPuZ2EhREkyjeByseh/1rwBxiXCX6n21gCTHeH77MEgadR0L701v6CGrb8L5x5bvne/A4ISQKuowyAkHXcyG6MTNwHkPeNnj1PIhIhuu/gPDj+0cfUNlr4Mu/wK4vIaotjPwTDLwKzNYjt930ESy4GUJjYcpbRtAMEJfHS0WVm/IqNxVVHt+z27+s0unB49VYzQqr2YTFbMJqVlhMJixmRYjZeLaYfMvNJiwmo+pLa9BovBq0PvSsMU7sGvAaG+H0eCl1uCmxuyj1PUp8j1JHjdd2N2UOF95GnnZtFhNhIWbuH9+LKwa3O66/lQQFcUjhr8bVW1IPOG0ahEY33b7txfDd0/DTi8b7ziMBbVz5epyHnmu+rvnsdRmfSx8CZ/0Bel50/FfdTSV3M7xwpnEl3PNCIxC0O8MIYoGy5wf4z0Roexr89mOwhgbuuxojb5tRTbRlIYTFwzn/B0OuB2vY0T93YAO8+xsoz8Vz0T/Z124ivxZUkJlvPH4tqCSrqBKPV6MAk1Jg/IdSyvfsW+5b1t6zj67u7WR7YtjjimO3M4YSdwB/kxNgs5iIDrMS43tEh1qM5xrLwkMshIeYCbWaCQsxE2b1PUJMxjLf8lCLGZNJQeb30G5o3YG4ASQoCONSZ81/YMl9h07MthgYch2cfhNEtTn+fburYOWr8M0TRmAYMMWoSoht5FWMswLWvgM/Pmc0VsZ1hDNuNq5CbZHHX74T8f51sH0J3L6hea/aN30E/50OvSbAFXONKpmWUrwXVvwd1r0D1nA4cyaceUu9FxRuj5f9xQ4yCyrILKjg1/wKCnKzuTbnYTI8G3nZPZ7H3VPxYCbSZqFjYjjt48Oxmk2+K/JDV90abSzTYNJOBpZ/y4jST+jhWHfE9zos0VSEtqEqvA2uiFQ8UW0hOg1TbDtC4toREp+GOSQcl9eL26Nxe7T/tcvjxeXx4vYar90ejdvrxeXR/uBkUkZwMl4rfwBT1csxtrGYTcSEWYgONU78odYmvLDRGr7/Jyx7GM59CM6+47h2I0Eh2JUdgIW3wo4lRgPoxOeh4iB8P9u46jNZjBP5WbdCYreG79frhU0fGvXKxXug8yg47xFI7X9i5fV6YOun8MO/jPrq0FgYfB2c/vsTC16Nlb8DnhsCw241jqu5/fi8EcTPuBnGPda8312WS/nmz6na/Bmx+5YBig1tr+DblGvI80ZR7nBTVuWm3GFUzfgfDjd2l6fWrsJDzHRIiKBLQgjXlr/CoAPzKWl7Nq5LXiUhKQV1rN5JRZmw+g2jCq8iD2I7wOBrofs4qCyAkmwozYLS/Ydel2SDvfDIfXU7Hy55ASISmuov1XxcDvjkdlj3rtF2c8m/j32XVg8JCsFs00fwyR3gshsntiE31L7qLNhlnHzWvm1c8fe8EIbdfuw+5r9+C0sfgP2/QEpfY99dxzR9+ff+D378F2z5xAhe/a80rlRTejf9dx3uo5tg0wLjLiHymPORBMbn98JP/4bz/2ZcnTcxrTW5pVXsPFBC0a7/EbFnOR0Kv6eLawcAB3QcSzyDedE9gRwSsJgUkaEWIm3GI6r6dajV/z4ixEKbGBsdEyLolBhBUpSt9ol/zZvw6Z0Q3RamvFv3b+n1GHdoq16DncuMS/HuFxh3tp1HN+zOyVlpBIrSbOORt834W0Ykw5X/gfTAtW80ufKDMO8q4yJp1P0w/O4T6uorQSEY2Ytg8d3GQKK2p8GklyCpe/3bl+fBzy/Bzy+DoxjanwXDbjPq0Gv+Azy4BZbNgu2fQ3Q6jP6zcaIOdN1/wS746QUjeLkqocsYo92h88jA9IMv/BX+Nci4O2nuq/SavF7c86dh2bqQDWf+kzVRo8gutpNVVEl2kR23VxMeYiYsxEK41ex7bT60rPq11Ux4iAWzSbG3sIIdueUcyM2hTd4PnOldzQjTOhJUGR4U26292BM/jMoOY4jvfBrtEyKICrUSFWrBZjEd+8q+Ifb9DO9dbfTouvQl6HWxsbzsgFHNuXquccUflWq0fZ32W4hJO/HvzV4D86dBWQ5c8DgMvr71j6PIWQ/vTjXuiia9CH0uOeFdSlAINjuXw8czjSqiEX+Cs+8EcwOHoVSVwy9vGncPJfsgqadRrdTxbPj2SeMWPiQKzrnTOGEe5+3rcassNK4e//eScXypA+CqD5r+Sn7hrbBuHty2rml7F9Xg8nhr9UzJL3f6T/ZZRXayiivJKrJjr6zgzZDHGKB2cY3zXtaZ+5AWF0ZabBhWs4lKp9GdsdL3sLs8VDrdOFzew75R00vtZZTpF8aGrKe/3o4JLw5rHKXpI7D1Hkd0n/NRzdV2UrrfCAzZq+GMW4z/37YtNkZ3dx5lNGJ3H3fcjan1qiyED2+EnUuh/2S46BkIiWja72gqWz6BD28wqlCnvttk41ckKAQLZwUsfRBWvmKczCe9CG0zjm9fHpdR9fT9s5C70VhmssLQG2H4XS3fVdJdBevfg0/uhD6T4LKXm27fxftgdgYMmgYXPnXEaq01VW6j+2Ols0bXR6fH3wWyospNid19RFfEmkGg0ump48shzGomLS6MdN8jLTacThFVjPzuakIc+ajrl6CSex3zMLxejcPlxrl3FaYtCwnd8QkhZXuNlakDD42taJvRcr28XA6jenPdO0aPpoyrYdB0SOgS2O/1eo1eeF/91fi3MvktSOwa2O9sDK2NnnzLHzG68U55p0nb0yQoBIN9P8NHvzeqPc68BUY/0DRdGbWGXcth709GL6D4Tie+z6b01d/g67/DNR9Bl9HHtQutNUWVLg6WOcgtrSLt+wfotPe/PNv7PbY74jhY5qDUcehkX+Hr794QESHmI7of1vU+JsxKfEQI6XFhxEeE1F1FU7THGMNgDoHrl9Z/B+P1GnXPmz+GzQuNahiTxahq6zXBuPpuTQPJtDYa9WPbN3/3211fwvvXGxdBlzwPvSc27/fXxeWAhX+ADfOh7+Uw8bkmvyOXoHAqczthxWNGN7XodJj0glHVEyxcDnjhLNBeuPnHI/7xeLyag2UO9hcbVTLZxXYOlDg4WFpFbpnxnFdWhdNjVLUkUcR3ttv50HM2j1lmkBIdSnK0jZgwKxEhFiJsFiJsZuO5+n2Iuc7l0aEWLOYm7kq6fy28Pt4YN3Ht4kPdQr0eY3zDloVGICg/YASPLmOME12PcUYKDnGk4n3w32lGNdaZM+HcWU1fZdVQZbkw7zeQvcporzvnroC0eUhQOJX9d7pRzZNxjdFDpSkHo50EHC4PhRuX0vbjyWzqcgOfp9xAdrGd7CI7+0vs5BQ7cB92VR8davGf7FOiQkmODiU5ykZKdCiDtv2DlM1v4JzxM7bkVlSdUNOOZfDOldBpuNFddvNC2PqJ0V3TEgrdzoNeE42qoSD7/+G4uatgyf2w8mWjk8UVrzdv92eAnHVGg7K9yOgY0ntCwL5KgsKpqmgPPDug5frRN6OSShc788rYkVvOzoPl7DhoPGcX2wF4yvoCF5t+4GLXY5RFdSUtLoy2sUZjbNvYMKOOPjaM1NgwIm31NLpX5MM/+xlVLJe+1IxHdxx+eQs+9nVRtUZA97HGHUHX81puoN+pYP1/YdGtEBJpBIbmuuvevNCo/g2LNxqUT3SszzE0NChIltSTzZq5xq3lkBtauiRNQmtNfrmTHQfL2OU78e/ILWdnXjl5ZVX+7UKtJrokRTK4YxyTk9rRLj6M9ranMS8cy2ftP8R07WfHNwL4x+eM8Rzn/F8THlWAZFwNtmjj9+8yBkLCW7pEp4b+V0CbvkavqLkTjFHDZ84MXEN8UabRk+6nf0PaYF+Dcutp75GgcDJxO41BQN3Ob3w6iRbi8WryyqqM6p1iO/t9j2xfXX92sZ0yh9u/fZTNQpfkSEZ2T6JbSiRdkyPplhxFWmyYkf/lcFWPGlfPv7xp9BxqjMpCY4xGn0lHH8/RmgSweiGoJfeCG76ChTON3nw/vQj9Lje6r7bpe+L7dzuNrrdr5hoN3cpkBPnxT7WePFc+EhROJls/MfrpD7m+pUtSi93pYefBcrbllrGnoMJ/wt9fYjTwujxH1u+nxYWTHhfG0E7xdEqMoFtyFF2TI0mJtjVuoNTAq4zcSUsfgB4XQGRywz/7vxfBWW50txUiNNrIObVlIax917iS/2E2JPcxBmv2u6Lxg+kKdhkD89a+bbT/RKfDyPuMgNAUA/MCQNoUTiZvXGTkG7p1bYv0MXe6vfyaX8G23DK2Hyhje67x2FNYSfX/RiYFbaJD/XX61XX81fX8bWNDiQpt4l4eeduN3kiNGbvgKDHaEjqeA1PebtryiFNDRYGR52v9fKO7L8pob+g/2bhjC42p+3PuKuMCbvUb8Os3xux63ccZYzG6jmmx8SHSpnCqydsOmd/CmAeb5X+qnBI76/aVsD23jG25ZezILWN3XoW/V4/ZpOiYEE7vttFckpFG95QouqdE0SHByHzZrJK6G6Otv/47DJzasLELP79sBIbhdwe+fOLkFJEAQ28wHoW7jQbp9fOMKqZP/8+4Mx0wxWjfsYQY4y5Wv2Ekr6ssgJj2RhfTgVcHbIR8IMidwsni8/vg5zlw5+bGVZE0gMPlYUN2Cb/sLeKXvcX8sreYA6UO//r28eF0T4mke0oUPdoYJ//OSRHYLC0870FNxxi7UEtVuXGXkD4Yrvpv85VRnPy0NsY2rH8PNn5gnPzD4o0xJNmrjAGDPS4w7goamsSvmcidwqnEZTfqJHtdfMIBQWvN3sJK38m/iDV7i9mSU+q/A2gfH87pnePJaBfLgHaxdE+JIqK+7pytiTXUyGfznwnwzZMw5oH6t131mpFiefgfm6984tSglHExkT7YGCO060sjQORvhzEPGW1cragn0fE4Cf61CzZ9ZGQxHXzdcX1858Fyvth8gNWZRfyyr5jCCidgpGMY0C6W34/oTEa7OAa2jyUx8iSebL3zCBgw1cjd1O9yo0fJ4Vx2Y86GziOPnSpciKMxW43Bgt3Pb+mSNCkJCieDVa9BYvcGD6rRWrM9t5zFG3L4bGMO23PLAeiaHMmYnslktI8jo71xF2Cuq5vnyWzso0ZO/k/ugOmLj7x9Xz3X6ME1/I0WKZ4QrZ0EhdYuZz1krYRxjx81H4rWmk37S/lsYw6fbTjA7vwKlIKhHeOZdXFvxvVNpU1M6+oPHRARiUZg+PjmI8cuuKuMu4gOw6DjsJYroxCtmASF1m7Va2AJM3o5HEZrzbqsEj7bkMNnGw+wt7ASs0lxRud4rju7E2P7pJAcFQSB4HADf1P32IW1b0PZfmNKQyFEnSQotGZVZcYsan0v82e79Hg1a/YW8fnGA3y+8QDZxXYsJsWwroncMqoL5/VuQ3xESAsXvIUpZTQ6vzjMSHh22ctGmuTvnjHSCnQe2dIlPGV4q6qo+PFHylesACC0Rw9sPXpi694dc2TrnMRGa42noABXdjau/fv9z87sbFzZ2bhzD4LJhCk0FFNoKKq+57BQTDbjWVmsaJcL7XTWfrhcaJcTr3/ZoW0wmTCFhKBsNpTNhinUhgqx+d6HGPv2v7ahbKGEDx1CaPfAjr4PaFBQSo0DngXMwCta68cPW98emAvE+ra5R2u9OJBlOqmsfw+c5TgzpvH9toN8sekASzfnkl/uJMRs4pxuidxxXnfO65VCTHgLpf1trZK6G7PPff24MXahdD8U74XxT7b+qRhPkNYab3k57vx8PAUFeErLsHXuhLV9e1QTdJH0lJRQ/vXXlC1bTvl336ErKzFFRIDJRPG89/zbWdu1I7SnESSM5x5Y09KapAx10V4v3rIyPMXFeIqKcBcX4ykuxp178IgAoKuqan3WFBODNa0tIR07EnHGmaA13ioH2u7A63CgHcazOz+/1nttt+N1OIz5LMxmVEiI72HFZA059N5q9b82hYejQkJAa3RVFd4qB97iYtxVVb73xnP1azyHJmZq8/DDAQ8KARunoJQyA9uB84AsYCUwVWu9ucY2c4BftNYvKKV6A4u11h2Ptt9gGadQ7nDh/fdZFFfBeMdfKK/yEBFiZmTPZMb2TmFUz2Sim3pk8KnG5TDuFrweIxDYouDGr0/aoOB1OnEfOIA7Lw93fgHu/Dw8BQW48/JxFxTgLsjH43t9+EkPwBQVRWifPoT160ton76E9u2LNa1tg9KKuPbvp2z5l5QtX07lypXg8WBJTiZyzGiixpxLxNAhYLXizsnBsXUbVdu24ti2naqtW3Hu2UP1kHdTRAS2Hj2w9eiOrVs3TDabcXL0ekFjbKe9aK2N115da5l2uoyT/uGPoiI8JSXGybkO5vh4rG3bYk1LO/I5rS3myOPPMltd1oAFO7fbCBBOp3H3EnZ8k++0hnEKQ4GdWuvdvgLNAyYCm2tso4Hq5O8xwP4AlqfxHKXGYKiw2Gb5uvzyKpZtzmXJpgNU7PqR+ZbtzFa/58J+bTm/bwpndUkk1NqKBoy1dtVjF+b6Joif/FarDQhaa+OqNicHV04Oruz9xnNODq6c/bj35+DOz/efXP2UwhwfjyUxEUtCAraOHTEnGK8tSYmYExIwR0RQtXMn9o0bcWzYSMEbc8HlAsAcF0do376E9u1DWF9foEhJMaYf3b6dsmXLKFu+nKrNWwAI6dqFhOuvJ+rcMYT27XvEidDati3Wtm2JGj3Kv8xbWUnVjh04tm2jaus2HNu2UbroE7zl5cf1t1IhIZjj4jDHxmKOjTWqqmJj/O8tNdaZY2OxJCVhCg9cRlmlVED/v1IWC8piMe7GmkEg7xQuB8ZprX/ne38NcLrWemaNbVKBL4A4IAI4V2u9uo593QjcCNC+fftBe/bsCUiZj/DWZZD5vdGD5aw/QEx6k39FdrGdzzbk8MWmXFbtKcSrIS02jH+Hv0Tfsu/g/7ZiDo1q8u8NKp/fZ8w5fc2CgIww1VpTtXUrFT/+hK5yoN0etMcNbrfvtQc87jqXe8vK/Cd/bbfX2q+y2bCmpmJtm4olNdU44bZJxZKSgiUxAUtiIua4OJS5cRcKXqeTqm3bcWzaiH3DBhwbN1G1c6e/msKSlISyWnHt3w9KEZaRQdSY0USOHo2tU9NMzaq1xn3wILjdxglVKd9vo1AmddgyjOCjlFENExrauKSJAmgFk+w0MCjc6SvDU0qpM4FXgb5a67rvAWnm6qPZGcbdgqMYUDBgMgy744Qn+95fbGfxhhw+3ZDDL3uLAejZJoqxvVMY26cNfWLdqKd7wWm/hQufPOHDEBhX2E14IqkOBKWffU7pks9x7dlbewOz2bjCM5vB/2xGmY3XymIBiwVTWJjvxN/20Mk/1Xhtjo9vtpOf127HsXUrjg0bcWzaiLeykojhw4kaNQpLYmKzlEEEVmuoPsoGaib9T/ctq+l6YByA1vpHpVQokAgcDGC5Gq6y0EiXO+w2YxTsmrlGV8felxgJ2Nr0a/CuckrsLN5wgE/X72eNLxD0To3m7vN7ML5fKp0Sa9wa/vAceKpg8LVNezynAOe+fZR/+SUhHTsS2rcvloSEhn2wCU6uWmuqtmyh9PMlhwKB2UzE6UNJuO56osaMxhwbawSEk+xK1hQWRnhGBuEZGS1dFNHCAhkUVgLdlFKdMILBFOA3h22zFxgDvKGU6gWEAnkBLFPDedxGFs3weGNCm/FPGHn3f/o3/PyKkVK32/nGjF3tT69zFwdKHP47gtV7igDoVV8gqOb1GmMT2p0BKX0CeYQnFVdODvkvvEjxhx8aVQ4+ltRUwvr28TechvXtY5yYm0j9geB0o279vPOwxMU12fcJ0dICFhS01m6l1ExgCUZ309e01puUUo8Aq7TWC4H/A15WSt2B0eg8XbeWtK2OYkBDeI0r0chkOHeWcefw8ytGgHhtLHQ4G4b/H3QexcGyKn8gWJlpBIKebaK4a2x3xvdLpXPSMXo5ZH4Dhbtg5D2BOrKTijsvj/w5L1M8bx4aiLvySuKn/RZ3Xp7RcLpxE44NGyhbusz/GWu7docaTvv0JbRPb8xRh9pltNb19yn3vfba7VT88COln3+Oa68EAhE8JHV2ffK2w/ND4NJXjDlc6+KsMHLp/DAbynIoiOnDgwXns9h9Gj3axHBhv1TG90+ly7ECQU3zfwu/fgt3bml10/Q1J3dREYWvvkrh2++gnU5iL51E4k03YU2re7YqT2kpjs2bcWzciH3DRhwbN+LKPlRbaY6JQbtceF0uf8+bY/IFgqgLxhF17rkSCMRJrTW0KZzcKguM5/D4+rcJiYAzb8YxcDqfvvU0g/fN5XnL09jbn0nYZc9DQpfGfWfZAdj6KZwx46QJCP7RoVlZOLOzUSYTtp49CenQ4bj6bXvKyih8/Q0K587FW1lJ9MUXkXTLLYR06HDUz5mjo4k44wwizjjDv8xdVGTcSWzcgOvgQWP0aEgIquagIt9AI2OZMcCoejtbz54SCETQkaBQH3uh8Xy0oIDRk2jGW2tYl5XBH0ZO4o7ElYQtfdCY8GXUfXDGLWBu4J95zZvgdcOg1tXA7CkrM076WVm4srJxZWX5gkAWruz9R3SlBDCFh2Pr1YvQ3r0J7dWL0D69sXXujLLWPeDOW1FB4VtvU/Daa3hLSog6/3yS/jATW9fj7+lliYsj8pyziTynYdllxanB5XFR6CikqKqIQt+/44iQCCKtkURYjedwazgmdWLdk11eF3a3HbvLTpWniipPFU6Ps87XLq/riGUWk4WYkBhibL5HSAyxtliibdFEhUSdcPmOlwSF+lT6gkJY/UHhx10FzHxnDVVuLy9ePYhxfdsAfYz86p/+Hyx90JgLYcJz0Kbv0b/P6zGm8us8qvF3GE1Ma03pokUUvvkWzr178ZaU1FpviojAmp5OSIeORA4bhjUtHWt6Otb0NHC7cWzZgmPzFhybN1P8wQfoykrAGHRk697dHyRCe/UipEMHihcsoGDOy3gKC4kcNYqkW/9AaK865kIQpzStNS6vC6fHidPrxOlx4vK4cHqd/hNqpbuSIkcRRY4iCh2Fxsnf97o6CJS5yhr0fRHWCCKsEURZo2oFjXBL+KETvtuOw+2o87Vbu4/9JfVQKDT1V90rFNG2aH/QqH49qdskzkg9o97PNQUJCvXxVx8d2eVRa82r3/3KY59tpWNCOC9dM5iuyTXaDaJTjcngNy+AxXfDnBFGHp7hd4GlnklsdnwBpVlwweN1r28mzj17OPDww1T88CO2nj2JvmAcIem+k36aceI3x8YetctlaO/ecJnxWns8OPfsMYLEls04Nm+m7IsvKP5v7WkwI846i6TbbiVswIBAHp44Bq/2UumqxO11ExESgdV0YqlUHG4HORU55JTnsL9iP/vL97O/Yj855TnkVuZid9uNIOALBI1hUibibHHEhcaREJpAr/hexIfGExcaR3xovP+1WZkpc5ZR4aqg3FXufy53lh+xLLcilwp3BVaTlTBLGGGWMEItocSGxvrf+5ebQ/3rwyxh2Mw2bGYbIeYQ/3P168OXW5QFt3ZT5iyjpKrk0MNZcsT70qpSShwl7C3dy/D04Sf0ezSEBIX62AvBHGK0G9RQ6XTzpw82sGjdfs7vk8KTVwwgqq4cREpBn0nQaQR8fi988wRsWWjcNdQ149eq1yAqFbqPC9ABHZ12Oil47XXyX3gBZbWS8uADxE2e3OjRsodTZjO2zp2xde5MzEUXGt+lNe79+3Fs2ULVzp2EnXYaEUOHNsVhCIwTe3FVMXmVeeTZ88i351PmLDviRFjuLK/1XOGqoMJVUesKNtQcSmRIJFEhUURZo4gMiSTSaryPtEb610VaIyl3lftP/tXPhY7CWmUzKzMp4SmkRqYyMHkg4ZZwbGYbVrOVEJNxEvU/mw+9r14fZgnzn/CjbdEtVsXSFKzK6j+W1kSCQn0qC4y7hBpXxHsKKvj9m6vZllvG3ef34OaRXY49SCk8Hi59yZgectHt8Op5RkPy6D8fCjhFe2DHUhjxR2OKv2ZWuWYNBx56iKodO4kaO5aU++/HmnJic0EfjVLKl4gsjahzzw3Y95xKtNZUeaood5VTYC8gz57nP+kfrDxIvj2fvMo8DtqN125v3VUbYZYwfzVJVEgUEdYIksOT/XXt1Sd9i8liBBJfwKgZVHIqcvzL7e7a7Uk2s43UiFTaRralR3wP2ka29b9vG9GWpPAkLCY57bRm8uvUp7KoVnvCV1sPctu8X1BKMffaoQzvntS4/XU7D27+EZY/bIxv2PoJXDwbuowy2hKUgtOmHXM3TclTWsrBp56m+L33sKSmkv7vf9dKZCaOVO4sJ6s8i6yyLPaV7SOrLIuscuP1wcqDxtWsNYxwSzjh1nD/c5il7mUmZaLCVVGreqOuK/hyZ3m9ddjRIdEkhyeTFJbE0JihJIUlkRSeRFJYEsnhySSEJRAdEk2ENaLJT8gur8sop7OcMGsYCaEJJ91oblGbBIX62AshPB6vV/PcVzt5Ztl2erWJ5qVrBtEu/jgzLoZGw4VPGZPmfDwT3rwEMq425hTufgHE1N0Hv6lprSn7/HMO/O1veAoKiZ82jaRb/9BsWRhbM4/XQ25lLtnl2XWe+IurimttH2OLoV1kO/ok9GF0u9G4tZtKVyWV7kr/c7493//a7rJT6a7Eoz219mMxWYwGzxpX8KmRqUdc1UdaI4kPjfef9JPCk7CZ62mnagZWk5W4UKNeX5waJCjUp7IAV0JPZry5mmVbcpmUkcbfJvUjLKQJUld3OAtmfA9f/x2+nw3aA4OvO/H9NoAzK5sDf3mEiq+/IbR3b9q98CJhfYMnnYbWmlJnqf9EX/2cXZZNVnkWORU5tapezMpMakQq6VHpnNfhPNKj0kmPTKddVDvSotKIDok+yrfVXwaX12U06Go3USFRhJhC5ApbtAoSFOpTWcg3djcrig4y6+LeTDurY9P+o7WGGSkzel8Ce3+ELqObbt910G43hXP/Q95zz4FSpNx7D3FXXWVk6zyJ2N12Mksyje6BHgdOj/PQs/uw9x4HVW6jT3hxVbH/6r/cVTuPf5wtjrTINPok9GFsh7GkR6WTFplGelQ6qRGpTV7lopTyN6IK0dqcXGeE5uL1ou2FbHaFcMd53Zk+rGlyyNep7UDjESCesjJKP/2UorffoWrHDiJHjaLNA3/G2rZtwL6zqbg8LrYXb2dT/iY25m9kU8EmdhXvOqLqpT4hphBsFhuh5lCiQqJIj0onIzmD9Mh00qLSSI9MJz0qnQirVJsJUU2CQl2qSlDaSwlR3Di46SfWCTStNZUrV1LywQeULvkC7XBg696dtGefJWrsea2ymsLj9fBrya9sLNhoBID8TWwr2obLa+QpirHF0DehLyPSR9AzvieRIZHYzMYJv7ofuM1iq9Un/GTurihES5GgUAdXeQFWILVNW5KjTo4cRACu3IOULFhA8Ycf4NqzF1NkJDETJxJ7+WXG1IktHAy82kuBvYCcihwOVBwgpyKH/eX72Vq4lS2FW/zdG8Mt4fRO6M1Vva6iT2If+iT0IT0yvcXLL0QwkKBQh1+27mIocFqvlk030RDa5aL8668pfv8Dyr/5BrxewgcPJnHGDKLPP/+4J/ludDm09o8IzanI4UDlAXLKD538D1Qc4EDlgSP6z4dZwugW141Lul5C38S+9E3oS4foDphNMhe1EC1BgkIdfty4g6FAv24BbEs4QVW7d1P8wQeUfLwQT34+lqQkEq6/ntjLLiWkY8cm/S67224MjKo86B8sVT1Qqvp1nj3viIFMZmUmOTyZ1IhU+iX1Y2zEWFIjUmkT0cb/HB0SLXcAQrQiEhQOc7DMQVb2PrCAJbL1zU1r37iJvKefpuKHH8BsJnLkSGIvu4zI4ec0SU+inPIcVuau5Oecn9mYv5GDlQfrTDBmM9v8A6Z6J/QmKTyJlPAUksKSaBvZljYRbUgMS5TRq0KcZORf7GE+XJNNtPadBI+SIbW5OfftI++Zf1K6eDHm2FiS7ryT2EmXYElq5Mjqw+RW5PLzgZ9ZlbuKn3N+Jqs8CzAadgcmDWRo6lD/yT85PNl4HZ5ElDVKrvCFOAVJUKhBa838lfu4JdYNlWYIjWnU572VlRz85z+xde5M9LhxTTJXsLuwkPwXXqRo3jyU2UzCTb8n4frra00v2Rh5lXn8fOBnVh5YycoDK9lbtheAqJAoBqcM5qpeVzGkzRC6xXWT3jtCBCEJCjWs3lPE7vwKBnb3AvG1kuEdi/Z4yP6/uyj/6isAcv/6NyJHjiRm4gQihw9HhTRuoJK3spLCuXMpeOVVvHY7sZddRuLMmY1KVFfdzXND/gbW569n1YFVZJZmAhBljWJQyiAm95jMkDZD6B7XXRp3hRASFGp6b+U+IkLMdAhzNKrqSGtN7t8eo/yrr0j5858JyxhI6cKFlHzyKWVLl2KOjSV6/AXETJxIaP/+R6120W43xR98SP5zz+HOyyNyzBiS77wDW5dj94TKrchlY/5G1uev9w/2qnBVAEYQyEjJ4LJulzEkdQg943pKEBBCHEGCgk95lZtPN+Rwcf+2WMqK6pxcpz6Fb8yl6O23iZ8+nfirrwIgrE8fku++m4rvv6fk44UUf/AhRe+8S0jHjsRMnED0xRMIST+UAE9rTdmyZeQ9/QzOX38lLCODtGf/Sfhpp9X5nRWuCjblb2JD/gb/42DlQcBIrtYjrgcXd76Yfkn96JfYjw7RHaQ6SAhxTBIUfD5dv59Kp4crh7SDTwshvnODPle65AsOPvEEUWPHkvzHu2utUxYLkSNGEDliBJ6yMsq++IKSjxeS9+xs8p6dTdjgQcRMnEhIWhp5/3oO+y+/ENK5M+nP/YvIMWNq3VFordlVvIsv933Jl3u/ZHPBZv9kKO2j2jOkzRD6JRoBoEd8jxbNnCmEOHlJUPB5b+U+uiRFcFr7WGN+5rRBx/xM5S+/sP+PfyRswADaPvF3lKn+K3FzVBSxl11G7GWX4crOpmTRJ5QsXMiBBx4EwJKURJtHHib20kv9XUu92sv6vPX+QLCndA8A/ZP6M2PADPon9advYl9ibI1rEBdCiPpIUAB2Hixjzd5i7hvfEwWHZl07CueePWTdfAuWlBTS//08ptCGp8OwpqWReNPvSfj9jTg2bqRq1y6ix47FFB6Oy+NiZfYPLN+7nK/2fUWePQ+LsjCkzRCu6XUNo9qPIjk8cLOiCSGCmwQFYP6qLCwmxaSMdHCWg9dlTKNZD3dREftu/D1oTfs5L2GJP77xDEopwvr1Q/fswrLs71i+dznfZn1LmauMMEsYZ6edzej2oxmePvy48vYLIURjBX1QcHm8fLgmi9E9k0mKskFRjrGinjsFb1UVWbfMxJWTQ/s33jihlBJZZVm8uvFVFu1aRJWnilhbLGM6jGFM+zGckXoGoZaTJxmfEOLUEPRB4cutB8kvdzJ5SDtjQWWh8VxHl1Tt9bL/T/dgX7OGtH8+Q/hpGcf1nZklmby84WU+3f0pJmViYteJjO80nozkDEkLIYRoUUF/Bpq/ch/JUTZGdPeli7D7gkId1UcHn3qKss8/J/nuu4geN67R37WzaCdzNsxhSeYSQkwhTO05lWv7XittBEKIViOog0JuqYOvth3k9yO6YDH7eg5V3ykcVn1U9O67FL76GrFTpxB/XePmU95SsIU56+ewbO8ywixhTOszjWm9p5EQ1vCxEEII0RyCOih8sCYLr4YrB7c7tLCO6qOyr77iwF8eJXLECNrcf3+DE8FtyNvAS+tf4uusr4m0RnJj/xu5ptc1xIbGNuFRCCFE0wnaoKC15r+rshjaKZ5OiTXm6LUXAgrCYo23GzeRfef/EdqzJ2lPP9Wg9NRrctfw0vqX+GH/D8TYYpg5cCZTe02VHkRCiFYvaIPCz78W8mt+BbeM6lp7RWWBERBMZlzZ2eybcRPmuFjSX3wBU8TRJ3gvdBTyx2/+yP9y/kd8aDx3DLqDyT0my8TwQoiTRkCDglJqHPAsYAZe0Vo/ftj6Z4BRvrfhQLLWOjaQZao2f1UWkTYL4/u1qb2ishDC4nEXFrL3hhvRjio6vPYa1uSjNwbnVuRyw9IbyCnP4e7Bd3NFjysIszTPVJhCCNFUAhYUlFJm4HngPCALWKmUWqi13ly9jdb6jhrb/wE4vj6ejVTmcLF4Qw6XZKQRHnLYn6CyAI85jn2/uwFXdjbtXp6DrVu3o+4vqyyL333xO4qrinnxvBcZlHLsFBlCCNEaBTJt5lBgp9Z6t9baCcwDJh5l+6nAuwEsj9+idTnYXR6uHJx+xDpvaQH7FhTj2L6d9NnPEjF06FH3tbtkN9M+n0a5q5xXxr4iAUEIcVILZFBIA/bVeJ/lW3YEpVQHoBPwZT3rb1RKrVJKrcrLyzvhgs1ftY/uKZEMbBdba7l2OslaWIg9q5K0fzxB5IgRR93PtsJtXPv5tXi8Hl47/zX6JvY94bIJIURLai0J9qcA72utPXWt1FrP0VoP1loPTjrBOYm355axdl8xVw5uVzs1tdtN9t1/pGIfpE4+jegLLjjqftbnrefaJddiNVl5Y9wbdI/rfkLlEkKI1iCQQSEbqDEAgHTfsrpMoZmqjuav3IfVrJiUUWOCG6+XnAcfomzJEpIHlhA7pu6JbaqtPLCSG764gVhbLHMvmEvHmI4BLrUQQjSPQAaFlUA3pVQnpVQIxol/4eEbKaV6AnHAjwEsCwBOt5cPf8nm3F4pJEQak9Borcl9/HFKPvyQxOuvJqFnxVHTZn+b9S0zls0gNSKVN8a9QVpknTViQghxUgpYUNBau4GZwBJgCzBfa71JKfWIUmpCjU2nAPO01jpQZam2fEsuhRXOWiOY8597nqL/vEncb68h8aqLjIX1zM+8dM9Sbv3qVjrHdOb1ca9LziIhxCknoOMUtNaLgcWHLXvwsPezAlmGmuav2keb6FCG+5LfFbzxBvnPP0/MpZeScs89qMxvjA3rSIa3aNci/vz9n+mf2J/nz31eRicLIU5JraWhOeAOlDj4enselw9Kx2xSFL//Pgcf/ztR559P6l8eMabSrCwwNj6s+mj+tvnc9919DEkZwkvnvSQBQQhxygqaNBfvr96HV8MVg9Mp/ewzch54kIhzziHtH0+gzGZjozqS4c3dNJcnVz3J8PThPD3yaWxmWwuUXgghmkfQBIXLB7UjNSaMhI2r2Hf3HwkbdBrps59FhYQc2qiy9lwKb2x8g6dWP8XYDmN5/JzHsZqtLVByIYRoPkETFNrEhHKBN4e9t95GaPfutHvhBUxhh+UmsheCLRrMVipdlby4/kWGpw/nieFPYDaZW6bgQgjRjIKmTcG+YSP7bpqBNT2ddq++gjkq6siNKgshLA6A5XuXU+GqYHqf6RIQhBBBI2iCgmPrFszx8bR/7VUscXF1b1RZ4G9kXrBzAemR6QxOGdyMpRRCiJYVNEEh7oor6LzwY6wpKfVvZC+E8HiyyrL4+cDPTOw6scGzrAkhxKkgaIICcGQbwuF8dwoLdy1EoZjY5WhJXYUQ4tQTVEHhmCqL8IbGsXDXQk5PPZ3UyNSWLpEQQjQrCQrV3E5wlrHK5CK7PJuJXeUuQQgRfCQoVLMbYxQWOPYRaY1kTPsxLVwgIYRofhIUqlUWUq4US0t3Ma7TOJlfWQgRlCQoVKssYElEOA7t4pKul7R0aYQQokVIUKhmL+TjqAg6RbSlf2L/li6NEEK0iAYFBaVUhFLK5HvdXSk1QSl1SiUCyizaxS+hoVzS8QIZmyCECFoNvVP4BghVSqUBXwDXAG8EqlAt4eO8VZi05qJul7Z0UYQQosU0NCgorXUlcCnwb631FUCfwBWreXm8HhaW7WCYw0VyTPuWLo4QQrSYBgcFpdSZwFXAp75lp0yWuB9zfuSg18El7lOqRkwIIRqtoamzbwfuBT7yzbPcGfgqYKVqZh/v/JgYzIy0RLZ0UYQQokU1KChorb8GvgbwNTjna61vDWTBmktJVQlf7v2Syz0hhBw2DacQQgSbhvY+ekcpFa2UigA2ApuVUncHtmjN47NfP8PpdTKx0nnE3MxCCBFsGtqm0FtrXQpcAnwGdMLogXTSW7BzAd3jutOrvKjW3MxCCBGMGhoUrL5xCZcAC7XWLkAHrFTNZEfRDjYVbOKSzhNQjmK5UxBCBL2GBoWXgEwgAvhGKdUBKA1UoZrLxzs/xqIsXNh2mLEgXO4UhBDBraENzbOB2TUW7VFKjQpMkZqHy+ti0e5FjGg3gniP11go1UdCiCDX0IbmGKXU00qpVb7HUxh3DSet77K+o9BRaCS/qywwFsqdghAiyDW0+ug1oAy40vcoBV4PVKGaw4KdC4gPjWdY2jD/XAoSFIQQwa6hg9e6aK0vq/H+YaXU2gCUp1kU2Av4Jusbrup1FVaTtcadgjQ0CyGCW0PvFOxKqbOr3yilhgH2wBQp8Bb/uhi3dh+aN6HSd6cgbQpCiCDX0DuFm4D/KKVifO+LgGmBKVJgaa1ZsHMBfRP60jWuq7HQXgjmEAg5qZtJhBDihDXoTkFrvU5rPQDoD/TXWmcAowNasgDZUriF7UXba8+uVllgVB3JPApCiCDXqJnXtNalvpHNAHcGoDwBt2DnAkJMIYzrNO7QwkoZzSyEEHBi03Ee87JaKTVOKbVNKbVTKXVPPdtcqZTarJTapJR65wTKc0xOj5PFvy5mdPvRxNhiDq2wF0rPIyGEoOFtCnU5apoLpZQZeB44D8gCViqlFmqtN9fYphtGSu5hWusipVTyCZTnmFbsW0FJVUntqiMwqo+SewXyq4UQ4qRw1KCglCqj7pO/AsKOse+hwE6t9W7fvuYBE4HNNba5AXhea10EoLU+2MByH5cFOxeQEp7CGaln1F5RWSjVR0IIwTGqj7TWUVrr6DoeUVrrY91lpAH7arzP8i2rqTvQXSn1vVLqJ6XUOOqglLqxejR1Xl7esY6pTgcrD/L9/u+Z0GUCZlONSeO8Xl/1kYxREEKIE2lTaAoWoBswEpgKvKyUij18I631HK31YK314KSkpOP6okW7FuHVXiZ2nVh7RVUJaK+0KQghBCfWpnAs2UC7Gu/TfctqygL+50vF/atSajtGkFjZ1IUZ12kc0bZoOkR3qL2ieuCa3CkIIURA7xRWAt2UUp2UUiHAFGDhYdsswLhLQCmViFGdtDsQhUmLTOOK7lccuUJGMwshhF/AgoLW2g3MBJYAW4D5WutNSqlHlFITfJstAQqUUpuBr4C7tdYFgSpTnSQZnhBC+AWy+git9WJg8WHLHqzxWmMMgmu5gXCSNlsIIfxauqG55Un1kRBC+ElQsBeCMkNozLG3FUKIU5wEhcoCo+pIkuEJIYQEBRnNLIQQh0hQqJTRzEIIUU2CgmRIFUIIPwkKlRIUhBCiWnAHBa2NhmZpUxBCCCDYg4KzHLwuuVMQQgif4A4K/tHM0tAshBAQ9EFBRjMLIURNwR0U7JI2WwghagruoFApGVKFEKImCQog1UdCCOET5EGhAFAQFtvSJRFCiFYhuIOCvdAICCZzS5dECCFaheAOCpIMTwghagnyoFAgPY+EEKKG4A4KkgxPCCFqCe6gIGmzhRCiFgkKYXEtXQohhGg1gjcoOCvBbZfqIyGEqMHS0gVoMZLiQgQJl8tFVlYWDoejpYsimkFoaCjp6elYrdbj+nzwBgUZzSyCRFZWFlFRUXTs2BGlVEsXRwSQ1pqCggKysrLo1KnTce0jeKuPJG22CBIOh4OEhAQJCEFAKUVCQsIJ3RUGb1CwSzI8ETwkIASPE/2tgzcoSPWREEIcQYKC3CkIEXAHDhxgypQpdOnShUGDBjF+/Hi2b99OZmYmSin+9a9/+bedOXMmb7zxBgDTp08nLS2NqqoqAPLz8+nYsWOtfRcUFDBw4EAGDhxImzZtSEtL8793Op3HLNuqVau49dZbm+xYT3bBGxTshWCLBvPxtdALIRpGa82kSZMYOXIku3btYvXq1Tz22GPk5uYCkJyczLPPPlvvCdxsNvPaa6/Vu/+EhATWrl3L2rVruemmm7jjjjv870NCQgBwu931fn7w4MHMnj37BI7w1BLEvY8K5C5BBJ2HF21i8/7SJt1n77bRPHRxn3rXf/XVV1itVm666Sb/sgEDBgCQmZlJUlISw4YNY+7cudxwww1HfP7222/nmWeeqXPd0UyfPp3Q0FB++eUXhg0bxpQpU7jttttwOByEhYXx+uuv06NHD1asWMGTTz7JJ598wqxZs9i7dy+7d+9m79693H777UF3FxHEQUEypArRHDZu3MigQYOOus2f/vQnLrjgAq677roj1rVv356zzz6bN998k4svvrhR352VlcUPP/yA2WymtLSUb7/9FovFwrJly7jvvvv44IMPjvjM1q1b+eqrrygrK6NHjx7MmDHjuPv8n4wCGhSUUuOAZwEz8IrW+vHD1k8H/gFk+xY9p7V+JZBl8rNL3iMRfI52Rd+SOnfuzOmnn84777xT5/p7772XiRMncuGFFzZqv1dccQVmszFfSklJCdOmTWPHjh0opXC5XHV+5sILL8Rms2Gz2UhOTiY3N5f09PTGHdBJLGBtCkopM/A8cAHQG5iqlOpdx6bvaa0H+h7NExBA0mYL0Uz69OnD6tWrj7ndfffdx9///ne01kes69atGwMHDmT+/PmN+u6IiAj/6wceeIBRo0axceNGFi1aVG9ffpvN5n9tNpuP2h5xKgpkQ/NQYKfWerfW2gnMAyYG8Psap7JIqo+EaAajR4+mqqqKOXPm+JetX7+eb7/9ttZ2PXv2pHfv3ixatKjO/dx///08+eSTx12OkpIS0tLSAPy9m8SRAhkU0oB9Nd5n+ZYd7jKl1Hql1PtKqXYBLM8hbic4y+ROQYhmoJTio48+YtmyZXTp0oU+ffpw77330qZNmyO2vf/++8nKyqpzP3369OG000477nL88Y9/5N577yUjIyPorv4bQ9V1q9YkO1bqcmCc1vp3vvfXAKdrrWfW2CYBKNdaVymlfg9M1lqPrmNfNwI3ArRv337Qnj17TqxwZQfgqR5w4VMw5Hcnti8hWrktW7bQq1evli6GaEZ1/eZKqdVa68HH+mwg7xSygZpX/ukcalAGQGtdoLWu8r19Baizi4LWeo7WerDWenBSUtKJl0xGMwshRJ0CGRRWAt2UUp2UUiHAFGBhzQ2UUqk13k4AtgSwPIdIMjwhhKhTwLqkaq3dSqmZwBKMLqmvaa03KaUeAVZprRcCtyqlJgBuoBCYHqjy1CLJ8IQQok4BHaegtV4MLD5s2YM1Xt8L3BvIMtSpUibYEUKIugRn7qPq6iNpUxBCiFqCMyjYi8AaDtbQli6JEEK0KsEZFGQ0sxDNKpCpswFGjRrFkiVLai375z//yYwZM+ot08iRI1m1ahUA48ePp7i4+IhtZs2adcwBcwsWLGDz5s3+9w8++CDLli076mdasyANCoUQFtfSpRAiKAQ6dTbA1KlTmTdvXq1l8+bNY+rUqQ0q4+LFi4mNjW3Qtoc7PCg88sgjnHvuuce1r9YgOLOkSjI8Eaw+uwcObGjafbbpBxc8Xu/q5kidffnll/PnP/8Zp9NJSEgImZmZ7N+/n3POOYcZM2awcuVK7HY7l19+OQ8//PARn+/YsSOrVq0iMTGRv/71r8ydO5fk5GTatWvnz/D68ssvM2fOHJxOJ127duXNN99k7dq1LFy4kK+//ppHH32UDz74gL/85S9cdNFFXH755Sxfvpy77roLt9vNkCFDeOGFF7DZbHTs2JFp06axaNEiXC4X//3vf+nZs2eD/+SBFKR3CjKXghDNpaGps5988kk8Hs8R62qmzq5PfHw8Q4cO5bPPPgOMu4Qrr7wSpRR//etfWbVqFevXr+frr79m/fr19e5n9erVzJs3j7Vr17J48WJWrlzpX3fppZeycuVK1q1bR69evXj11Vc566yzmDBhAv/4xz9Yu3YtXbp08W/vcDiYPn067733Hhs2bMDtdvPCCy/41ycmJrJmzRpmzJhxQjmdmlpw3inIXAoiWB3lir4lNUXq7OoqpIkTJzJv3jxeffVVAObPn8+cOXNwu93k5OSwefNm+vfvX+c+vv32WyZNmkR4eDgAEyZM8K/buHEjf/7znykuLqa8vJzzzz//qMe0bds2OnXqRPfu3QGYNm0azz//PLfffjtgBBmAQYMG8eGHHx51X80p+O4UPG5wFEv1kRDNpLlSZ0+cOJHly5ezZs0aKisrGTRoEL/++itPPvkky5cvZ/369Vx44YX1psw+lunTp/Pcc8+xYcMGHnrooePeT7XqFN2tLT138AUFR7HxLNVHQjSL5kqdHRkZyahRo7juuuv8DcylpaVEREQQExNDbm6uv3qpPsOHD2fBggXY7XbKyspqlaWsrIzU1FRcLhdvv/22f3lUVBRlZWVH7KtHjx5kZmayc+dOAN58801GjBhx1O9vDYIvKMhoZiGaVXOmzp46dSrr1q3zB4UBAwaQkZFBz549+c1vfsOwYcOO+vnTTjuNyZMnM2DAAC644AKGDBniX/eXv/yF008/nWHDhtVqFJ4yZQr/+Mc/yMjIYNeuXf7loaGhvP7661xxxRX069cPk8lUq7G9tQpY6uxAGTx4sK7uW3xc9vwIr4+Dqz+ErmOarmBCtFKSOjv4tNbU2a2TJMMTQoh6BV9QkLTZQghRryAMCjLBjhBC1Cf4goK9EMw2CIlo6ZIIIUSrE3xBoXo0s1ItXRIhhGh1gjAoFEnVkRBC1CMIg4LkPRKiuSmluPrqq/3v3W43SUlJXHTRRY3aT8eOHcnPz2/UNh6Ph4yMjDq/65ZbbmHgwIH07t2bsLAwBg4cyMCBA3n//fcbVJ76Um6fzIIv95G9EJKlz7YQzSkiIoKNGzdit9sJCwtj6dKlpKWlNct3P/vss/Tq1YvS0tIj1j3//POAka31oosuYu3atbXWu91uLJb6T5OLFy+ud93JKviCQqWkzRbB6+8//52thVubdJ8943vyp6F/OuZ248eP59NPP+Xyyy/n3XffZerUqf5UF4WFhVx33XXs3r2b8PBw5syZQ//+/SkoKGDq1KlkZ2dz5pln1sqL9NZbbzF79mycTienn346//73vzGbzbW+Mysri08//ZT777+fp59+ukHHs2LFCh544AHi4uLYunUr27dv55JLLmHfvn04HA5uu+02brzxRuBQyu3y8nIuuOACzj77bH744QfS0tL4+OOPCQsLa+ifsdUIruojr9e4U5A2BSGa3ZQpU5g3bx4Oh4P169dz+umn+9c99NBDZGRksH79ev72t7/x29/+FoCHH36Ys88+m02bNjFp0iT27t0LGCN233vvPb7//nvWrl2L2WyulY+o2u23384TTzyBydS4U92aNWt49tln2b59OwCvvfYaq1evZtWqVcyePZuCgoIjPrNjxw5uueUWNm3aRGxsLB988EGjvrO1CK47haoS0F5pUxBBqyFX9IHSv39/MjMzeffddxk/fnytdd99953/JDp69GgKCgooLS3lm2++8aeVvvDCC4mLM2ZMXL58OatXr/bnJrLb7SQnJ9fa5yeffEJycjKDBg1ixYoVjSrr0KFD6dSpk//97Nmz+eijjwDYt28fO3bsICGhdo1Dp06dGDhwIGCkw87MzGzUd7YWwRUUJBmeEC1qwoQJ3HXXXaxYsaLOq+2G0lozbdo0HnvssXq3+f7771m4cCGLFy/G4XBQWlrK1VdfzVtvvXXM/UdEHBrHtGLFCpYtW8aPP/5IeHg4I0eOrDNtdnUqbDDSYdvt9kYeVesQXNVHMppZiBZ13XXX8dBDD9GvX79ay8855xx/9c+KFStITEwkOjqa4cOH+yfe+eyzzygqKgJgzJgxvP/++xw8eBAw2iT27NlTa5+PPfYYWVlZZGZmMm/ePEaPHt2ggHC4kpIS4uLiCA8PZ+vWrfz000+N3sfJJLjuFOxypyBES0pPT+fWW289YvmsWbO47rrr6N+/P+Hh4cydOxcw2hqmTp1Knz59OOuss2jfvj0AvXv35tFHH2Xs2LF4vV6sVivPP/88HTp0aPIyjxs3jhdffJFevXrRo0cPzjjjjCb/jtYkuFJnr30HFsyAW3+B+M5NWzAhWilJnR18JHV2Q0n1kRBCHFWQBYUCUGYIjWnpkgghRKsUXEHBXijJ8IQQ4iiCKyjIaGYhhDiq4AsK0p4ghBD1Cq6gUF19JIQQok4BDQpKqXFKqW1KqZ1KqXuOst1lSimtlDpmd6kTImmzhWgRrTV19ty5c5k6dWqtZfn5+SQlJVFVVVXn/t944w1mzpwJwIsvvsh//vOfI7bJzMykb9++Ry1nZmamf2AewKpVq+ocw9HcAhYUlFJm4HngAqA3MFUp1buO7aKA24D/BaosAGgt1UdCtJCaqbOBFkmdXZdJkyaxdOlSKisr/cvef/99Lr744lppK+pz0003+ZP3NdbhQWHw4MHMnj37uPbVlAI5onkosFNrvRtAKTUPmAhsPmy7vwB/B+4OYFnAWQ5el9wpiKB24G9/o2pL06bOtvXqSZv77jvmdq0xdXZ0dDQjRoxg0aJFTJ48GYB58+Zx//33s2jRIh599FGcTicJCQm8/fbbpKSk1Pr8rFmziIyM5K677mL16tVcd911AIwdO9a/TWZmJtdccw0VFRUAPPfcc5x11lncc889bNmyhYEDBzJt2jQyMjJ48skn+eSTT+r9e8yaNYu9e/eye/du9u7dy+23397kdxeBrD5KA/bVeJ/lW+anlDoNaKe1/vRoO1JK3aiUWqWUWpWXl3d8pan0Jd+S3kdCtIjWmjp76tSpzJs3D4D9+/ezfft2Ro8ezdlnn81PP/3EL7/8wpQpU3jiiSeOenzXXnst//rXv1i3bl2t5cnJySxdupQ1a9bw3nvv+U/ijz/+OOeccw5r167ljjvuqPWZ+v4eAFu3bmXJkiX8/PPPPPzww7hcrqOWq7FaLPeRUsoEPA1MP9a2Wus5wBww0lwc1xfKaGYhGnRFHyitNXX2hRdeyM0330xpaSnz58/nsssuw2w2k5WVxeTJk8nJycHpdNZKpX244uJiiouLGT58OADXXHMNn332GQAul4uZM2f6g1f1HA1HU9/fo7q8NpsNm81GcnIyubm5pKenH3OfDRXIoJANtKvxPt23rFoU0BdYoYzBZG2AhUqpCVrr40xudBSSDE+IFtcaU2eHhYUxbtw4PvroI+bNm+evZvrDH/7AnXfeyYQJE1ixYgWzZs06rrI+88wzpKSksG7dOrxeL6Ghoce1n2qHp+h2u90ntL/DBbL6aCXQTSnVSSkVAkwBFlav1FqXaK0TtdYdtdYdgZ+AwAQEqDGXgtwpCNFSWmvq7KlTp/L000+Tm5vLmWeeCRgps6sbw6uzttYnNjaW2NhYvvvuO4BaVVklJSWkpqZiMpl488038Xg8AERFRVFWVlbn/ur7ezSHgAUFrbUbmAksAbYA87XWm5RSjyilJgTqe+sl1UdCtLijpc5evXo1/fv355577qmVOvubb76hT58+fPjhh3Wmzu7fvz/nnXceOTk5x12u8847j/379zN58mR8NRfMmjWLK664gkGDBpGYmHjMfbz++uvccsstDBw4sFaD+M0338zcuXMZMGAAW7du9U/g079/f8xmMwMGDOCZZ55p0N+jOQRP6uytnxqps6/8D5jMx95eiFOEpM4OPieSOjt4JtnpeaHxEEIIUa/gSnMhhBDiqCQoCBEETrZqYnH8TvS3lqAgxCkuNDSUgoICCQxBQGtNQUHBCXV7DZ42BSGCVHp6OllZWRx3NgBxUgkNDT2hwWwSFIQ4xVmt1qOOxhWiJqk+EkII4SdBQQghhJ8EBSGEEH4n3YhmpVQesOeYG9YtETj6tE2ntmA+/mA+dgju45djN3TQWicd6wMnXVA4EUqpVQ0Z5n2qCubjD+Zjh+A+fjn2xh27VB8JIYTwk6AghBDCL9iCwpyWLkALC+bjD+Zjh+A+fjn2RgiqNgUhhBBHF2x3CkIIIY5CgoIQQgi/oAkKSqlxSqltSqmdSql7Wro8zUkplamU2qCUWquUCswc2K2IUuo1pdRBpdTGGsvilVJLlVI7fM9xLVnGQKnn2GcppbJ9v/9apdT4lixjoCil2imlvlJKbVZKbVJK3eZbHiy/fX3H36jfPyjaFJRSZmA7cB6QBawEpmqtN7dowZqJUioTGKy1DooBPEqp4UA58B+tdV/fsieAQq31476Lgjit9Z9aspyBUM+xzwLKtdZPtmTZAk0plQqkaq3XKKWigNXAJcB0guO3r+/4r6QRv3+w3CkMBXZqrXdrrZ3APGBiC5dJBIjW+hug8LDFE4Hq2c/nYvxjOeXUc+xBQWudo7Ve43tdBmwB0gie376+42+UYAkKacC+Gu+zOI4/1klMA18opVYrpW5s6cK0kBStdY7v9QEgpSUL0wJmKqXW+6qXTsnqk5qUUh2BDOB/BOFvf9jxQyN+/2AJCsHubK31acAFwC2+KoagpY0601O/3vSQF4AuwEAgB3iqRUsTYEqpSOAD4HatdWnNdcHw29dx/I36/YMlKGQD7Wq8T/ctCwpa62zf80HgI4zqtGCT66tzra57PdjC5Wk2WutcrbVHa+0FXuYU/v2VUlaME+LbWusPfYuD5rev6/gb+/sHS1BYCXRTSnVSSoUAU4CFLVymZqGUivA1OqGUigDGAhuP/qlT0kJgmu/1NODjFixLs6o+IfpM4hT9/ZVSCngV2KK1frrGqqD47es7/sb+/kHR+wjA1w3rn4AZeE1r/deWLVHzUEp1xrg7AGP61XdO9WNXSr0LjMRIG5wLPAQsAOYD7TFSr1+ptT7lGmTrOfaRGFUHGsgEfl+jjv2UoZQ6G/gW2AB4fYvvw6hXD4bfvr7jn0ojfv+gCQpCCCGOLViqj4QQQjSABAUhhBB+EhSEEEL4SVAQQgjhJ0FBCCGEnwQFIXyUUp4amSTXNmU2XaVUx5qZS4VorSwtXQAhWhG71npgSxdCiJYkdwpCHINvPoonfHNS/KyU6upb3lEp9aUv0dhypVR73/IUpdRHSql1vsdZvl2ZlVIv+3Ldf6GUCvNtf6svB/56pdS8FjpMIQAJCkLUFHZY9dHkGutKtNb9gOcwRsYD/AuYq7XuD7wNzPYtnw18rbUeAJwGbPIt7wY8r7XuAxQDl/mW3wNk+PZzU2AOTYiGkRHNQvgopcq11pF1LM8ERmutd/sSjh3QWicopfIxJjVx+ZbnaK0TlVJ5QLrWuqrGPjoCS7XW3Xzv/wRYtdaPKqU+x5gYZwGwQGtdHuBDFaJecqcgRMPoel43RlWN1x4OteldCDyPcVexUiklbX2ixUhQEKJhJtd4/tH3+geMjLsAV2EkIwNYDswAYypYpVRMfTtVSpmAdlrrr4A/ATHAEXcrQjQXuSIR4pAwpdTaGu8/11pXd0uNU0qtx7jan+pb9gfgdaXU3UAecK1v+W3AHKXU9Rh3BDMwJjepixl4yxc4FDBba13cRMcjRKNJm4IQx+BrUxistc5v6bIIEWhSfSSEEMJP7hSEEEL4yZ2CEEIIPwkKQggh/CQoCCGE8JOgIIQQwk+CghBCCL//B0HUFQYPdg3MAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.17795944213867188 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "plt.plot(history.history['accuracy'])\n",
+    "plt.plot(history.history['val_accuracy'])\n",
+    "plt.plot(history4.history['accuracy'])\n",
+    "plt.plot(history4.history['val_accuracy'])\n",
+    "plt.title(\"Model Loss\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Loss')\n",
+    "plt.legend(['CNN Train', 'CNN Validation', 'Model4 Train', 'Model4 Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "serious-inspection",
+   "metadata": {
+    "papermill": {
+     "duration": 1.38556,
+     "end_time": "2021-04-25T15:07:40.934374",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:39.548814",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6.10 Model 2 (Resnet) v/s Model 4 (Simple Neural Network)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "caring-omega",
+   "metadata": {
+    "papermill": {
+     "duration": 1.477683,
+     "end_time": "2021-04-25T15:07:43.824354",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:42.346671",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Loss v/s no. of epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "banned-steps",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:07:47.410067Z",
+     "iopub.status.busy": "2021-04-25T15:07:47.387751Z",
+     "iopub.status.idle": "2021-04-25T15:07:47.527265Z",
+     "shell.execute_reply": "2021-04-25T15:07:47.527888Z"
+    },
+    "papermill": {
+     "duration": 1.849164,
+     "end_time": "2021-04-25T15:07:47.528096",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:45.678932",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAEWCAYAAABi5jCmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAABSlElEQVR4nO3dd3xUVdrA8d+Zkt4bBAKEUEzoTZqAFFFExS6iKFbWvq7vuqtbbFt0XfvqiogKCoJYcO2dgEoRkCIlVAOkkN77zJz3jzsJSUhICJlMknm+u/OZO7fNuRmZZ065z1Faa4QQQohqJncXQAghRPsigUEIIUQdEhiEEELUIYFBCCFEHRIYhBBC1CGBQQghRB0SGIRoglIqVimllVKWZux7g1Lqh7YolxCuIoFBdCpKqWSlVKVSKqLe+q3OL/dYNxXtlAKMEO4kgUF0Rr8Cc6pfKKUGA37uK44QHYsEBtEZvQVcX+v1PODN2jsopYKVUm8qpbKUUoeVUn9RSpmc28xKqaeUUtlKqUPABQ0c+5pSKl0plaqU+rtSynw6BVZKdVNKfaSUylVKHVBK3Vpr22il1GalVKFSKkMp9YxzvY9SaqlSKkcpla+U2qSU6nI65RACJDCIzmkDEKSUSnB+YV8NLK23z3+AYCAOOBsjkNzo3HYrcCEwHBgFXFHv2MWADejr3Odc4JbTLPMKIAXo5ny/fyqlpjq3PQ88r7UOAvoAK53r5zmvoQcQDtwGlJ1mOYSQwCA6repaw3RgD5BavaFWsHhQa12ktU4Gngauc+5yFfCc1vqo1joXeLzWsV2AmcC9WusSrXUm8KzzfC2ilOoBnAX8UWtdrrXeBizieK2nCuirlIrQWhdrrTfUWh8O9NVa27XWW7TWhS0thxDVJDCIzuot4BrgBuo1IwERgBU4XGvdYaC7c7kbcLTetmq9nMemO5tv8oFXgKjTKGs3IFdrXdRIeW4G+gNJzuaiC53r3wK+BFYopdKUUk8qpaynUQ4hAAkMopPSWh/G6ISeCXxQb3M2xq/tXrXW9eR4rSIdo3mm9rZqR4EKIEJrHeJ8BGmtB55GcdOAMKVUYEPl0Vrv11rPwQg+/wLeU0r5a62rtNaPaq0HAOMxmr+uR4jTJIFBdGY3A1O11iW1V2qt7Rjt9P9QSgUqpXoB93G8H2IlcI9SKkYpFQo8UOvYdOAr4GmlVJBSyqSU6qOUOvsUyuXt7Dj2UUr5YASAdcDjznVDnGVfCqCUmquUitRaO4B85zkcSqkpSqnBzqaxQoxg5ziFcgjRIAkMotPSWh/UWm9uZPPdQAlwCPgBeBt43bntVYwmmu3Az5xY47ge8AJ2A3nAe0D0KRStGKOTuPoxFWN4bSxG7WEV8LDW+hvn/jOAXUqpYoyO6Ku11mVAV+d7F2L0o6zBaF4S4rQomahHCCFEbVJjEEIIUYcEBiGEEHVIYBBCCFGHBAYhhBB1dLgsjxERETo2NtbdxRBCiA5ly5Yt2VrryObs2+ECQ2xsLJs3NzYCUQghREOUUoeb3ssgTUlCCCHqkMAghBCiDgkMQggh6uhwfQxCiFNTVVVFSkoK5eXl7i6KaAM+Pj7ExMRgtbY80a4EBiE6uZSUFAIDA4mNjUUp5e7iCBfSWpOTk0NKSgq9e/du8XmkKUmITq68vJzw8HAJCh5AKUV4ePhp1w4lMAjhASQoeI7W+Kw9JjDsPVbE45/tobjC5u6iCCFEu+YxgeFobimvrD3E3mMyJa4Qbc1sNjNs2DAGDRrERRddRH5+fpu873PPPUdpaekJ6y+99FKGDRtG3759CQ4OZtiwYQwbNox169Y167zjx49v7aK2Kx4TGBK6BQGwJ72oiT2FEK3N19eXbdu2sXPnTsLCwnjppZfa5H0bCwyrVq1i27ZtLFq0iIkTJ7Jt2za2bdtW84Vvs528ZaG5AaSj8pjA0C3YhyAfC3vSpcYghDuNGzeO1FRjeu2DBw8yY8YMRo4cycSJE0lKSgLg3XffZdCgQQwdOpRJkyYBsHjxYi677DJmzJhBv379+MMf/lBzzq+++opx48YxYsQIrrzySoqLi3nhhRdIS0tjypQpTJkypclyLV68mFmzZjF16lSmTZtGcXEx06ZNY8SIEQwePJj//e9/NfsGBAQAkJiYyOTJk7niiiuIj4/n2muvpTNMfuYxw1WVUsRHB0lgEB7t0Y93sTutdf8NDOgWxMMXDWzWvna7nW+//Zabb74ZgPnz57NgwQL69evHxo0bueOOO/juu+947LHH+PLLL+nevXudZqdt27axdetWvL29OeOMM7j77rvx9fXl73//O9988w3+/v7861//4plnnuGhhx7imWeeYfXq1URERDSrfD///DM7duwgLCwMm83GqlWrCAoKIjs7m7FjxzJr1qwTOne3bt3Krl276NatG2eddRY//vgjEyZMaN4fr53ymMAAMCA6iHc3H8Xh0JhMMkpDiLZSVlbGsGHDSE1NJSEhgenTp1NcXMy6deu48sora/arqKgA4KyzzuKGG27gqquu4rLLLqvZPm3aNIKDgwEYMGAAhw8fJj8/n927d3PWWWcBUFlZybhx41pUzunTpxMWFgYY9wT86U9/Yu3atZhMJlJTU8nIyKBr1651jhk9ejQxMTEADBs2jOTkZAkMHUlCdCAllXaO5pXSK9zf3cURos0195d9a6vuYygtLeW8887jpZde4oYbbiAkJIRt27adsP+CBQvYuHEjn376KSNHjmTLli0AeHt71+xjNpux2WxorZk+fTrLly8/7XL6+x//Xli2bBlZWVls2bIFq9VKbGxsg/cHNFSmjs5j+hgAEqKrO6ClOUkId/Dz8+OFF17g6aefxs/Pj969e/Puu+8Cxi/07du3A0bfw5gxY3jssceIjIzk6NGjjZ5z7Nix/Pjjjxw4cACAkpIS9u3bB0BgYCBFRS0bcFJQUEBUVBRWq5XVq1dz+HCzs1Z3eB4VGPp3CcSkYLeMTBLCbYYPH86QIUNYvnw5y5Yt47XXXmPo0KEMHDiwpoP3/vvvZ/DgwQwaNIjx48czdOjQRs8XGRnJ4sWLmTNnDkOGDGHcuHE1ndjz589nxowZzep8ru/aa69l8+bNDB48mDfffJP4+PiWXXAHpDpaD/qoUaP06UzUM+3pRPpEBrDw+lGtWCoh2q89e/aQkJDg7mKINtTQZ66U2qK1btYXn0fVGMBoTtojN7kJIUSjPDIwHM0to6i8yt1FEUKIdskDA0MgAEnHpJ9BCCEa4oGBwRiZlCQjk4QQokEeFxi6BvkQ4meVkUlCCNEIjwsMSiniuwbKvQxCCNEIjwsMYDQn7T1WhMPRsYbqCtFRtbe0248++igPPvhgnXXbtm076bDeRx55hKeeegqAhx56iG+++eaEfRITE7nwwgtPWqZt27bx2Wef1bz+6KOPeOKJJ056TFvz2MBQVmXncO6J/8EIIVpfe0u7PWfOHN55550661asWMGcOXOadd7HHnuMc845p0Vlqh8YZs2axQMPPNCic7mKZwaGrpIaQwh3aQ9pt/v3709oaCgbN26sWbdy5UrmzJnDq6++yplnnsnQoUO5/PLLGwwsN9xwA++99x4AX3zxBfHx8YwYMYIPPvigZp+ffvqJcePGMXz4cMaPH8/evXuprKzkoYce4p133mHYsGG88847LF68mLvuuguA5ORkpk6dypAhQ5g2bRpHjhypeb977rmH8ePHExcXV/PeruJRSfSq9esSgNmk2JNeyMzB0e4ujhBt5/MH4NgvrXvOroPh/OY1hbSntNtz5sxhxYoVjBkzhg0bNhAWFka/fv0ICwvj1ltvBeAvf/kLr732GnfffXeD11NeXs6tt97Kd999R9++fZk9e3bNtvj4eL7//nssFgvffPMNf/rTn3j//fd57LHH2Lx5My+++CJgBLxqd999N/PmzWPevHm8/vrr3HPPPXz44YcApKen88MPP5CUlMSsWbO44oormvU3bwmPDAw+VjNxEf4ym5sQbaQ9pt2ePXs248eP5+mnn67TjLRz507+8pe/kJ+fT3FxMeedd16j50hKSqJ3797069cPgLlz57Jw4ULASMI3b9489u/fj1KKqqqmb6pdv359Ta3juuuuq1MruuSSSzCZTAwYMICMjIwmz3U6XBYYlFKvAxcCmVrrQQ1svxb4I6CAIuB2rfV2V5WnvvjoIH4+nNdWbydE+9DMX/atrT2m3e7Rowe9e/dmzZo1vP/++6xfvx4wmm0+/PBDhg4dyuLFi0lMTGzRNf/1r39lypQprFq1iuTkZCZPntyi81Srfe2uznHnyj6GxcCMk2z/FThbaz0Y+Buw0IVlOUFCdCCp+WUUlElqDCHaSntLuz1nzhx+97vfERcXVzPZTlFREdHR0VRVVbFs2bKTXk98fDzJyckcPHgQoE5wKigooHv37kDd5qKTlWn8+PGsWLECMOaDmDhx4knf31VcFhi01muB3JNsX6e1rv7JvgGIcVVZGlJ9B/ReSY0hRJtqT2m3r7zySnbt2lVnNNLf/vY3xowZw1lnndVkqm0fHx8WLlzIBRdcwIgRI4iKiqrZ9oc//IEHH3yQ4cOH15m8Z8qUKezevbum87m2//znP7zxxhsMGTKEt956i+eff/6k7+8qLk27rZSKBT5pqCmp3n6/B+K11rc0sn0+MB+gZ8+eI1tjwoyMwnLG/PNbHp01kHnjY0/7fEK0V5J22/N0+LTbSqkpwM0Y/Q0N0lov1FqP0lqPioyMbJX3jQr0JtTPKkNWhRCiHreOSlJKDQEWAedrrXPa+L2NuRkkMAghRB1uqzEopXoCHwDXaa33uaMMCdFB7M0owi6pMYQQooYrh6suByYDEUqpFOBhwAqgtV4APASEA/9VSgHYmtv+1VriuwZSXuUgOaeEPpEBbfnWQgjRbrksMGitT5p0xNnR3GBnc1upHpm0J71QAoMQQji5vfPZnfp1CcDiTI0hhBDC4NGBwdtipk9kAEmSGkMIl1JKMXfu3JrXNpuNyMjIJlNU1xcbG0t2dvYp7WO32xk+fHiD73XnnXcybNgwBgwYgK+vL8OGDWPYsGHNTlI3c+bMNksh3pY8MldSbfHRgWz6tdH78IQQrcDf35+dO3dSVlaGr68vX3/9dc1dwa72/PPPk5CQQGHhiS0D1em/k5OTufDCC09Iz2Gz2bBYGv+arJ0+uzPx6BoDGP0MaQXl5JdWursoQnRqM2fO5NNPPwWM1BG17zbOzc3lkksuYciQIYwdO5YdO3YAkJOTw7nnnsvAgQO55ZZb6uQIWrp0KaNHj2bYsGH85je/wW63n/CeKSkpfPrpp9xyS/O7MxMTE5k4cSKzZs1iwIABgJHAbuTIkQwcOLAmSR4cr50kJyeTkJDArbfeysCBAzn33HMpKys7tT9QO+I5NYasvbBtGUz+E1h9alZXd0AnHStibFy4u0onRJv410//Iik3qVXPGR8Wzx9HN3p/ao2rr76axx57jAsvvJAdO3Zw00038f333wPw8MMPM3z4cD788EO+++47rr/+erZt28ajjz7KhAkTeOihh/j000957bXXAOPO3nfeeYcff/wRq9XKHXfcwbJly7j++uvrvOe9997Lk08+edJ8SQ35+eef2blzJ7179wbg9ddfJywsjLKyMs4880wuv/xywsPrfl/s37+f5cuX8+qrr3LVVVfx/vvv12k+60g8JzDk/go/Pg99pkHc2TWrE7oGAsbIJAkMQrjOkCFDSE5OZvny5cycObPOth9++IH3338fgKlTp5KTk0NhYSFr166tSUN9wQUXEBoaCsC3337Lli1bOPPMMwEjrXftPEUAn3zyCVFRUYwcOfKUM6SOHj26JigAvPDCC6xatQqAo0ePsn///hMCQ+/evRk2bBgAI0eOJDk5+ZTesz3xnMAQexaYLHAosU5giAz0JtzfS0YmCY/QnF/2rjRr1ix+//vfk5iYSE5Oy5MdaK2ZN28ejz/+eKP7/Pjjj3z00Ud89tlnlJeXU1hYyNy5c1m6dGmT5/f3969ZTkxM5JtvvmH9+vX4+fkxefJkysvLTzimfkrwjtyU5Dl9DN6BEHMmHFpdZ/Xx1BgyMkkIV7vpppt4+OGHGTx4cJ31EydOrElxnZiYSEREBEFBQUyaNIm3334bgM8//5y8PCMh87Rp03jvvffIzMwEjD6K+sk1H3/8cVJSUkhOTmbFihVMnTq1WUGhvoKCAkJDQ/Hz8yMpKYkNGzac8jk6Gs8JDABxkyFtG5TWHYWUEB3IvowibHaHW4olhKeIiYnhnnvuOWH9I488wpYtWxgyZAgPPPAAS5YsAYy+h7Vr1zJw4EA++OADevbsCRizt/3973/n3HPPZciQIUyfPp309HSXlHnGjBnYbDYSEhJ44IEHGDt2rEvepz1xadptVxg1apTevHlzyw4+shFePxeuehMGXFyz+v0tKfzfu9v55r5J9I0KbKWSCtE+SNptz9Ph0263qe4jwCsQDtZtTqoembRbmpOEEMLDAoPZCrETjA7oWvpGGakxkqQDWgghPCwwAPSZAnm/Ql5yzSovi4m+UQEyMkkIIfDEwBA32XiuV2uQkUlCCGHwvMAQ0R8CuzXQzxDIscJy8kokNYYQwrN5XmBQyqg1/LoGHMeHp9bMzXBMmpOEEJ7N8wIDGIGhLA+O7ahZFd+1etIeaU4SorW117TbS5YsqZPMDyA7O5vIyEgqKioaPP/ixYu56667AFiwYAFvvvnmCfskJyczaNCgk5YzOTm55uY9gM2bNzd4j4c7eG5ggDp3QUcGehMR4C0d0EK4QO2024Bb0m435NJLL+Xrr7+mtLS0Zt17773HRRddVCfFRWNuu+22ExL3NVf9wDBq1CheeOGFFp2rtXlmYAjsAlEDGuiADpTAIISLtMe020FBQZx99tl8/PHHNetWrFjBnDlz+PjjjxkzZgzDhw/nnHPOISMj44TjH3nkEZ566ikAtmzZwtChQxk6dGjNPA9gBICJEycyYsQIRowYwbp16wB44IEH+P777xk2bBjPPvssiYmJNbWaxv4ejzzyCDfddBOTJ08mLi7OZYHEc5Lo1Rc3BTYtgqoysPoCRj/D4h+TsdkdWMyeGTNF53bsn/+kYk/rpt32Toin65/+1OR+7TXt9pw5c1i2bBmzZ88mLS2Nffv2MXXqVAoLC9mwYQNKKRYtWsSTTz7J008/3eh5brzxRl588UUmTZrE/fffX7M+KiqKr7/+Gh8fH/bv38+cOXPYvHkzTzzxBE899RSffPIJQJ0MsI39PQCSkpJYvXo1RUVFnHHGGdx+++1YrdYm//6nwoMDw2TY8BIc2WDc24BRY6i0OziUXUL/LpIaQ4jW1F7Tbl9wwQXccccdFBYWsnLlSi6//HLMZjMpKSnMnj2b9PR0Kisr66Thri8/P5/8/HwmTZoEwHXXXcfnn38OQFVVFXfddRfbtm3DbDazb9++Jv9Wjf09qsvr7e2Nt7c3UVFRZGRkEBMT0+Q5T4XnBoZe48FkNZqTagJDdQd0oQQG0Sk155e9K7XHtNu+vr7MmDGDVatWsWLFCp555hkA7r77bu677z5mzZpFYmIijzzySIvK+uyzz9KlSxe2b9+Ow+HAx8en6YNOon56b5vNdlrna4jntpd4B0CP0XU6oOMiArCalYxMEsJF2mva7Tlz5vDMM8+QkZHBuHHjACPddnUHeXW218aEhIQQEhLCDz/8AFBzLdXniY6OxmQy8dZbb9X0hQQGBjbaxNXY36OteG5gAKM5KX0HlBi/XIzUGNIBLYSrtNe029OnTyctLY3Zs2ejlKop05VXXsnIkSOJiIho8hxvvPEGd955J8OGDavTSX7HHXewZMkShg4dSlJSUs0kQEOGDMFsNjN06FCeffbZZv092orL0m4rpV4HLgQytdYnDOhVxl//eWAmUArcoLX+uanznlba7fqOboLXzoEr3oBBlwFw38pt/LA/m5/+fE7rvIcQbiZptz1Pe067vRiYcZLt5wP9nI/5wMsuLEvDug0H7+A6w1YHRAeRWVRBTnHDN7cIIURn57LAoLVeC+SeZJeLgTe1YQMQopSKdlV5GmS2QO+JdQJD9R3QScekn0EI4Znc2cfQHTha63WKc90JlFLzlVKblVKbs7KyWrcUcZMh/zDkHgKMIauA9DOITqWjzdQoWq41PusO0fmstV6otR6ltR4VGRnZuievl4Y7PMCbqEBvdktgEJ2Ej48POTk5Ehw8gNaanJyc0x4S6877GFKBHrVexzjXta3wvhAUY6ThHnUTAPHRQSTJkFXRScTExJCSkkKr17ZFu+Tj43PaN7y5MzB8BNyllFoBjAEKtNYtH2/WUtVpuJM+AYcdTGYSogN542AOVXYHVkmNITo4q9V60rt2hajPZd96SqnlwHrgDKVUilLqZqXUbUqp25y7fAYcAg4ArwJ3uKosTeozBcrzIX07YIxMqrQ7OJhV7LYiCSGEu7isxqC1ntPEdg3c6ar3r6/SXsn3qd8ztcfUmhtYavQ28ptwaDV0H1EnNUb1KCUhhPAUHtNO8smhT7h39b38nNnAPXQBUdBlUE0HdO8If7zMJulnEEJ4JI8JDOf3Pp8gryCW7m44Vwpxk41Mq5WlWM0m+nUJkJFJQgiP5DGBwdfiyxX9r+C7o9+RWtzA4Ke4KWCvhCPrASPTqiTTE0J4Io8JDABz4uegUKxIWnHixl7jwOxVk201vmsg2cUVZBVJagwhhGfxqMDQ1b8r5/Q6h/f3vU9pVWndjV7+0GNMTT/DgOjq1BjSnCSE8CweFRgA5ibMpaiqiI8OfnTixriz4dgvUJJdZ2SSEEJ4Eo8LDEMjhzIwfCDL9izDoR11N8ZNNZ4PJRLq70XXIB/pZxBCeByPCwxKKeYOmEtyYTI/pv5Yd2O3YeBzPA13fHQg24/mS44ZIYRH8bjAAHBer/OI9I1k2Z5ldTeYzMbNbocSQWvOHdCVQ9klbErOc0s5hRDCHTwyMFjNVmafMZsf037kUP6huhvjJkPBUcg9xCXDuxHsa2XJumR3FFMIIdzCIwMDwJVnXImXyevEWkPcFOP50Gr8vCzMPrMHX+w6Rlp+WdsXUggh3MBjA0OYTxgz42by8aGPKagoqLUhDoJ7Gmm4gevG9kJrzbKNh91UUiGEaFseGxjAGLpaZivjg/0fHF+plDFs9dfvwWGnR5gf0xK6sPyno5RX2d1XWCGEaCMeHRjOCDuDM7ueydtJb2Nz2I5v6DMFKgogbSsAN4yPJbekko+3p7mppEII0XY8OjAAXJtwLcdKjvHdke+Or+x9tvHsTI8xvk84/aICWLwuWYauCiE6PY8PDJNjJtM9oHvdTmj/COg6BA6tAYx7H+aNj2VXWiFbDsvQVSFE5+bxgcFsMnNN/DX8nPkzu3J2Hd9Qk4a7BIDLRnQn0MfC4oaGrpblG53Va5+CldfD/m/aouhCCOESHh8YAC7tdyl+Fj+W7a5Va4ibDI4qOGyk4fbzsjB7VA++2ZlC9t4N8NOrsOo2ePFM+FcveOsS+O5vRlBY9RsoyXbLtQghxOly2dSeHUmgVyCX9L2ElftW8ruRvyPSLxJ6jQezN+z6AMryIHUL96f8xP3WHXgvrzIO9I+E7qNgyFXQfSR0Gw6F6fDKJPj8j3DFa+69MCGEaAEJDE7XJFzD8qTlrNy3kjuH3QlWX+g5FrYtMx5WP7yjh/Fl8CV8V9yDR++Yh094L2N4a22+oTDpfkj8Jwy6HOJnuueChBCihSQwOPUK6sWkmEms3LuSWwbfgrfZG2b+G45uNGoCkQlgtuC/P5t3XtvI6MMWLo9QDZ9swu9gz0fwye+MmodvSJteixBCnA7pY6jl2oRryS3P5fNfPzdWRJ4BI66HroPBbMTQs/qG07epoasWL7j4RSjJgq/+3EalF0KI1iGBoZax0WPpG9KXZXuWNfqlr5Ri3rhe/JJawM9H8hs/WbfhcNZvYetSOPCtawoshBAuIIGhFqUU1yZcS1JuElsytjS632UjYgj0tjSddfXsP0JEf/j4XqiQCX+EEB2DBIZ6Loi7gGDvYJbuWdroPv7eFq4c1YPPfkkno7C88ZNZfWDWi0Ya728edUFphRCi9bk0MCilZiil9iqlDiilHmhge0+l1Gql1Fal1A6llNuH8PhafLmy/5WsPrqa1OLURve7flwv7FqzbOORk5+w5xgYeztsehWSfzz5vkII0Q64LDAopczAS8D5wABgjlJqQL3d/gKs1FoPB64G/uuq8pyK2WfMRqFYvmd5o/vERvgz5Ywo3t54mApbE1lXp/4FQmPho7ugsrR1CyuEEK3MlTWG0cABrfUhrXUlsAK4uN4+GghyLgcDLktfWnnkCCl33429qOm2/q7+XZneazof7P+A0qrGv8hvGB9LdnEln/2SfvITevnDRS9A7iHj/gYhhGjHXBkYugNHa71Oca6r7RFgrlIqBfgMuLuhEyml5iulNiulNmdlZbWoMJWHj1CUuIaj83+Do6Skyf3nDphLUVUR/zv4v0b3mdA3grhIfxb/mNx0AeLOhpE3wvqXIKXxjm0hhHC3ZgUGpZS/UsrkXO6vlJqllLK2wvvPARZrrWOAmcBb1e9Tm9Z6odZ6lNZ6VGRkZIveKGDiBLo/9RRl27dz9M67cJSfpNMYGBo5lMERg1m4YyH78/Y3uI/JpLhhfCzbUwrYeqQZWVenPwaB0fC/O8FW0ZLLEEIIl2tujWEt4KOU6g58BVwHLG7imFSgR63XMc51td0MrATQWq8HfICIZpbplAWddy7dnnic0o0bSfntb9GVlSfd/9Hxj6JQzPtiHpuPbW5wn8tGxBDQnKGrAD5BcNHzkLXHyMQqhBDtUHMDg9JalwKXAf/VWl8JDGzimE1AP6VUb6WUF0bn8kf19jkCTANQSiVgBIaWtRU1U/CsWXR95BFK1qwl9ff3o222RvftF9qPt2a+RbhPOL/5+jd8e/jEG9UCvC1cMTKGT39JJ7Po5LUQ46TTYegc+OEZSN9xOpcihBAu0ezAoJQaB1wLfOpcZz7ZAVprG3AX8CWwB2P00S6l1GNKqVnO3f4PuFUptR1YDtyg22CKtNDZV9HlwQco+uor0v/8Z7TD0ei+3QO68+b5bxIfFs99a+5j5d6VJ+wzb3wsVXbN200NXa123j/BN8xoUrJXtfQyhBDCJZobGO4FHgRWOb/c44DVTR2ktf5Ma91fa91Ha/0P57qHtNYfOZd3a63P0loP1VoP01p/1cLrOGVh8+YRee9vKfjfRxx79LGTTtkZ6hPKq+e+yoTuE/jbhr/x4tYX6+zfO8KfyWdEsmzjESptjQeZGn5hcMHTcGwHrHuhNS5HCCFaTbMCg9Z6jdZ6ltb6X87O4Wyt9T0uLpvLRdx2G+Hz55P/zjtkPvGvkwYHP6sfz095nkv7XsorO17hkfWPYHMcb4a6YXwsWUUVfL6ziaGr1QbMggGXQOITkLX3NK9ECNFhVBTBO9fBonOg2KUt5y3W3FFJbyulgpRS/sBOYLdS6n7XFq1tRP7uXkKvu47cJUvIeuHkv94tJguPjn+U+UPm88H+D7h39b2U2coAmNQvkt4R/rzRnKGr1Wb+G7wCnE1Kjfd1CCE6ibzD8Nq5kPQpHPsFFl9gTO7VzjS3KWmA1roQuAT4HOiNMTKpw1NK0eXBBwi+4nJyXl5A9sJXm9z/7uF38+cxf2Ztylpu+eoW8svzMZmMrKvbjuaz7Wh+8948IMoIDimbjKlBZTpQITqvIxvh1alQmApz3zcehamweCYUpLi7dHU0NzBYnfctXAJ8pLWuwrhruVNQJhPRjz5K0IUXkvXMM+S++VaTx1wdfzXPTH6GpJwkrvv8OtKK07h8pJF19ckvknA4mvnnGXwFXLLACA4LJ0PattO6FiFEO7T9HVhyoTFk/ZZvoc8UiJ0A160yfhC+cT7kJbu7lDWaGxheAZIBf2CtUqoXUOiqQrmDMpvp9vg/CThnGhn//Cf5773X5DHn9DqHhecuJKc8h7mfzSWt9BAPzkxg3cEclv3UzBFKAMPmwE1fGMuvnwfbV7TwKoQQ7YrDAd8+BqvmQ48xRlCI6Hd8e4/RMO8jKC+E18+H7APuK2stze18fkFr3V1rPVMbDgNTXFy2NqesVro/8wz+EyeS/teHKPj4kyaPGdllJEtmLEEpxQ1f3EDfnseY2C+Cxz/bw9HcU0iY1204zE+EmDNh1W/g8z/KUFYhOrLKEnj3evj+aRgxD+Z+YIxIrK/bcLjhU7BXGjWHzD1tX9Z6mtv5HKyUeqY6X5FS6mmM2kOnY/LyIuaF5/EbNYq0Bx6g8OuvmzymX2g/ls1cRpRfFLd9cxtnDv0Fk6mK+9/b3vwmJQD/CLjuQxh7J2xcAG9e0m5HLQghTqIwzfiST/oUznvcyHhg8Wp8/66D4MbPQJmMDmk33/za3Kak14Ei4CrnoxB4w1WFcjeTry8xL7+M76BBpN33fxT/2PQ8Cl39u/Lm+W8yOno0r+56noC+T7Il/0NeX3+KQ1HNFpjxT7jsVUjdDAvPhtSfW3glQog2l/ozLJwCOYdgzgoYdwco1fRxkWcYwcHiC0suglT3JdtsbmDoo7V+2JlC+5DW+lEgzpUFczdzgD89Fr6CV1wcKXfdTenWrU0eE+wdzIJzFrB4xmIGRZ6BT5fPeC7pRp796ZWTpu9u0JCr4OavQJnh9RmwdVkLr0SIU7RpEbw0FjYsgKoyd5emY9m1Ct6YadQObv4K+p93aseH9zGCg0+w0WJwZINLitmU5gaGMqXUhOoXSqmzgE7/X4w5OJiery3CEhXJ0d/cRnlSUrOOG9llJIvOW8QzE15FVXbj9T0vMuP9Gbz2y2unFiCihxr9Dj3HwP/ugM/ul34H4Tpaw5p/w6f/B+X58MUf4bkh8OPzUFHs7tK1b1rDmifh3RuMf7e3fAdd6s9L1kyhveDGz8E/Et66DH79vlWL2hyqOamJlFJDgTcxJtMByAPmaa3bvCFs1KhRevPmhjOdukpVairJ185FV1URu2wpXrGxzT525aajPPDZxwwcsIHk0q2EeIcwb+A85sTPwd/azG4auw2+eRjWvwg9x8NVS4x7IIRoLVrDl3+GDS8ZSR5nvQhHN8LaJ+FQIviGGn1fY+Ybv2bFcWV5xo+2X96FIVfDrBfA4n365y06Bm9ebAxjvXoZ9D3ntE6nlNqitR7VrH1PJWedUioIQGtdqJS6V2v9XMuK2HLuCAwAFYcOcXjudSgfb2KXLcMaHd2s47TW3Lh4ExsP5fLcvFA+TF7MD6k/EOwdzPUDruea+GsI8ApoXiF+eQ/+d5fxj3T2UogZeRpXJIST3QYf/xa2LYUxtxmdpaZajQlHN8Haf8P+L8E72AgOY+9oeISNJ8k+YAwS2fY2VJXAtIdgwn3N609orpJso0kpey9c9SaccX6LT+WywFDvTY5orXu26ODT4K7AAFC+ezeHr5+HJSKCXsuWYgkPb9Zx6QVlnPvsWhKig1hx61h25exkwY4FrE1ZS5BXEHMT5jK913T6hPRBNfUfVfoOeOdaKMuH23+EkDb/CERnYquA92+GPR/D2Q/A5Aca/2JL324EiD0fg9UfzrwZxt/dfmuvhWnww7NQnAH9zzfa+083mGkNv66BDS/Dvi/A7AWDr4Sxt0PXwa1T7vpKc2Hp5UbSzStehwH1Z0hunrYKDEe11j2a3rN1uTMwAJRu2cKRm2/Bq3dvei1ZjDkoqOmDgJWbj/KH93bw8EUDuPGs3gDsyt7Fgu0LSExJBCDSN5Kx0WMZ220sY6PHEuXXyD+4vMPw8lkQPQTmfQymk2ZAF6JhFcXwzlw4tBpmPGF8uTVH5h5jbP7O940vxpE3wPh7ILj+zL1uUpprzHfy06vgsINfOBQfMwZyxE6AhIvgjJmnVt6qcqOpaMPLkLkL/CLgzFuM4NgWgbG8AN6ebTTzjZzXolNIjcHFir//nqN33Inv4MH0XPQqJj+/Jo/RWnPT4k2sP5TD57+dRO+I4/0LacVpbEjfwIa0DWxI30BehTFNaJ/gPozrNo6x0WMZ1XVU3T6Jbcvhw9vgnEdgwu9a+xKF1q3bJNDelOXBsiuNIZGzXoTh1576ObIPGL/Id6wwxt+PuxOmPlS3GaotVRTB+v/Cuv8YTTtDrobJf4SQXpD2M+z5BJI+gex9xv7dRkDChRB/EUT2b/icRRmw+TXY9BqUZkPUQGP46aArwOrTdtcGRpA7jR+BrRYYlFJFNJwTSQG+WmtLy4rYcu0hMAAUfvEFqff9H/7jxhHz8n8xeZ3k5hWnYwXlTH92DfFdA3ln/jhMphO/eBzawb68faxPW8+G9A1sydhChb0Ci7IwJHJITY1iUPhArO/fatxAc8s30G2YC67SQxWkwPKrIaCLcT9JZ2tLL8qAty6FnP1G00TCRad3vrzDkPg4bF9upJK/9JW2/dKsKje+vL9/GkpzjOuZ8heIim94/6x9kPSxESjSnPcIRfSH+AuNQNFthJH5dMPLsPM9YyRg/xlGjar3pA77g6FNagzu0l4CA0D++++T/ue/EHjuuXR/5mmUpek4+d6WFH7/7nb+euEAbp7Qu8n9K+wVbMvcxob0DaxPW8/unN1oNL4WX+KD+zIwZRsD8WHgFcvoFX4GJuWmX2udReYeY4hgRRHYKyC4B1yzEiL6urtkrSPvsDHSpTjTGOnSpxUz26x7Eb76M/Q6yzi3b2jrnbshdhtsWwZr/mVkKY2bAtP+Ct1PYVBGQarx4yrpE0j+AbTdmF2xLBesfjDsWiMghPdx3XW0EQkMbShn8WIyn/gXwZddRvTf/4ZqohqttebmJZtZdzCbz+6ZSFxkM0ckORVUFLAxfSNbM7eyK2cXe7J3Uu4w7m0ItAYyIHwAAyIGMCh8EAMjBtLNv1vTHdrCcHidUVOw+MLc94xcNyuuBUcVXLmkdb9E3SEzyUjvXlVmpHyOadZ3xKn55T1YdRuE9zX+hsExrf8eDgfsXgXf/QNyDxr5xaY9ZPyaPx2lubDvSzj4nZGiYsT1rg9ubUgCQxvLeuE/ZP/3v4TNu56oBx5o8os4o7Cc6c+soV+XQFb+ZhzmBpqUmsvmsHHo03vZtfcDdg26iJ22Avbm7a2ZXS7UO5SBEQMZGG48EsIT6OLXpf0Ei63LjE7AuMnuLcfuj+D9W4xRXnPfN24yAuMX9vKrjVn2zv8XjL7VveVsqdQtsPQKo7P4ulUtv/mqOQ6tMTq1vQKM4NBlYOucV2vY/zV895jR1BM1AKb+1RjC2V7+e27HJDC0Ma01Gf98nLy33iLi7ruIvPPO49uqqnCUltZ9lJTywy9HeHvNXq5ICGNCn3ACJk7A2r2FozqqyuHVKUb76u3rqPQJYn/efnZm72RXzi525uzkYP5BHNqYjzrMJ4yE8AQGhA1gQPgAEsIT3FOz2POJMfRWmeHil4z04+6waRF8+nvjF/Q1K0/sU6goMoLGvi/gzFuNETzmNu9ea7lfvzeCm184XP8hhLVBNptjO2HZFUat6+q3offE0zvf4XVG+uoj6yG0N0z5Mwy6TEbknQIJDG6gHQ7S//RnCj78EEvXruiyMhylpeiq5qew8B05kuCLLiTwvPOwhJ5iFfbYTiM49DvXuPmt3pd8aVUp+/L2sTtnN3ty97AnZw8H8w9i00bNItg7mISwhJpAMSBsAD0Ce7guWOQfhQUTIDTWuJP21zVw3j+NkS1tRWtY/Q9jbH7/GXDFG+DVyAgzhx2+eQTWvWC0ZV/5RvtuZtDaaDPftMhoPw/va2TuDWrejZmtIv+oERxyD8GlC2DQ5ad+jvTtRkA48A0EdIWz/2A08ZitrV/eTk4Cg5tom43slxdQlZ6Oyc+v3sMXk58fqua1P/nazJylO+gXbOEfoZkUffoJlQcOgtVKwIQJBF90IQFTpmDy9W1eAao7/2b9x/jH04QKewX78/azO2d3zWN//v6aZqgAawA9AnvQLaAb3QK60T2gO90DutcsNzulR312m5FaOGMX3LYWgrobv8j3fAQT/89oHnB17cVug09+C1uXwvDr4MLnmlcL2LoUPr7XaGq6ZmX765QsLzAmetr0mnG3rG+o0YE68f/cM7qqNNfopzmy7tQCf/Z++O7vsPtD4xom3Gc041mb+W9BnEACQwfy4dZU7n1nG7NH9eDxywZRuXcvBR9/QuGnn2LLyMDk50fg9OkEXXQR/mPHnHzkk8MBb10MKVvg9h9a1GRQZa/iQP4BdufsZm/eXlKKUkgrTiOtJI0yW928iSHeIScEjGj/aEJ9Qgn1DiXUJ5QAa8CJtY5v/wbfPwWXv2ZMbQrGL/JPfgc/L4GRN8IFT7uumaCyFN670WgamvQHmPKnUwtEh9cZX3baYaQpiDvbNeU8Fek7jCGbO1ZCVakxMufMW2Dgpe7/Mq0qN2Yw2/0/GHcXTP9b4/c65B81RhltexssPkYgGX+X5GdqBRIYOpinvtzLi6sPMH9SHA+eH49SCm23U7ppMwWffEzRl1/hKCrCHBFB0MzzCb7oInwGDWq4macgFV4eZ4zLvvGLVmsL11qTW55LWnEaqcWppBannrBc6ag84TiLyUKodyghPiGEeYcRYqsk9NBawqIGETL0WkJ9Qunu3524kDj8LX7w7aPGTVMDLoHLFrZOMrLaSnJg+WxI2QwXPGV8ebZE7q9Gu33OAZj5bxh1U+uWszmqyo0v202LIOUn44t08BUw6mboPqLty3MyDjt88SD89AoMvMxoWqr92RZnGfchbH7NeH3mLUYtISDSPeXthNpNYFBKzQCeB8zAIq31Ew3scxXwCMaNdNu11tec7JydMTBorXn4o128uf4w9593BndOqTtm3lFRQfGaNRR+/AnFiYnoqiqsPXsSOGUyAWefjd+oUajaN9jtfB/euwkm/8m487MNOLSDnLIcMkozyCvPI68iz3iuvVyaSV7GL+SZTRQ2ENO6+nelT3AfepcW0OfAGvpEDCbusjcIDuzWOoXMO2zknMk/ApcvggGzTu985YVGnqH9X8Ho3xhNJW3RKZ2XDJvfgK1vGQMOwvoYX6TD5rT/fo91L8DXD0HsxON9Yev+Y9yxbCszmr3O/iOEtHm2nU6vXQQGpZQZ2AdMB1KATcAcrfXuWvv0A1YCU7XWeUqpKK115snO2xkDA4DDoblv5TY+3JbG3y4ZxHVjezW4n72wkKKvvqLw668pXb8BXVmJyd8f/7POImDyZALOnmQk9/tgvjGm/OavXDNe/VQ5HPD2lcYImfmrqYrsT0FFAbnluRwtOsqh/EMcKjjEwfyD/FrwK+X28ppDI3zC6BPSj7iQOCNwBPcmwjeCEJ8QgryCsJia8WV87BdjuKatzJhVq9f4VrouO3z1VyNdddxk6DPNuDHOVgG28lrPlfVeO59r5tdw/jus+ffY2GuH0f6ulJHv58xboPfZ7ktD0RI73oUPbzeGBpflGuk5BlwCU/8CEf3cXbpOq70EhnHAI1rr85yvHwTQWj9ea58ngX1a60XNPW9nDQwAVXYHty/dwrdJmTw3exgXDzv58FVHaSklGzZSnJhIcWIitsxMUAqfIYMJnDCWgGOL8I6yom77AbxP7Ua6VvfjC/D1X+GCZ4zEYyfh0A7SitM4tHMFBze+yMGAEH6N6sfB4qOUVJWcsH+QVxAh3iGE+IQYz85HqE8owVWVhGYfIOiXVfhaffG54Fl8ogbga/HF1+KLj9kHc2v0ZWxZAp/93pjQHQBltO1bvMHsbTxbfOo9exv3FeCsPtVvGqx5XW97ZLwxuMAVN4+1lUOJsHKe8aNl6l8lpUsbaC+B4Qpghtb6Fufr64AxWuu7au3zIUat4iyM5qZHtNZfNHCu+cB8gJ49e448fPiwS8rcHpRX2Zn3+k9sPpzHwutGMi2hS7OO01pTsWcPRYmJFCeuoXyHMYeSxddOwJCeBMz7M/7jxjZ/hFNrStkMr59n/MK96s1T6+j99XtYbjSR6LkfkOEXyK8Fv9Y0URVUFJBX7nyuyKPA2WSVX1FAOY5mvYXVZDWChMWnJlj4WnwJ8g4i0jeSCN8IInwjiPSNJNw3nEg/Y523uV7/R2WpkVLB4gMmi9x01RSHo2PVdDq4jhQYPgGqgKuAGGAtMFhrnd/YeTtzjaFaUXkV1y7ayN5jRSy5aTRj45o370NttuxsitespfjdlynZeQSHzYTy9sZ//HgCpk4hcPJkLJFt0LFXlg+vTDRaQm5b27I28LRtRt8AwHUfGFMn1laUYbTz7/8SDq6GymIwe1MWO4GCuAnkdx9Oobc/5fZyymxllNvKKbcZy2X246+rt1c/CisKySrLIrc8t+bmwNoCvQKJ9I2sCRjhvuFYTVaU8xe+UqrOMoBC1VlvNVkJ8wkzjvcJJ8w3jHCfcHwsbZy5U3R67SUwNKcpaQGwUWv9hvP1t8ADWutNjZ3XEwIDQG5JJbNfWU96QTlv3zqGITEhLTuRrRLHgqmU7k+nOGQ2xd9vpCotDQCfoUMInDqNwKlT8Orbt/VvZtPamAN3z8dw0xfQY3TLz5V9wMjzU5YPc5YbN6LtcwaDtK3GPoHdjMlY+p9n5M3xauF9FvXYHXbyKvLIKs0iqyyLnLIcssqyyCrNIqc8p2Z9bnluzT0gGo3xf+N/YNTqdIPJik/kb/U3AkWtoBHua7wO8grC2+KNr9mo5VQve1u88TH74GPxab0mMtFptJfAYMFoJpoGpGJ0Pl+jtd5Va58ZGB3S85RSEcBWYJjWOqex83pKYAAjTfcVC9ZRUmHj3dvG0TcqsGUnytoLr0wCiw961M1UhE+neMM2ir5bTfkvvwBg7dGDwKlTCJgyFb+RI1DWVrizdMtiY8rIaQ/DxPtO/3wFqUa66Oy9zhXKSKBWHQy6DOowzTfV/+4q7BXkleeRU55DTlkOOeU55JbnGstlzmXntvyK/GYHFjCGClcHD3+rP4FegQR6BRJgDahZbuy1v9Ufi8mCSZkwKRMWZcFkMmFWZkzKeK5ebjd5t8RJtYvA4CzITOA5jP6D17XW/1BKPQZs1lp/pIz/op4GZgB24B9a6xUnO6cnBQaA5OwSrliwHotJ8e5t4+gR1vSkQA1K22bcVLbnE6PDc+jVMP5uquzBRuf1d99Rsn69McopKIiASZMImDwZnwED8OrZo1kpxevI3AMLJ0PPsTB3Veu1JZfmGvPshvUxJkf3P/Vmto7K5rCRV55HcVVxTdNXdTNYhb3CaCazl1Nhq6DMXkaFraKmeay4spjiqmKKK4sprCykuKqYosoiKuwVp12u6uBhNVnxMfvgZfbC2+yNt8Ubb5M3XmYvfCy11td61O7bqb/sZ/Gr87q6/8diskgwaoF2ExhcwdMCA8Ce9EJmv7KeUH8v3r1tHFGBp9H+nH0A1r9o3Flqr4T4C4xpGXuOMUY5rVtH0XerKU5MxJ6bC4CyWvGKi8O7Tx+8+/XFq29fvPv2xatHIwGjshRenWrMeHXbjxDYvA500fYq7ZUUVRbVBIrq5ZKqEuwOO3Ztx6Ed2LUdu+P4skM7sGmb8dq5n81ho8JeUfOotFdSbi+n0l5prLNV1NleYa+g3FaOXdtPudzVtRizyXz82WTBrOo9V2+v/9pk1HjMJjNWk7VmuXo/q8laE7ys5lrLtdZ7mb1qgp2X2Qs/ix9+Vr+aZy+T12kHMLvDXifo+1n8CPVp2b0qEhg6oS2H85i7aCO9wv14Z/44gv1Os6mnOBN+WmjMi1ueDz3GGAHijJlgMqHtdsr3JFGxfz8VB/ZTceAAlfsP1PRPACgvL7x698a7b18jYPTpgzW6G6z5N3rPJ+hz/gFdhqBtdrTdBjZbg8vm0FC8evXCq2dPTD6u6XTVWsuvzHZIa02Vo6pOp3/NwIAGHhX2CmwOGzaHrSZY2XS91w4bNm2rE7Bqv65zTK19ah9f6aik0m48qhNNniqTMhlBwhkofC2+x58tfpiV+YTBD+W2ckptpTXr6mcTuHnQzdw78t4WlUcCQyf1/f4sbl68mUHdg1h6yxj8vFrhLtvKEiMx3PoXjTuCw/sa+WyGzmlwekZHSQkVhw5Rsf8AFQcOUHFgP5UHDtYJGC2mFJborkaQiI2t+xwT02i/h66qoiojE1t6GlXHjlGVlk5Vehq29GNUpadTlZ6OrqzEu39/fOLj8RmQgHd8PD5nnNGs+bqFZ7M5bFTaK6lyVNWpDVXXhKprRtXBq7SqlFJbKaVVpcZrWyllVcZz9fpSWykO7ahpHvOxGA9fs69xv029ddVNav1D+5MQntCi65DA0Il9sTOdO5b9zPg+Ebx6/Sh8vVpp5IndZmSyXPeCkerYP9JIZhfUzZjoXSlA1Vt2vkZhL6+k8ugxbN/8BxUaAzP+gfLyNpqazGaUxVJ32fmM2YwtO4fK5GQqDydTmXyYysOHqUxOxlFYeLx8ZjPWmO549eqFtVs37AUF2NKML31bVlatO4SduwcHY+nWDWt0NNauXVFWC+V791G+Zw+OggJjJ6Xwio3FJyEe7/gEfBIS8EmIxxIR0Tp/UyHaEQkMndz7W1K4/73tjOoVxms3jCLQpxVz02sNv66FH5+Hg9+e+vG+oTB/zfEZ0FpcDI09P98IGMmH6wSNqrQ0LKGhWKK7Yo12fvlHd8USHV0TCBqrCWitsaWnU56URPmePZTv2UPFniSqUlNr9rFERuKdEI9XbCzWqCgsXbpgiYzC0iUKa5cuLa5laLsde14etpwc7Dk52HJy0BUVWLt1w9qjhzOAyTwDwjUkMHiAT3akce+KbQzoFsSSG0cT6u/V9EGnqjTXyOejHc5f5Lresj5xfWBX8A1p/bK4mL2ggPKkvVQk7aF8jxE0qlJScJScmILDFBBgBIuoSKxRXbBUB4+IcBzFxdhycrHlZGPPyXUGgWxsObnY8/JOqNnUYTYbga1HDF4xPbDGxODVI8YIGjExmENCpJ9EtJgEBg/x7Z4Mbl/2M73D/XnrltGnN1pJNMheXIItMxNbZga2jAyqMjOxZWQa6zIyqMrKxJaZBba6HZQmf3/M4eFYwsMxh4dhCY/AEh5Ws85YH47y8qIqNY2qlKNUHj1KVUoqVUePUpmSgj2n7u08poAArDExWCIjMQX4Yw4IwBQQWGs5AJN/AKbAgOOvA4xl5ecnQcXDSWDwIOsOZHPLm5uJCvRm6S1jiAmVztS2ph0O7Lm52HJyMQcYAaE1Rlc5SkqoTE2lKiXFCBZHjWdbXh6OoiIcxcXYS0rQpaVNnkv5+GCJjDzxERGBJer4a3NoKMpF+YscpaVUZRgB1paRgS07G5N/QE0TnaVLl1Z5/9pNdrasbHRlxQkzKipfX0z+/iir1WMCpgQGD7PlcB43vPETgd4Wlt06lt4RrZMKQnQM2mbDUVJiBIriEhwlxTiKirAXF+MoLsFRVIgtOwdbVpbxyM7GlpWFo6joxJNZLDU1GlNNLcTfqJX4+xuv/fwbXO+oqHDWpjKMAHCsupaVgS0js+H3q89qxRoZaTTNdemCtUsUlqjjy6bgYOx5+diys7BnZzuvJdsIAtnZxvqcXCNBX3NYLHWDhm/1FLy+mHydr319jEBS/drP13jtYyybfH1RPj5GM6HDgXY4m1YdDrTdAdqBdjjAub562eTrg7VbNyzR0Zi8XNAUXI8EBg+0K62A61/7CaUUS28ZTXzXIHcXSbRzjrKymiBhy8w6HjiysrDl5jiDTUlN0HGUlKArT5ylr0Emk1ELaeDL3dKlK5YuUVgiI40+mQxnIKkdVDIya5ruTlojslqNWk+thzki3LkciSUyAmX1wlFWii4rw1FaajxKSo8vVz/KqreVoEvLcJSX4ygrQ5eWGs/NvfZTpRSWyEhjEEL37s7nWsvdurVKVmQJDB7qQGYxcxdtpNxmZ8mNoxnaI8TdRRKdjK6sxF7iDBa1AoajuNj4td+li/HFHxGOMp/+UGqt9fHgcSwDR1Eh5tAwLJERRq0mOLjNmoK0zWYEi1JnkKmzXAEmZTSDKVOdZWU2GSlhlAllUjXLjpISqtLSjEdq6vHl9PQT+qzMYWFYu3Uj5IorCL16dovKfyqBoQ3mIRRtpW9UAO/eNo5rFm3g2kUbeW3eKMa0IGW3EI1RXl5YvLwgtG2mEFVKYQ4MxBwYiHffvk0f4MqyWCyYnZ35rqTtdmxZWccDRurx4IGpbYKg1Bg6oWMF5Vy7aAOp+WW8ct0ozu4vE6oL4elOpcYg0yd1Ql2DfVj5m3HERQRwy5JNfLEz3d1FEkJ0IBIYOqnwAG+Wzx/L4O7B3Pn2VlZtTXF3kYQQHYQEhk4s2NfKWzePYUzvMO5buZ1nv95HedWppzgWQngWCQydnL+3hddvOJOLh3bj+W/3M+3pNXy8PY2O1rckhGg7Ehg8gI/VzHNXD2fF/LEE+1q5e/lWrnplPb+kFLi7aEKIdkgCgwcZGxfOx3dP4InLBvNrdgmzXvqB+9/dTmZRubuLJoRoRyQweBizSXH16J589/vJ3Doxjg+3pTLl34n8N/GA9D8IIQAJDB4ryMfKn2Ym8NXvzmZcnwie/GIv059dwxc706X/QQgPJ4HBw/WO8GfRvFEsvXkMvlYzty39mTmvbmB3WmHTBwshOiUJDAKACf0i+Oyeifzt4oHsPVbEhf/5ngc/+IWsogp3F00I0cYkMIgaFrOJ68bFkvj7KcwbH8u7m48y+d+reeHb/ZRW2po+gRCiU5DAIE4Q7Gfl4YsG8tXvJjGxXyTPfL2Pyf9OZMVPR7DZm5nnXgjRYUlgEI2KiwxgwXUjee+2ccSE+vLAB78w84Xv+S4pQzqohejEXBoYlFIzlFJ7lVIHlFIPnGS/y5VSWinVrMx/om2Nig3j/dvHs2DuCKrsmpsWb+aaVzfKDXJCdFIuCwxKKTPwEnA+MACYo5Qa0MB+gcBvgY2uKos4fUopZgyK5qvfTeKxiweyN6OIi178gd+u2MrR3KbnHBZCdByurDGMBg5orQ9prSuBFcDFDez3N+BfgNx+2wFYzSauHxfLmvsnc9eUvny56xjTnl7DPz7dTX6pi6Y+FEK0KVcGhu7A0VqvU5zraiilRgA9tNafnuxESqn5SqnNSqnNWVlZrV9SccoCfaz8/rwzWP37yVwyvBuLfviVs/+dyMK1B+UOaiE6OLd1PiulTMAzwP81ta/WeqHWepTWelRkpMxG1p5EB/vy5BVD+fy3ExnWI4R/fpbE1KcSWbn5KHaHdFAL0RG5MjCkAj1qvY5xrqsWCAwCEpVSycBY4CPpgO6Y4rsGseSm0bx96xgig3z4w3s7mPHcWr7adUxGMAnRwbgyMGwC+imleiulvICrgY+qN2qtC7TWEVrrWK11LLABmKW1lgmdO7DxfSL48I7xvHztCOwOzfy3tnDFgvVsSs51d9GEEM3kssCgtbYBdwFfAnuAlVrrXUqpx5RSs1z1vsL9lFKcP9gYwfT4ZYNJySvlygXruXnxJpKOSQ4mIdo71dGq+aNGjdKbN0uloiMpq7SzeF0y/008QHGFjUuHd+e+6f2JCfVzd9GE8BhKqS1a62Y11UtgEG0mv7SSlxMP8sa6ZNAwd2wv7pralzB/L3cXTYhOTwKDaNfSC8p47uv9vLvlKH5eFi4cEs3IXqGM6BVKXIQ/Sil3F1GITkcCg+gQDmQW8dw3+1m7L4vCciN7a6ifleE9QxnZK5ThPUMY1iMEPy+Lm0sqRMd3KoFB/sUJt+kbFciL14zA4dAczCpmy+E8fj6Sx5bDeXyXlAkYU5EmRAcywhksRvQMJSbUV2oVQriQ1BhEu5RfWsnWI/k1gWLb0XxKK407qqMCvblkeHfmjulFz3DpwBaiOaQpSXQ6NruDvRlF/Hwkn+/3ZfFtUiYOrZlyRhTXjevF2f0iMZmkFiFEYyQwiE4vvaCM5RuP8PZPR8kurqBXuB9zx/TiylExhPjJKCch6pPAIDxGpc3BF7uO8db6ZDYl5+FtMXHxsG5cPy6WQd2D3V08IdoNCQzCI+1OK+StDYf5cGsqZVV2hvcMYd64WM4f3BVvi9ndxRPCrSQwCI9WUFbFe1tSWLrhML9mlxDu78WVo3pwweBoBnUPkhFNwiNJYBACcDg0PxzI5s31h1m9NxO7Q9M9xJcZg7py/qCujOgZKh3WwmNIYBCintySSr7ZncEXu47xw/5sKu0OIgO9OW9gF2YMjGZMXBhWs9umJxHC5SQwCHESheVVrE7K5Iudx0jcm0VZlZ0QPyvTE7owY1BXJvSLkD4J0elIYBCimcoq7azZl8WXu47xzZ4MisptBHhbmBIfxcR+EQzuHky/qAAsUpsQHZykxBCimXy9zMwY1JUZg7pSaXOw7mA2X+w8xle7M/h4exoA3hYTCdFBDO4ezODuwQzqHky/LgHS9CQ6LakxCNEAh0Pza04JO1ML+CWlgF9SC9iVVkhxhZHsz9tiIj46iMHdgxjSPUSChWj3pClJCBdoTrAYGxfOtIQopsZHyUREol2RwCBEG3E4NMk5JfySWsDWI/kk7s0kOacUgPiugc4g0YVhPUIwy9BY4UYSGIRwo4NZxXy3J5Nv9mSw+XAedocm3N+LyWdEMS3B6NQO9LG6u5jCw0hgEKKdKCitYs3+LL7dk0Hi3iwKyqqwmhVjeoczNT6KSf0j6RXuJ30TwuUkMAjRDtnsDn4+ks+3ezL4NimTA5nFAFhMiphQX2Ij/IkN9yc23I/YCH96R/jTPcRXhsqKViGBQYgO4HBOCT/9mktyTgnJOaUkZ5eQnF1CiXNCIjCCRo8wP2LD/egVbgSLM7oGMiQmWKY8FadE7mMQogPoFe5Pr3D/Ouu01mQVV3A4p5RfnYEiOaeE5OxSNv6aWzOLndmkiO9qTHk6vGcII3qG0ivcTxIEilYhgUGIdkQpRVSgD1GBPpwZG1Znm9aarKIKdqYV1Ex7umprKm9tOAxAmL8Xw3uE1ASKIT1CCPCWf+Li1Ln0vxql1AzgecAMLNJaP1Fv+33ALYANyAJu0lofdmWZhOiolFJEBfkwNciHqfFdALA7NPszi4xAcTiPrUfz+TYpEwCTgv5dAhneM4QeYX5EBngTEehNZIA3UYHehPl7Sf+FaJDL+hiUUmZgHzAdSAE2AXO01rtr7TMF2Ki1LlVK3Q5M1lrPPtl5pY9BiJMrKK1iW8rxQLH9aD4FZVUn7KcUhPl5ERnobTxqBY7IQG+6BPkQHexD12AffKySVLCjay99DKOBA1rrQ85CrQAuBmoCg9Z6da39NwBzXVgeITxCsJ+Vs/tHcnb/yJp1ZZV2sosryCyqIKuogqziCrKdz1nOdb9ml5BVVEGFzXHiOX2tRAf71ASLLkFGwOga7ENX57pgX6v0cXQSrgwM3YGjtV6nAGNOsv/NwOcNbVBKzQfmA/Ts2bO1yieEx/D1MtMjzI8eYSdP06G1pqjCRmZhBRmF5RwrKOeY8zm9oJyMwnJ2pxeSXVxB/caGAG8LfSL9iYsMoE+kP30iA4iLDKBXuJ/UODqYdtEzpZSaC4wCzm5ou9Z6IbAQjKakNiyaEB5FKUWQj5UgHyt9owIa3a/K7iCzqIJjBWUcK6ggvaCMo7mlHMwqYeOhHFZtTa3Z16QgJtSvTrCoDiDh/l4yi1475MrAkAr0qPU6xrmuDqXUOcCfgbO11hUuLI8QopVYzSa6h/jSPcS3we2llTYOZZVwMKu45vlgVgnrD+VQXnW8qcpsUoT4Wgn19yLMz4tQfyuhfl61XnsR6nd8e1iAF4HeFmmycjFXBoZNQD+lVG+MgHA1cE3tHZRSw4FXgBla60wXlkUI0Yb8vCwMcs5dUZvDoUkrKONQVgmHsorJKakkt6SSvFLj+XBOKVuP5JNXWkmVveHGAV+rucF+jtqd5REB3pK08DS4LDBorW1KqbuALzGGq76utd6llHoM2Ky1/gj4NxAAvOv8BXBEaz3LVWUSQriXyaSICfUjJtSPSbU6x+vTWlNcYSO/tIrckkpySyvJK6kkp7jS6PMoLCejoJyffs0ls6j8hCBiNiminCOrugR5Ex7gTbi/l/EI8CY8wIsI57oQPy8JIvVISgwhRIfmcGhySyuNjvJaneXVz1lFFeSUVJBbUomjga87kzJuDgzz9yLc3wgagT5W/L3M+Hlb6j57mfHzsuDv7Xz2suDnbSbA29LuO9jby3BVIYRwOZNJERHgTUSA9wlNV7XZHZp8Z5NVdnElOSUV5BRXklNcQXaJ8ZxTXMnutEKKKmyUVtjq5K1qirfFRIif0UdS+znEz+gnMZ6rt1kJ8LZiNSusFhNWkwmrWWE2qXbRfyKBQQjhEcwm5WxG8qZfl+Yd43Boym12SirslFbajj9X2msCR2mljaJyGwVlVeSVVJJfVkV+aSX7M4vJLzWWbQ1VVRrhZTZhMSusZpPzYSxbzIprRvfklolxLfwLNJ8EBiGEaITJpPDzsjgz2Xq36By1+0vyS6vIKzWCR3G5DZvDQZVdU2V3UGVzUOU4vmxzaCrrLUcEtKwMp0oCgxBCuJBSikAfK4E+VnqENb1/eyAZtIQQQtQhgUEIIUQdEhiEEELUIYFBCCFEHRIYhBBC1CGBQQghRB0SGIQQQtQhgUEIIUQdHS6JnlIqCzjcwsMjgOxWLE5H48nX78nXDp59/XLthl5a68ZT2tbS4QLD6VBKbW5udsHOyJOv35OvHTz7+uXaT/3apSlJCCFEHRIYhBBC1OFpgWGhuwvgZp58/Z587eDZ1y/Xfoo8qo9BCCFE0zytxiCEEKIJEhiEEELU4TGBQSk1Qym1Vyl1QCn1gLvL05aUUslKqV+UUtuUUpvdXR5XU0q9rpTKVErtrLUuTCn1tVJqv/M51J1ldJVGrv0RpVSq8/PfppSa6c4yuopSqodSarVSardSapdS6rfO9Z7y2Td2/af8+XtEH4NSygzsA6YDKcAmYI7WerdbC9ZGlFLJwCittUfc5KOUmgQUA29qrQc51z0J5Gqtn3D+MAjVWv/RneV0hUau/RGgWGv9lDvL5mpKqWggWmv9s1IqENgCXALcgGd89o1d/1Wc4ufvKTWG0cABrfUhrXUlsAK42M1lEi6itV4L5NZbfTGwxLm8BOMfTKfTyLV7BK11utb6Z+dyEbAH6I7nfPaNXf8p85TA0B04Wut1Ci38g3VQGvhKKbVFKTXf3YVxky5a63Tn8jGgizsL4wZ3KaV2OJuaOmVTSm1KqVhgOLARD/zs610/nOLn7ymBwdNN0FqPAM4H7nQ2N3gsbbSfdv421ONeBvoAw4B04Gm3lsbFlFIBwPvAvVrrwtrbPOGzb+D6T/nz95TAkAr0qPU6xrnOI2itU53PmcAqjKY1T5PhbIOtbovNdHN52ozWOkNrbddaO4BX6cSfv1LKivGluExr/YFztcd89g1df0s+f08JDJuAfkqp3kopL+Bq4CM3l6lNKKX8nR1RKKX8gXOBnSc/qlP6CJjnXJ4H/M+NZWlT1V+KTpfSST9/pZQCXgP2aK2fqbXJIz77xq6/JZ+/R4xKAnAO0XoOMAOva63/4d4StQ2lVBxGLQHAArzd2a9dKbUcmIyRcjgDeBj4EFgJ9MRI236V1rrTddI2cu2TMZoRNJAM/KZWm3unoZSaAHwP/AI4nKv/hNHO7gmffWPXP4dT/Pw9JjAIIYRoHk9pShJCCNFMEhiEEELUIYFBCCFEHRIYhBBC1CGBQQghRB0SGIRwUkrZa2Wg3NaaWXiVUrG1M54K0Z5Z3F0AIdqRMq31MHcXQgh3kxqDEE1wzmfxpHNOi5+UUn2d62OVUt85k5N9q5Tq6VzfRSm1Sim13fkY7zyVWSn1qjNX/ldKKV/n/vc4c+jvUEqtcNNlClFDAoMQx/nWa0qaXWtbgdZ6MPAixh30AP8BlmithwDLgBec618A1mithwIjgF3O9f2Al7TWA4F84HLn+geA4c7z3OaaSxOi+eTOZyGclFLFWuuABtYnA1O11oecScqOaa3DlVLZGBOjVDnXp2utI5RSWUCM1rqi1jliga+11v2cr/8IWLXWf1dKfYExuc6HwIda62IXX6oQJyU1BiGaRzeyfCoqai3bOd7HdwHwEkbtYpNSSvr+hFtJYBCieWbXel7vXF6HkakX4FqMBGYA3wK3gzGtrFIquLGTKqVMQA+t9Wrgj0AwcEKtRYi2JL9MhDjOVym1rdbrL7TW1UNWQ5VSOzB+9c9xrrsbeEMpdT+QBdzoXP9bYKFS6maMmsHtGBOkNMQMLHUGDwW8oLXOb6XrEaJFpI9BiCY4+xhGaa2z3V0WIdqCNCUJIYSoQ2oMQggh6pAagxBCiDokMAghhKhDAoMQQog6JDAIIYSoQwKDEEKIOv4fjSvmUXFJHeYAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.16688895225524902 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "plt.plot(history2.history['loss'])\n",
+    "plt.plot(history2.history['val_loss'])\n",
+    "plt.plot(history4.history['loss'])\n",
+    "plt.plot(history4.history['val_loss'])\n",
+    "plt.title(\"Model Loss\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Loss')\n",
+    "plt.legend(['Resnet Train', 'Resnet Validation', 'Model4 Train', 'Model4 Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pacific-front",
+   "metadata": {
+    "papermill": {
+     "duration": 1.380052,
+     "end_time": "2021-04-25T15:07:50.299202",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:48.919150",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Accuracy v/s no. of epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "incomplete-laugh",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:07:53.221449Z",
+     "iopub.status.busy": "2021-04-25T15:07:53.196579Z",
+     "iopub.status.idle": "2021-04-25T15:07:53.361398Z",
+     "shell.execute_reply": "2021-04-25T15:07:53.360896Z"
+    },
+    "papermill": {
+     "duration": 1.633127,
+     "end_time": "2021-04-25T15:07:53.361519",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:51.728392",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEWCAYAAAB1xKBvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAABZqElEQVR4nO3dd3hUZdrA4d+TSa+k0pJAaNKEAAEUO4piF9eGq8Lqt+6ubdW1rwXRXXtfVxd7xwpiLxSx0EKVprSQBqT3NuX9/jiTkAQIE8ikPvd1zTWnz3sycJ55uxhjUEoppQ7Gp60ToJRSqmPQgKGUUsojGjCUUkp5RAOGUkopj2jAUEop5RENGEoppTyiAUN1eSLSV0SMiPh6cOx0EfmpNdKlVHujAUN1KCKSJiI1IhLTaPtq90O/bxslrX5aQkWkTES+auu0KNWSNGCojmgHMLV2RUSOBILbLjn7+ANQDUwSkR6t+cGe5JKUOlQaMFRH9BZwRb31acCb9Q8QkQgReVNEckVkp4jcLSI+7n02EXlcRPJEZDtw5n7OfUVEdolIlog8KCK2ZqRvGvAisA64rNG1jxWRX0SkSEQyRGS6e3uQiDzhTmuxiPzk3naiiGQ2ukaaiJziXp4hIh+JyNsiUgJMF5FxIrLE/Rm7ROQ/IuJf7/xhIvKdiBSIyB4RuUtEeohIhYhE1ztutPvv59eMe1edmAYM1REtBcJFZIj7QX4J8HajY54DIoB+wAlYAeZP7n1/Bs4CRgEpwAWNzn0dcAAD3MecCvyfJwkTkT7AicA77tcVjfZ95U5bLJAMrHHvfhwYA0wAooDbAJcnnwmcC3wEdHN/phO4CYgBjgZOBq5xpyEM+B74Gujlvsf5xpjdwCLgonrXvRyYbYyxe5gO1clpwFAdVW0uYxKwCciq3VEviNxpjCk1xqQBT2A9AMF6KD5tjMkwxhQAD9U7tztwBnCjMabcGJMDPOW+nicuB9YZYzYCs4FhIjLKve9S4HtjzHvGGLsxJt8Ys8ad87kS+LsxJssY4zTG/GKMqfbwM5cYY+YaY1zGmEpjzEpjzFJjjMN97//DCppgBcrdxpgnjDFV7r/PMve+N3DniNx/w6lYf2elANDyTtVRvQUsBpJoVByF9cvaD9hZb9tOoLd7uReQ0WhfrT7uc3eJSO02n0bHN+UK4CUAY0yWiPyAVUS1GkgAtu3nnBgg8AD7PNEgbSIyCHgSK/cUjPX/fKV794HSAPAp8KKIJAFHAMXGmOWHmCbVCWkOQ3VIxpidWJXfZwCfNNqdB9ixHv61EtmbC9mF9eCsv69WBlaFdYwxppv7FW6MGXawNInIBGAgcKeI7BaR3cB44FJ3ZXQG0H8/p+YBVQfYV069Cn33L//YRsc0HnL6BWAzMNAYEw7cBdRGvwysYrp9GGOqgA+wchmXo7kL1YgGDNWRXQVMNMaU199ojHFiPfj+JSJh7rqDm9lbz/EBcIOIxItIJHBHvXN3Ad8CT4hIuIj4iEh/ETmBg5sGfAcMxaqfSAaGA0HA6Vj1C6eIyEUi4isi0SKSbIxxAa8CT4pIL3el/NEiEgD8DgSKyJnuyue7gYCDpCMMKAHKRGQw8Ld6+z4HeorIjSIS4P77jK+3/01gOnAOGjBUIxowVIdljNlmjEk9wO7rsX6dbwd+At7FeiiDVWT0DbAWWMW+OZQrAH9gI1CIVaHcs6m0iEggVt3Ic8aY3fVeO7AevNOMMelYOaJ/AAVYFd4j3Ze4BfgVWOHe9wjgY4wpxqqwfhkrh1QONGg1tR+3YNWXlLrv9f3aHcaYUqx6n7OB3cAW4KR6+3/Gqmxf5c7FKVVHdAIlpVR9IrIAeNcY83Jbp0W1LxowlFJ1RGQsVrFagjs3olQdLZJSSgEgIm9g9dG4UYOF2h/NYSillPKI5jCUUkp5pNN03IuJiTF9+/Zt62QopVSHsnLlyjxjTOO+PfvVaQJG3759SU09UAtLpZRS+yMiHjef1iIppZRSHtGAoZRSyiMaMJRSSnlEA4ZSSimPeC1giMirIpIjIusPsF9E5FkR2Soi60RkdL1900Rki/s1zVtpVEop5Tlv5jBeByY3sf90rKGgBwJXYw3JjIhEAfdhDQs9DrjPPaKoUkqpNuS1gGGMWYw16uaBnAu8aSxLgW4i0hM4DfjOGFNgjCnEGtemqcCjlFKqFbRlP4zeNJwpLNO97UDb9yEiV2PlTkhMTNzfIUopdViMMdQ4XZRXO3E4XSAgCCLWrFQi4n63tiPU7QOocbiocriosjuprHFS7XBSZXdRWeOkyr1cZXfWvWqcBh8BXx/B5uODzQfrXcBm88Em4t639xUd4s+EATFe/1t06I57xphZwCyAlJQUHRRLKYXLZaiwO6modlBW7aCixul+d1Be7aS82kF5Te27w3qvrr9uLdeeV17twOFq34+XUYndmNPJA0YWDafJjHdvywJObLR9UaulSinVasqqHWQWVpBZUElGYQWZhZVkFlZQVu3A6TK4XOAyBqcxuFwGl8Habkzde+22ihonFTXWg95TAb4+hAT4EhJgI8Tfl5AAX8KD/OgZEWht97e591vLvjYfaz5cYzDWG6b+MtY6deuGAF8bgX4+BPrZ9r58fQjyr122EejvU7fsZxOMAaf7Hp0ug8Nl3b/Dfc/1150ug7+tdRq8tmXAmAdcJyKzsSq4i40xu0TkG+Df9Sq6TwXubKtEKqWa1vhB5nQaHC5X3YOuvNpRFwgy3O+ZhZVkFFRQWGFvcK1APx/iI4PpFuSHjwg+PuDn42Mti1X84iPUWxZ8fASbQJB//Qe8+91/78M+OMCX0AAbwe5twf42/FrpQdtcIuCD4Gdr65Q05LWAISLvYeUUYkQkE6vlkx+AMeZF4Eus6Sq3AhXAn9z7CkTkAaypKgFmGmOaqjxXSnmoxuEivaCcrTllbMstp6C8hmqHk2q7i2qHy1p2uNzr7uXa7e5jrECwNyA0Z4YEf18f4iODiI8MZnjvCBIig93rQSREBRMd4o+IHPxCqk14LWAYY6YeZL8Brj3AvlfZO/+yUqqZSqvsbMstZ1tOGVtzy+re0/MrGpTHh/jbCPCzEeDr437ZCPCzloP9fYkM9iHAz4dA93Z/mw++Np+6SldfH+sXfm0Fbd12m7tCVoQgf5sVECKDiQkNwMdHA0JH1aErvZXqSlwuQ2mVg+JKO0WVNRRX2q3lCus9p6TKHRzK2V1SVXeer4/QNyaEQXFhnD68BwPiQhkQG0a/2BBCAvQRoDyn/1qUaicqa5yszy5mdXohG7JLKCivqQsGxZV2SqrsTRb/hAb40j82hAn9o+kfF2oFhrhQEqOC221ZvepYNGAo1QaMMezIK2dNRhGr04tYnVHIpl2lON3FRb27BREXHkB0qD/9Y0OICPIjItjfeg/yo1uQHxHBe5fDg/wIbG81pKrT0YChVCsorrCzJrOINe7gsCajiCJ3C6HQAF9GJkTwtxP6k5zQjeTEbsSEBrRxipXalwYMpQ6TMYb88hp2F1eRXVTJ7pIqsouq2F1cSXZxFbuKK8koqASs5pKD4sKYPKwHoxK7kZwQyYC4UGxaEaw6AA0YSnloV3Ely3cUsGlXaV0w2O1+1ThdDY71swk9IgLpGR7EqIRILk5JYHRiJEfGRxAW6NdGd6DU4dGAodR+1NYxLN9RwPK0ApbvKCCz0MolNAgGid3oERFIr4igBu/RIf7afFR1OhowlMIaWmLz7hKW7yhgRVoBy3cUkldWDUB0iD9j+0Zx5TFJjEuKYkjPcC1CUl2SBgzVJRlj2LSrlB9+z2X5jnxSdxZSWuUArBZKxw2MYVxSFGP7RtE/NkR7HyuFBgzVhVTUOPhlaz7zN+ew6LccdhVbndsGxIVy1ohejE+KYmxSFL27BbVxSpVqnzRgqE4to6CChb/lMH9TDku251PjcBHib+O4gbHcdEocJx4RS1x4YFsnU6kOQQOG6lQcThcrdxayYHMOCzbnsCWnDICkmBAuG9+HiYPjGJcUhb+v9nxWqrk0YKgOw+50UVheQ355DfllNeSXV9e9F5TXkFNSzYq0AkqqHPjZhHFJUVw8NoGJg+PoFxva1slXqsPTgKHanZzSKuauzmJ1ehH5ZTXkuQNCUaO5E2rZfISoEH+iQ/w5dVgPTh4cx7EDY7S/g1ItTAOGahfsThcLNufwYWomC3/Lweky9IsJIS48gCE9wokO9beCQmgAMSH1lkP9CQ/00z4PSrUCDRiqTf22u5QPUzOYszqL/PIa4sIC+PNx/bhgTDwD4rQYSan2xKsBQ0QmA88ANuBlY8zDjfb3wZooKRYoAC4zxmS69zmBX92HphtjzvFmWlXrKa60M29tNh+lZrA2sxg/m3DKkO5cmBLP8QNj8dWhuJVql7w5RasNeB6YBGQCK0RknjFmY73DHgfeNMa8ISITgYeAy937Ko0xyd5Kn2pdLpfh5215fJiaydcbdlPjcDG4Rxj3njWU80b1JirEv62TqJQ6CG/mMMYBW40x2wFEZDZwLlA/YAwFbnYvLwTmejE9qg3sLq7i/RUZfJCaQVZRJRFBfkwdm8CFKQkM6xWuPaiV6kC8GTB6Axn11jOB8Y2OWQucj1VsNQUIE5FoY0w+ECgiqYADeNgYM7fxB4jI1cDVAImJiS1+A+rQOF2GxVtyeXdZOgs2WxXYxw2M4c4zBnPKkO460Y9SHVRbV3rfAvxHRKYDi4EswOne18cYkyUi/YAFIvKrMWZb/ZONMbOAWQApKSlNTF6pWkNOSRUfpGbw3nIrNxET6s/Vx/dj6thEEqOD2zp5SqnD5M2AkQUk1FuPd2+rY4zJxsphICKhwB+MMUXufVnu9+0isggYBTQIGKrt1dZNvLssne827sHhMkzoH82dZwzm1KE9tEe1Up2INwPGCmCgiCRhBYpLgEvrHyAiMUCBMcYF3InVYgoRiQQqjDHV7mOOAR71YlpVM+WVVfNhaiazV6SzM7+CyGA/rjw2iUvGJmivaqU6Ka8FDGOMQ0SuA77Balb7qjFmg4jMBFKNMfOAE4GHRMRgFUld6z59CPA/EXEBPlh1GBv3+RDValwuw5acMpbvyOfnrfnM37wHu9MwLimKmycNYvLwHgT4at2EUp2ZGNM5iv5TUlJMampqWyej03C6DJt2lbBsRwHLd+SzfEcBhe6hOXpGBDJ5eA/+OD6RAXFhbZxSpdThEJGVxpgUT45t60pv1U44nC7WZ5ewbHt+3bSktRMKJUYFc8qQ7oxLiuKoftHERwZpc1iluiANGF2Yy2WYszqLuWuyWLWzkPIaq4Fav9gQzhrRi6P6RTEuKYqeETqhkFJKA0aXtSq9kPvnbWBtZjH9YkP4w5h4xidFMzYpkrgwnVBIKbUvDRhdzJ6SKh75ajOfrM6ie3gAT108kvOSe2sRk1LqoDRgdBFVdiev/LSD5xduxeE0XHtSf645cQAhAfpPQCnlGX1adHLGGL7buIcHv9hEekEFpw7tzt1nDtWe10qpZtOA0Ylt2VPKzM838uOWPAZ1D+Xtq8Zz7MCYtk6WUqqD0oDRCRVX2Hnq+995a+lOQvxtzDh7KJcd1UfnmVBKHRYNGJ2I3enig9QMHv/mN4or7Uwdl8g/Tj1C55pQSrUIDRidwK7iSt5bnsHs5enklFYzLimKGWcPY2iv8LZOmlKqE9GA0UG5XIZftuXz9tKdfLdpDy5jOHFQLI8c3ZcTj4jVZrJKqRanAaODKa6w8+HKDN5dls72vHIig/34v+OS+OO4PtrySSnlVRowOohfM4t5a2ka89ZmU2V3MTqxG09dPJLTh/fUGeyUUq1CA0Y7VmV38tnabN5eupO1mcUE+dmYMiqey45KZFiviLZOnlKqi9GA0Q5V1jh5c0kaL/6wjcIKOwPiQplx9lDOHxNPeKBfWydPKdVFeTVgiMhk4BmsCZReNsY83Gh/H6xZ9mKBAuAyY0yme9804G73oQ8aY97wZlrbg2qHk9nLM/jPwq3kllZz/KBY/npCP47uF91+KrELdsC698E/BHqnQM+R4K91J0o1YAxUFkJFAUT2BVvn+G3utbsQERvwPDAJyARWiMi8RjPnPQ68aYx5Q0QmAg8Bl4tIFHAfkAIYYKX73EJvpbct2Z0uPl6ZybPzt5BdXMW4pCiev3Q045Ki2jppFmNg+0JYNgt+/7p2o/UmNug+FHqPsQJI7zEQewT4aL2KOgSVRZCVCvYqCOsBod2tl2876UvkdEB5DpTuhrIcKNsNpXvqvdd7OWusc7r1gaOugVGXQUDHnr7Ym2FvHLDVGLMdQERmA+cC9QPGUOBm9/JCYK57+TTgO2NMgfvc74DJwHteTG+rc7oM89Zm8fT3W9iZX8HIhG48esFIjhnQTnIU1aWwdjYsnwV5v0NwDBx/C6RcCT6+kLXSemWmwvo5sPJ16zz/UOg1yh1ExkB8CoT3atNb6VDSl1m5OLBycrUvv2Drb+sfYuXq/EPd20Ks5YAw8OtAQ9MbA/lbIWOZ+7UCcjdT92OkvqBICO0BYd2t99C4vQElrAeExIH4gHGCywkuh3vZVW+50XZnDdSUWf/Oa9+ry5reVlV8gPRF7U1PzEArfaE9wC/I+j/09e2w6N+QchWM/4t1bAfkzYDRG8iot54JjG90zFrgfKxiqylAmIhEH+Dc3o0/QESuBq4GSExMbLGEe5vLZfhmw26e/O53tuSUMaRnOC9fkcLJQ+LaR6DI32YFiTXvQnUJ9BoNU/4Hw6aAb8De44443XqB9R+wYLv167A2iCx5HlzWtK50S4SznoIBp7T+/XQELhds+RZ+fhrSl4BfiPXwrykHR5Xn1/ELhuBoCI5yv0dbD7PG22rXQ7u3Xm6wphyyVrmDw3LIXG4V2wAEdoOEcTD8D5AwFgIjrF/wpbutX+u172V7YOcv1i/62l/wLUV8wD/MCrwBoe4gHGo93P3d24Ii9wap2gAWEtd0DijlT9b9/vKc9f3+8hyMuAiOvs7KnR+uykIoz4eYAYd/rYNo64K1W4D/iMh0YDGQBTg9PdkYMwuYBdac3t5IYEsyxrDwtxye+PZ3NmSX0D82hOcvHc3pw3vg49PGgcLlgq3fw/L/We8+flaAGP8XK4dwMD4+1j/YmAEw8hJrm6Madv9qBZCVr8PbF8BJ/4Tj/mEdr8BRA+s/gp+fhdxNEJEAkx+B0ZdbOQewfhnXlIO9wnqvfdnLG65Xl1hl5hUFUJEPlQVQmGYtVxXv//P9QqzcYPyYvcWK4b3gcH+4VJVA7m/WPe3+1QoSu9dbv+4BYo6AwWdBwngrUEQPbN6/CWOgqmhvcVBZLmCsh76PrxUExeZe9nEvu9frLwe4A4R/qJUb8NYPtoRxcPFb1o+qpS/A6rdhzTvQ/2SYcD30O9Gzz3ZUw571kOnO3WelWrm0+LHwf997J+31iDHeec6KyNHADGPMae71OwGMMQ8d4PhQYLMxJl5EpgInGmP+4t73P2CRMeaARVIpKSkmNTW1pW+jxaxIK+ChLzexKr2IhKggbjx5EOeN6o2trQNFdSmsegtWvGT9Yw7tYRU5jZlu/XpqKTXl8NmN8OsHMGiylWMJ6tZy1z8ULqf14GmLCsnqMlj1hpULK8mCuGFwzN9h+Plg80JLOKd9byVsRb77lQc5m6wHz+5f9/5iD+1h/UjoPdoKIL1GQeABhpmpLoXc363AkLPJKlLK2QwlmXuP8QuxAlLCeIgfZ107uJ3Uz7WVigJIfRWW/c+qE+l+JEy4Doadvze3Yow71+7OsWethN3r9n5PIXHu78n9t0067pCSIiIrjTEe/Cr0bsDwBX4HTsbKOawALjXGbKh3TAxQYIxxici/AKcx5l53pfdKYLT70FXAmNo6jf1prwGjvNrBo19v5o0lO+kRHsgNJw/kwpR4/NrDyLHl+fD6mdZ/9oTxMO5qGHKO9yoYjYEVL8PXd1i/pC9+C3oc2TLX3rUWFj8GRelWIHDareIwp8P9vp91jJWTGvt/cOLtVnGDt5XlWrm45S9Zv5D7HAvH3mgV1bVlcaSj2soB1C9SLNjm3ikQM8h6OHUfBqW7rKCQuxmK65Uc2wIgdhDEDrEaPsQNgdjBVishbQSxf45q+PVDq5gqdzOE9YKh50DeFut7qCqyjvMLdtcLjt7buCQivkX+zbSLgOFOyBnA01jNal81xvxLRGYCqcaYeSJyAVbLKINVJHWtMabafe6VwF3uS/3LGPNaU5/VHgPGL1vzuP2TdWQWVjLt6L7cNvkIgv3buhTQrbII3jjbqsy+5J3WrVtIXwYfTrPScPbTe4uwDkXBdljwIKz/2Hrgx4+1goDN1/3uZxU92Pz2v160E9a+Z5Whn3QXjPmTd3IcBTtgyX+soghHNQw+E469ybPivrZSUQDZqxoWf1Tkg83fCiCxgyFusBUg4oZoYDgcxsDW+fDLs5D2k/W3rV9MGDvYaznhdhMwWlN7Chhl1Q4e/moTby9NJykmhEcvGMHYvu0oC15dBm9NgezVMHU2DGyDiuiyHPjwT7DzJ+sX/mkPNS9nU7oHFj9q1Y3Y/K1mi8fcYFWWNtfuX+HrOyHtR4gbCqf9G/qf1PzrNOZywY4frDRummcFqhEXW0VPMQMP//qtzRgoz7Uq0TtJv4J2yeVq1To+DRht6Kctedz+8Tqyiyu56pgk/nHqEQT5t6NfXfZKeOdCq6XJRW/AkLPbLi1OB8yfYWXH48fChW9AxD6N4RqqKrF+hS35r9V6aMx0OOG2w2+maAxs/hy+vduqKD7iDDj1QYju3/xrleyyKjRXv2VdKygSRl1uBbXwnoeXTqVamAaMNlBSZeehLzfx3vIM+sWG8NgFIxnTpxXKxJvDUQ2z/2i1gjr/JRhxYVunyLJhLnx6LfgGwoWvQdLx+x7jqLbqPxY/brX+GXY+TLz70B7oTbFXwbIXrM9xVMNRf4Xjbz14zsXpsP6uq96A37+xWgP1Pc4KaIPP6lj9I1SXogGjlS36LYc7P/mVPSVV/Pn4ftx0yqD2N4Ks0wEfTYdNn8HZz8KYaW2dooZyf4f3L4P8LXDyfVaxjYhVgb3ufVj4b6uCtd9JcMp9VgWgN5XugQUzYfU7Vp+FiXfD6Cv2LaMv3GnlJFa/A6XZVsuVUX+0chQtHcyU8gINGK2kuNLOg59v5MOVmQyMC+WxC0eSnNCtVdPgEZcT5vzVatI6+RHrV3N7VF0Kn14HG+daRWVHXgiLHoacjdAzGU6Z0TJ1C82Rvdqq30hfYjV9nPyQ1aLsty9g5RuwfZF13MBJVkAZNNk7zWKV8hINGK1g/sbd3DV3PXllNfz1hH7ccPJAAnzbWa4CrLL5z/5uFZWcfK/Vaa49M8bqm/DdvVaxTlR/OPkeGHJu23X2MwY2zLHSVJwBAeFWJ7nweKuD3ajLrCaOSnVAzQkY2tThEKz84mUGLHuEIeEP8o9rJnNkfDudm8IY69fxqjfguFvaf7AAqxhqwnVWz9j8bXDkBW3/i13E6lB3xOmw9L9W8dmRF1q5HW1GqroQzWE0V2URRY+OoJspxpVwND5/+rL9DnMxfyb8+ITVOue0f7dtxzClVLvUnBxGO33StV+5n99PuKuEjX0uxydjidVrtz1a/LgVLMZM12ChlGoRGjCaY89Goja8wQecQsIlT8LA0+D7+yFva1unrKEl/4UFD1idxM58SoOFUqpFaMDwlDHYv7iVUhPI9iNvIizIH85+xuqd/Ok1Vkuk9iD1NfjmTmtMqHP/236Ly5RSHY4+TTy1cS5+6T/xuOMi/nDsCGtbeE84/TFr6Oal/23b9O3+FeZeA5/fBANPhT+8osM3KKValD5RPFFTjvnmbrZKX7YkXMARPcL27htxEWz8FOY/YBVRxQ5qvXS5nFav4qX/tcZB8gu2RpyddH/7mdJSKdVpaA7DEz89hZRkclfVFVw+oV/DfSLWTHL+wTD3b61TNFVdao2j/9wYmD3VGgl10ky4eSOc8ag1EYxSSrUwzWEcTMEO+PlZloRMJM1vJKcO3c8gd2Hd4YzH4eOrrIH0jr3RO2kp3GlNnbrqTavjWMJ4a5iMwWdr8ZNSyuv0KXMw39yFy8fGTQXnM/WkBPx9D5ApG/4Hq2hq4b+s4SHiBrfM5xsD6UutYqfNn1tTUA49z+pbET+mZT5DKaU8oAGjKVu+h9++5IeEa8jdFs3U8YkHPlYEznwSdv4Mc/8KV31/eL/6jbEmBVryH2s8o8Bu1oB8Y/988CHAlVLKC7xahyEik0XkNxHZKiJ37Gd/oogsFJHVIrLOPUMfItJXRCpFZI379aI307lfjhr4+nZcUf25PfNYJg3pTs+Ig9QNhMbCmU9YD/ifnz70zy7YAW+eaxVx1ZRbdSQ3b7IG39NgoZRqI17LYYiIDXgemARkAitEZJ4xZmO9w+4GPjDGvCAiQ4Evgb7ufduMMcneSt9BLf0v5G/ll3EvkrMYrji6j2fnDZtiFU0tetgae6j7MM8/0+W0KrMXPABiswLF6Onal0Ip1S5480k0DthqjNlujKkBZgPnNjrGAOHu5Qgg24vp8VzJLlj8GAw6ncd3JNIvNoSj+0d7fv4ZT0BQN2tIcafds3Nyf4NXJ1ud7voeC9cuhZQrNVgopdoNbz6NegMZ9dYz3dvqmwFcJiKZWLmL6+vtS3IXVf0gIsft7wNE5GoRSRWR1Nzc3JZL+Xf3gtPOb8l3siajiMuP6oM0Z3iNkGgrd7B7Hfz0VNPHOu1WcHrxWMjfas2Ed+kHOly2Uqrdaeufr1OB140x8cAZwFsi4gPsAhKNMaOAm4F3RSS88cnGmFnGmBRjTEpsbGzLpGjnEmuioQnX88pGCPKz8Ycxh/Dwrp0A6IdHYNe6/R+TvQZmnQQLHoTBZ8K1y62OgDr2k1KqHfJmwMgCEuqtx7u31XcV8AGAMWYJEAjEGGOqjTH57u0rgW2A97tQu5zw1a0QHk/xmOv5dE02543qTXjgIc7HcPqj1vSec6+xKtFr2avg+xnw0kQoz4WL34ELX7cqzZVSqp3yZsBYAQwUkSQR8QcuAeY1OiYdOBlARIZgBYxcEYl1V5ojIv2AgcB2L6bVsvJ1a0ymUx/gw18LqHa4uPwoDyu79yc4Cs56Gvb8Cj8+bm3buQRePMYqqkqeatVVDDmrJVKvlFJe5bVWUsYYh4hcB3wD2IBXjTEbRGQmkGqMmQf8A3hJRG7CqgCfbowxInI8MFNE7IAL+KsxpsBbaQWgosBqndT3OFxDzuPtJ38gpU8kQ3vtUxLWPIPPgJFTrfkpCtNg3QfQLQEunwP9J7ZI0pVSqjV4teOeMeZLrMrs+tvurbe8EThmP+d9DHzszbTtY8GDUFUCpz/Cj9vyScuv4KZJLVQKNvkh2L7IChbj/wIT74GA0Ja5tlJKtZKDBgwRORv4whjjaoX0tI1d62Dla1Yv6u7DeOvrVKJD/Jk8fD/jRh2KoEiY/gXYK6DHkS1zTaWUamWe1GFcDGwRkUdFpIUGSGpHjIGvbrMe6ifdSWZhBQs27+GScQkE+Npa7nOi+2uwUEp1aAcNGMaYy4BRWC2VXheRJe7+D2EHObVjyN8GezbCyfdBUCTvLksH4NLxh1HZrZRSnZBHraSMMSXAR1i9tXsCU4BVInJ9kyd2BDED4IbVMOpyqh1O3l+RwclDutO7m84poZRS9R00YIjIOSIyB1gE+AHjjDGnAyOxWjl1fCHR4OPDV7/uJr+85vCa0iqlVCflSSupPwBPGWMW199ojKkQkau8k6y28dbSnfSNDubYATFtnRSllGp3PCmSmgEsr10RkSAR6QtgjJnvnWS1vg3ZxazcWchlR/XBx0eH5lBKqcY8CRgfYnWeq+V0b+tU3l66k0A/Hy4ck3Dwg5VSqgvyJGD4uocnB8C97O+9JLW+4ko7c1dnc87IXkQEH+K4UUop1cl5EjByReSc2hURORfI816SWt/HKzOptDu54ui+bZ0UpZRqtzyp9P4r8I6I/AcQrDkurvBqqlqRMYa3l+4kOaEbw3tHtHVylFKq3TpowDDGbAOOEpFQ93qZ11PVitILKsgvr+G6iQPaOilKKdWueTT4oIicCQwDAmtnnjPGzPRiulpNn+gQlt55MjZtGaWUUk3yZPDBF4Fg4CTgZeAC6jWz7QyC/FtwzCilVKdjjMGZn4+rshKfoCB8goORoKDmTd3cCXiSw5hgjBkhIuuMMfeLyBPAV95OmFKq4zLGULlmDcVz5lK9ZQuBQ4cSlDySoJEj8UtIaLcPWmdpKTVpO6lJS2v42rkTV9m+pfESHIxPcHBdEKkLJsHu9cAgjMuJqarGVFfjqqluuFxdg6mqarBsnE58AgKQoCB8AgORoEB8AmuXG26TwAB8AoPwS4gn8sILvf738SRgVLnfK0SkF5CPNZ7UQYnIZOAZrAmUXjbGPNxofyLwBtDNfcwd7jk0EJE7saZwdQI3GGO+8eQzlVIH5yovx74nB1tkN3wjI1vsuvZduyj+dB7Fc+ZQs3MnEhRE4BFHUDRnDoXvvAOALSqKoJFW8AhKHkng8COxhYa0WBqa4qqpwZmXhyM/H/vu3dh37qS6LjDsxJlXrwGoCH69e+Pfty8Ro0bh37cvPiEhuCorMJWVuMorcFVW4qqosF6VFZja5bw8a19lJWKzWQ92/wAkwHr5BAdji4y0lgPqbQ/wB5uvFVCqKjGVVbiqquqWncXFOPbswVVVZaWhytofNGxYuwkYn4lIN+AxYBXWzHgvHewk9xSrzwOTgExghYjMc0+aVOtu4ANjzAsiMhRrsqW+7uVLsOpNegHfi8ggY4zT81tTqusxxuAqK8Oxezf23Xtw7NmNfddu7Ht246hd370HV2lp3TkBAwcSPDaF4LFjCR47Ft+Y5g2N46qspPT7+RTPmUP5kiVgDMEpKURffTVhp52GLTQE43RSvXUrlWvWUrlmDZVr11K2cKF1ARECBg6sCyBBI0fi26MnGBe4XGAMxpi9y+73vesGnA6cRUU48vNx5OXhzM/HkWsFBkd+Hs68fBz5+Q3uu5YtJgb/vn0IPfEEAvr2xd/98ktIwCcg4LC+j9ZinK3zaGwyYIiIDzDfGFMEfCwinwOBxphiD649DthqjNnuvtZs4FygfsAwQO0cqBFAtnv5XGC2MaYa2CEiW93XW+LRXSnViRm7HXtWFjXp6dTsTKdm505q0ndiz8zCsXs3roqKhieIYIuJxq9HT/z79iV4/FH49eiOb1wc9uxdVKxYQdHcTyl89z0A/JOS3MHDCiJ+PfadSMwYQ+Xq1RTPmUPJl1/hKi/Hr3dvYq65hojzzsU/oeGICWKzEXjEEQQecQSRF18EgLO4mMp1v1K5di2Va9dS8s03FH3YcoNI+ISH4xsdjW90NAGDBxMSHY1vTDS26Gh8Y2LwjY3Dv28fbGEdf6YGsbVOPWyTAcMY4xKR57Hmw8D9AK/28Nq9sfps1MoExjc6ZgbwrXuY9BDglHrnLm10bm8PP1epDs/U1FCTlYU93R0Q6gJDOvasLKj3i9InOBi/vn0IGDCA0OOOxbd7Dysg9OiBX/fu+MbGIv5NDM7w179g7HaqNm6kIjWViuUrKPnyS4o++AAAv4QEK4CkpBBwxCDKf/yRojlzsO9MR4KDCT/1VCKmTCF4bAri49GMCQDYIiIIPe5YQo871rpnl4uatDQq16zFWVQEPuK+noCPDwjWuviASMP9Nh9sERH4xsTWBQWfpu5ZHRJPiqTmi8gfgE+MMaaFP38q8Lox5gkRORp4S0SGe3qyiFwNXA2QmJjYwklT6vAYl4vyn3+heM4n2LN3YRwO98sOdke9dQc4Gq03KmLwCQnBv08fgoYPI/yM0/FP7IN/3z74JyZii44+7Epk8fOrq1eIvuoqjNNJ1ebNVKamUr5iBWXz51P8ySd1xwePG0fMX/9G+KmT8AlpmfoH8fEhoF8/Avr1a5HrqZbnScD4C3Az4BCRKqze3sYYE970aWQB9fOl8e5t9V0FTMa64BIRCQRiPDwXY8wsYBZASkpKSwczpQ6JPSeH4k8+oejDj7BnZWGLjCRwyGDw9UV8/RBfX+vl53vgbf7++PXqVRcYbJGRrdqySGw2goYNI2jYMKKmTcO4XFRv3Ur15s0EjR6Df7xm+LsiT3p6H2oB3wpgoIgkYT3sLwEubXRMOnAy1tSvQ4BAIBeYB7wrIk9iVXoPpJP1/VAtyxhDxfIViI8QOHJkqxdHWLmJnyn64ANKFywEp5Pgo44i7h83E3rKKR2+eER8fAgcNIjAQYPaOimqDXnSce/4/W1vPKHSfvY7ROQ64BusJrOvGmM2iMhMINUYMw9rxr6XROQmrArw6e5irw0i8gFWBbkDuFZbSKkDqcnIYPfMByj/8UcAxN+foJEj6ypug5KT8QnyzpS79j05FM/5hKIPPsSenY0tMpKo6dPodsEFBCQleeUzlWorcrBqCRH5rN5qIFZrpZXGmIneTFhzpaSkmNTU1LZOhmpFpqaG/FdfI++FFxCbjdi/34BfQgIVy1dQsWIFVZs2WU0v/fwIGj58bwAZNfqw2v0bp5PyX37ZJzcRedGFnSI3oboWEVlpjEnx6Njm1mOLSALwtDHmD4eSOG/RgNG1VKxYwa4Z91OzbRthp55K93/ehV/37g2OcZaWUrl6NRUrVlCxfAWVGzaAwwE2G4FDhxKckkLQyJGIrw2Xu/etqanGVe3ujbu/5eoaqn79tS43EXH+FM1NqA7N2wFDgA3GmKGHkjhv0YDRNTgKC8l57HGKP/kEv9696X7P3YSdeKJH57oqKqhcs4byFe4cyNp1GLu9yXMkMNDqgevvb/XGDQzAr0dPup0/RXMTqlNoTsDwpA7jOaz6BbAmXErG6vGtVJNclZXUpKVRvX07jtxcAgcPJmjECHyCg5t9LWMMxZ98Qs6jj+EsLyf6z38m5pq/Natuwic4mJAJEwiZMMFKX3U11Vu2IjYfKxj4W0Mz1AYJ8fNrt2MeKdUWPGlWW/9nuwN4zxjzs5fSozoYYwyOnBxqtm+nevt2anakWctpO3Bk79r3BJuNwCFDCB4zmqBRowkaPQq/uLgmP6N6yxZ23X8/lakrCRozhp4z7iNg4MDDTrtPQABBw4cd9nVUx2KMobi6mFJ7KaF+oYT5h+Hr49FMD4fM4XJQ5aiiyllFlaOKamd1g/X62x0uB5GBkUQFRhEZGEl0YDRh/mH4iOedIr3Fk0rvEKCqtpWSe4yoAGNMRZMntjItkmodxumk8P33qVy1mpodO6jZsaPBUBQ+wcH49+uHf1ISAf2S8E+yln2jo6yexCtXUblqFZXr1mGqrUED/BISCB49iqDRYwgePQr//v0RHx9clZXkvfAi+a++ii0khLjbbiViypRm9SZWXYcxhpKaEnIrcsmpzCG3Ipfcyty695yKHPIq88ipyMHualgUGeIXQrh/uPUKCN+73GjdR3wot5dbL0c5FfYKKuwVlDusbRX2irr9FQ5rX5WjCodxHNa9+Yov3QK7ERUY1SCQ1C7Hh8VzVM+jDunaLVqHISJLgVNqZ9pzz7z3rTFmwiGlzks0YHifPSeH7FtupWL5cnx79SQgqR/+/fq5A4MVHHzjYj0qxjE1NVRt2kTFqtVUrlpJxarVOPPzAfCJiCA4OZnqbduwZ2YSMWUKcbfegm9UlLdvUbURYwx5lXnsLNlJemk6hVWFVDur615VjipqnDVUOav2bne497l/nRdUFVDt3HfkojC/MGKDY4kNjiUuKI6Y4BjiguII9Q+l3F5OSXUJJTXu136Wq5xV+0mxJcAWQIhfCMG+wda7XzDBfsGE+IbUrQf5BhFgC6h7D/QNJNAWSKBv4H63iwjF1cXkV+VTWFVIQVUBBVUFFFYVkl+VX7dcUFVAub0cgJGxI3n7jLcP6W/fonUYWIMN1g0Eb4wpE5HmF0KrDq18yRKybr0NV3k5PR9+iG7nnXdY16vtKxE0ciT8aTrGGOw7d1oBZPUqKlauwic8jMQ33yBk3LiWuQnlEbvLTmlNKcXVxXUPzuKaYkqqSyi3lxPsF0y4fzgRARF0C+hGREAEEf4RhPmHYfM58CB4xhiKqovqgkJacRrppemkl6Szs2QnFY59Cy38ffwJsAUQ4Btgvdd/+QYQERCBv82fQFsg0UHRxAbFEhccR0xQTN17sN/hPa5qnDV1fweD2RsYfIO9VpTVI2TfAR/3p9pZTWFVIXZn0403Woond1suIqONMasARGQMUOndZKn2wjid5L3wInnPP49/v370ef01Aga0/PznIlI3rHS386e0+PW7OqfLSW5lLtll2ewq38Wu8l1kl2VTUFWwT1DY34PbU2H+YUT4R1hBxB1IRISM0gzSStIordk7vLhNbPQO7U1ieCKju4+mT3gf+oT1ITE8keigaAJsAe2i3N7f5k9MUAwxQc0b9r01BNgCPA4uLcGTgHEj8KGIZGONI9UDuNibiVLtgyMvj+zbbqP8lyVEnHsuPe6795BaOCnvchkXpTWlFFQVsKvMHQzKs9lVZr3vLt/NnvI9+5SjRwZEEh0UTbh/OD1De3KE/xFEBEQ0KLuP8I+oK8OPCIggxC+ESnslxTXFFFUXUVxdXJcTqV0urimuW84szcRpnCSEJXBG0hkkhiXSN6IviWGJ9A7rjZ+PXxv91dSh8GQsqRUiMhg4wr3pN2NM6+R/VJspX76c7H/cgrOkhJ7/epCI88/XJqYHYYwhpyKH7cXbrVeR9b6jeAcO4yDUL5RQv1BC/EII9bfew/zCCPEPqdse5h9GiF8IQbYgyh17y9frioca5QZKakoorSnF0LAu0iY24oLj6BnSk+S4ZHqF9KJnaE/rPaQnPUJ6HHJRTYAtgG6B3ehDn5b4s6kOxJN+GNcC7xhj1rvXI0VkqjHmv15PnWp1xuUif9ZL5D77LP6JiSS8/BKBRxxx8BO7EKfLSVZZ1n4DQ5l977zPYf5h9I/oz/HxxxNgC6DcXk6pvZRyezm5Fbmk2dMos5dRVlNGjaumyc/0Fd+9rXUCwokKjCIpIqkuN1Bbn9Ar1AoIccFxXm8qqroeT/5F/dkY83ztijGmUET+DGjA6GQcBQVk33Y75T/9RPiZZ9Lj/vtbba7l9qjCXsHOkp3sKN7BjpId1nvxDtKK0xo84GODYukX0Y+z+59Nv4h+1qtbP6IDPZ+nosZZQ7m9vC6AVDoq65p6RgREEOQbpDk81eY8CRg2EZHayZPc/TB0PIROpmLlSrJu/gfOwkJ6zJhBt4sv6hIPKGMM+VX5dcGg/iu7PLvuOB/xIT40nqSIJCb0mlAXFGp/5R8uf5s//jZ/IgMjD/taSnmLJwHja+B9Efmfe/0vwFfeS5JqTcblouDVV8l56mn84nvTd/Z7BA5tV8OEeWR3+W5W7VlFflU+lY5KqhxVVDoqrWV3O/39bS+tKa1ryw4Q5BtE3/C+JMclMyViCv0irKCQGJ5IgC2gDe9QqbbnScC4HWsa1L+619dhtZRSHZhxuSj74QfyZ71E5erVhJ12Gj0ffABb2KHOl9W6ssuyWbF7Bal7UkndnUpmWWaD/T7iQ5BvEEG+QXWdpIJ9gwn0DSQ2OLZue7BfMH3C+5AUnkRSRBLdQ7q3i6acSrVHnrSSconIMqA/cBHWFKofezthyjuM3U7xF19Q8MorVG/Zim/PnvSYeT/dLryw3RZBGWPILMskdXdqXYCoLS4K9w8npXsKlw65lJTuKfQK7VXXoaq93o9SHdUBA4aIDAKmul95wPsAxpiTPL24iEwGnsGace9lY8zDjfY/BdReLxiIM8Z0c+9zAr+696UbY87x9HPVvlzl5RR99BH5r7+BY9cuAgYOpNcjDxN+xhmIX/tqC19WU0Z6aTqb8jeRuieVFbtXsKdiD2D1HUjpkcIVw64gpXsKAyMHao5AqVbSVA5jM/AjcJYxZiuAeypVj7grx58HJgGZwAoRmWeM2Vh7jDHmpnrHXw+MqneJSmNMsqefp/bPUVBAwVtvUfjue7iKiwlOSaHHffcSesIJbfYLvHaIiPTSdDJKM8goybCGiChNJ7M0k4KqgrpjowKjSOmewtgeY0npnkK/bv00QCjVRpoKGOcDlwALReRrYDZWT29PjQO2GmO2A4jIbOBcrHm692cqcF8zrq+aUJORQcFrr1H08SeYmhpCT55IzP/9H0HJya3y+VWOKmsICndv46yyLDJKM0gvsYJCqX3vEBGC0COkBwlhCZyUcBKJ4YkkhCXQv1t/ksKTtGhJqXbigAHDGDMXmOse3vxcrCFC4kTkBWCOMebbg1y7N5BRbz0TGL+/A0WkD5AELKi3OVBEUrHm4HjYnZ7G512NVSFPYmLiQZLTNVRt3Ej+y69Q8vXXYLMRcc7ZRF91FQH9+rXo51TYK8guyya7PNt6dy/vKttFVlkW+VX5DY6vHTcoISyBkbEj64JC7RAR2gJJqfbPk0rvcuBd4F0RiQQuxGo5dbCA0RyXAB/Vzrnh1scYkyUi/YAFIvKrMWZbo7TNAmaBNbx5C6anw3EWFbHn4UconjsXn5AQov40nagrpuHXvenJiTxV5ahi2a5lLMxYyI9ZP5JTkdNgv5+PHz1DetIrtBcnJJxAr5Bedb2Oe4f2JjY4VnseK9XBNet/sDGmEOsBPcuDw7OAhHrr8e5t+3MJcG2jz8pyv28XkUVY9Rvb9j1VlXzzLbsfeABnYSHRV19N9P9dhS388DuT5VXmsThzMQszFrI0eylVzipC/EI4ptcxDI0e2iAgRAdFa92CUp2cN3/yrQAGikgSVqC4BLi08UHugQ0jgSX1tkUCFcaYahGJAY4BHvViWr2uJj0dZ3ExgcOHt1iZvCM3l90PPEjpt98SMHQIiS/NInDIkEO+njGGLUVbWJSxiB8yfmBd3joAeoX04vyB53NCwgmM7T4WP1v7alWllGodXgsYxhiHiFwHfIPVrPZVY8wGEZkJpBpj5rkPvQSYXTv0iNsQ4H8i4gJ8sOowDlRZ3u45CgrY+cfLcOTmEjhiBFFXXEH4aacecnNWYwzFcz9lz8MPYyorib35ZqL/NP2Qrmd32kndk8qijEUsylhU17/hyJgjuX7U9ZwQfwKDIgdpxbNS6uBTtHYU7XWKVmMMmX+7hvKffyb6b3+lZN5n1KSl4du9O5GXXkq3iy7EN9Lz8YPs2dnsum8G5T/+SNDo0fR88IFmVWg7XA425m9k+e7lLN+1nDW5a6h0VBJgC+DonkdzYsKJHB9/PLHBsYdyu0qpDqZF5/TuKNprwCh46232/OtfdL/rLqKuuBzjclH+448UvPEm5b/8ggQGEnHuuURdcTkB/fsf8DrG5aJw9mxyH38CA8TdfDORl05FfJquN3C6nPxW+Bsrdq9g2a5lrMpZVTd20oBuAxjXYxxH9zqa8T3HE+Qb1JK3rpTqADRgtBNVmzeTduFFhEyYQPyLL+xTrFP1++8UvvUWxZ/Ow9TUEHLccURdcQUhxx7T4NjqHTvYdc89VKauJGTCBHrMnIl/fO/9fqYxhq1FW+tyEKl7UimpKQGgb3hfxvUYx9ieYxnbfSzRQdHeu3mlVIegAaMdcFVUsOOCC3GVlpL06Vx8o6IOeKyjoICiDz6g8J13ceTm4t+/P1GXX074WWdSNHs2uc/9BwkIoPsddxAx5bx9Ao8xho0FG5m7ZS7f7vy2rqd079DeVoDoMZZxPcbRPaS7V+9ZKdXxaMBoB3bdcy9FH31E4quvEHL00R6dY2pqKPn6awpef4OqjRvB1xccDsImnUL3e+7BL65hn4qCqgI+3/Y5c7fNZUvhFvx9/Dkp8SSO6XUM43qOo3fo/nMhSilVqzkBQ3tSeUHJ199Q9OGHRP/5/zwOFgDi70/EOecQfvbZVK5aRfHnnxMy/ijCTju1Lldhd9n5KfMn5m6dy+LMxTiMgyNjjuSeo+7htL6nEREQ4a3bUkp1cRowWpg9O5td995L4IgRxN5wwyFdQ0QIHjOG4DFj6rZtLdzK3K1z+Wz7ZxRUFRAdGM1lQy/j3P7nMiByQEslXymlDkgDRgsyDgdZt94GTie9H3/ssIcNL6kp4avtXzF361zW56/HV3w5IeEEzhtwHsf0PgY/H+1Ap5RqPRowWlDeCy9SuXIlvR57FP/DGAyxxlnDmxvfZNa6WVQ6KhkUOYjbxt7Gmf3OJCrwwJXnSinlTRowWkhFaip5L7xAxLnnEHH22Yd0DWMMizMX88iKR8gozWBiwkT+MvIvDIkaoj2tlVJtTgNGC3AWFZF16234JcTT/Z57D+kaO4p38OiKR/kp6yeSIpL43yn/Y0LvCS2cUqWUOnQaMA6TMYZd99yLIzeXvu+9iy00pFnnl9WUMWvdLN7a9BaBtkBuTbmVqUOmav2EUqrd0YBxmIo++JDS774j7tZbCDrySI/PcxkXn2//nKdWPkVeZR5TBkzhhtE3EBMU48XUKqXUodOAcRiqt25lz0MPETJhAlF/+pPH563PW89Dyx9iXe46jow5kmdPepYjYz0PNkq1BLvdTmZmJlVVVW2dFNUKAgMDiY+Px+8wWm9qwDhErupqsm7+Bz7BwfR8+KGDDgIIkF+Zz7Orn2XOljlEBUbxwDEPcE7/c3TiIdUmMjMzCQsLo2/fvtqoopMzxpCfn09mZiZJSUmHfB0NGIco59HHqP79dxL+9+I+Q3bsz2fbPuOhZQ9R6ajkiqFX8JeRfyHMP6wVUqrU/lVVVWmw6CJEhOjoaHJzcw/rOl79aSsik0XkNxHZKiJ37Gf/UyKyxv36XUSK6u2bJiJb3K9p3kxnc5XOn0/hO+8QNe0KQk844aDHL0hfwD9/+icDIwfy8bkfc8vYWzRYqHZBg0XX0RLftddyGCJiA54HJgGZwAoRmVd/5jxjzE31jr8ea95uRCQKuA9IAQyw0n1uobfS66nqHTvIvv0OAocNI/Yf/zjo8b/m/srti29neMxwXpz0os45oZTqsLyZwxgHbDXGbDfG1ACzgXObOH4q8J57+TTgO2NMgTtIfAdM9mJaPeKqqCDrhhsQX1/in30GH3//Jo/PKM3gugXXER0UzXMTn9NgoVQjNpuN5ORkhg8fztlnn01RUVGrfO7TTz9NRUXFPtunTJlCcnIyAwYMICIiguTkZJKTk/nll188uu6ECZ2775Q3A0ZvIKPeeqZ72z5EpA+QBCxo7rmtxRjDrrvvoXrrNno98Th+vZtOTlFVEdd8fw1O4+SFU17QyYqU2o+goCDWrFnD+vXriYqK4vnnn2+Vzz1QwJgzZw5r1qzh5Zdf5rjjjmPNmjWsWbOmLhA4HI4mr+tpYOmo2kul9yXAR8YYZ3NOEpGrgasBEg9j7CZPFL71FiVffknsjTcSeswxTR5b7azmhoU3kF2WzUunvkRSxKG3SlCqNdz/2QY2Zpe06DWH9grnvrOHeXz80Ucfzbp16wDYtm0b1157Lbm5uQQHB/PSSy8xePBgPvzwQ+6//35sNhsREREsXryY119/nXnz5lFRUcG2bduYMmUKjz76KADffvst9913H9XV1fTv35/XXnuNV199lezsbE466SRiYmJYuHBhk+l6/fXX+eSTTygrK8PpdPLFF19w7rnnUlhYiN1u58EHH+Tcc63Ck9DQUMrKyli0aBEzZswgJiaG9evXM2bMGN5+++0OX2fkzYCRBSTUW493b9ufS4BrG517YqNzFzU+yRgzC5gF1gRKh57UplWkprLn0ccIPflkoq/+c5PHuoyLu368i9U5q3nshMcY3X20t5KlVKfhdDqZP38+V111FQBXX301L774IgMHDmTZsmVcc801LFiwgJkzZ/LNN9/Qu3fvBsVXa9asYfXq1QQEBHDEEUdw/fXXExQUxIMPPsj3339PSEgIjzzyCE8++ST33nsvTz75JAsXLiQmxrOOsqtWrWLdunVERUXhcDiYM2cO4eHh5OXlcdRRR3HOOefsEwxWr17Nhg0b6NWrF8cccww///wzxx57bIv9zdqCNwPGCmCgiCRhBYBLgEsbHyQig4FIYEm9zd8A/xaRSPf6qcCdXkzrAdlzcsi86Sb8e/emlwf9LZ5e+TTf7vyWf4z5B5P7tnm1i1IeaU5OoCVVVlaSnJxMVlYWQ4YMYdKkSZSVlfHLL79w4YUX1h1XXV0NwDHHHMP06dO56KKLOP/88+v2n3zyyUREWJOHDR06lJ07d1JUVMTGjRs5xl0iUFNTw9HNmNCsvkmTJhHlnmbZGMNdd93F4sWL8fHxISsriz179tCjR48G54wbN474+HgAkpOTSUtL04BxIMYYh4hch/XwtwGvGmM2iMhMINUYM8996CXAbFNvrlhjTIGIPIAVdABmGmMKvJXWAzF2O1k33oSrrJzEV17BFtZ0U9j3Nr/Haxte45IjLmHasHbVElipdqm2DqOiooLTTjuN559/nunTp9OtWzfWrFmzz/Evvvgiy5Yt44svvmDMmDGsXLkSgICAgLpjbDYbDocDYwyTJk3ivffe2+c6zRUSsneMuHfeeYfc3FxWrlyJn58fffv23W9v+f2lqaPzaj8MY8yXxphBxpj+xph/ubfdWy9YYIyZYYzZp4+GMeZVY8wA9+s1b6bzQPY8+hiVq1bR88EHCBw0qMljF6Yv5OHlD3Ni/IncMe6ODl9WqVRrCg4O5tlnn+WJJ54gODiYpKQkPvzwQ8D6Rb927VrAqtsYP348M2fOJDY2loyMjANe86ijjuLnn39m69atAJSXl/P7778DEBYWRmlp6SGltbi4mLi4OPz8/Fi4cCE7d+48pOt0RDomxQEUf/Y5hW+9RdS0K4g488wmj12ft57bFt/G0KihPHL8I9h8bK2USqU6j1GjRjFixAjee+893nnnHV555RVGjhzJsGHD+PTTTwG49dZbOfLIIxk+fDgTJkxg5MiRB7xebGwsr7/+OlOnTmXEiBEcffTRbN68GbDqSCZPnsxJJ53U7HT+8Y9/JDU1lSOPPJI333yTwYMHH9oNd0BSrySoQ0tJSTGpqaktcq2q334n7ZJLCBw2lD6vvdbkVKuZpZn88cs/EuQbxNtnvK2jzaoOY9OmTQwZMqStk6Fa0f6+cxFZaYxJ8eR8zWE04iwpIfOG67GFhhL/1FNNBovi6mL+9v3fcLgc/PeU/2qwUEp1au2lH0a7YFwusm+/A3tWNn3efAPf2NgDHlvtrOaGBTeQVZbFS6e+RL+Ifq2YUqWUan2aw6gnf9YsyhYupPvttxM8+sD9J1zGxd0/3c2qnFX8+9h/M6b7mFZMpVJKtQ0NGG5lP/1M7jPPEn7WWURe9scmj/1066d8nfY1N4+5mclJ2tdCKdU1aMAAajKzyP7HPwgYOJCeM+8/aJPYb3Z+Q3xoPNOHTW+dBCqlVDvQ5QOGq7qarBtuwLhcxD/3LD7BwU0eX1pTyrJdyzg58WTta6GU6lK6fMBw5uXhqqyk1yOP4N+nz0GP/ynrJxwuBxMTJ7ZC6pTq3Nrb8Ob3338/d97ZcBSiNWvWNNn8eMaMGTz++OMA3HvvvXz//ff7HLNo0SLOOuusJtO0Zs0avvzyy7r1efPm8fDDDzd5Tmvr8gHDr3dv+s37lLCJnnXgmZ8+n6jAKEbGHrjDkFLKM+1tePOpU6fy/vvvN9g2e/Zspk6d6tF1Z86cySmnnHJIaWocMM455xzuuGOfQTDalDarhSb7WtRX7azmx8wfOT3pdO3NrTqXr+6A3b+27DV7HAmne/4LuT0Mbz5o0CAiIyNZtmwZ48ePB+CDDz7gm2++4aWXXmLWrFnU1NQwYMAA3nrrLYIbFWFPnz6ds846iwsuuICvv/6aG2+8keDg4AaDDi5fvpy///3vVFVVERQUxGuvvUZSUhL33nsvlZWV/PTTT9x5551UVlaSmprKf/7zH9LS0rjyyivJy8sjNjaW1157jcTERKZPn054eDipqans3r2bRx99lAsuuOCQv7KD6fI5jOZYtmsZFY4KLY5SqoXVDm9+zjnnANbQHc899xwrV67k8ccf55prrgGoG9587dq1zJtXNyQda9as4f333+fXX3/l/fffJyMjg7y8vLrhzVetWkVKSgpPPvkkN9xwA7169WLhwoX7nQtj6tSpzJ49G4ClS5cSFRXFwIEDOf/881mxYgVr165lyJAhvPLKKwe8n6qqKv785z/z2WefsXLlSnbv3l23b/Dgwfz444+sXr2amTNnctddd+Hv78/MmTO5+OKLWbNmDRdffHGD611//fVMmzaNdevW8cc//pEbbrihbt+uXbv46aef+Pzzz72eI9EcRjMsSF9AsG8wR/U8qq2TolTLakZOoCW1x+HNL774YiZMmMATTzzRoDhq/fr13H333RQVFVFWVsZpp512wGts3ryZpKQkBg4cCMBll13GrFmzAGvwwmnTprFlyxZEBLvdftA0LVmyhE8++QSAyy+/nNtuu61u33nnnYePjw9Dhw5lz549B73W4dCA4SGny8nCjIUcF38c/ram5/JWSnmmPQ5vnpCQQFJSEj/88AMff/wxS5ZYU/VMnz6duXPnMnLkSF5//XUWLVp0SPd8zz33cNJJJzFnzhzS0tI48cQTD+k6terfu7fHBtQiKQ+tzV1LQVUBJyee3NZJUarTaW/Dm0+dOpWbbrqJfv361U2CVFpaSs+ePbHb7bzzzjtN3s/gwYNJS0tj27ZtAA2CVnFxMb179was6V9rNZWmCRMm1BWTvfPOOxx33HFNfr63aMDw0IL0Bfj6+HJs7449Y5ZS7VV7Gt78wgsvZMOGDQ1aRz3wwAOMHz+eY4455qBDmgcGBjJr1izOPPNMRo8eTVxcXN2+2267jTvvvJNRo0Y1mFTppJNOYuPGjSQnJ+/TUuu5557jtddeY8SIEbz11ls888wzTX6+t3h1eHMRmQw8gzXj3svGmH0KSkXkImAGYIC1xphL3dudQG2zjXRjzDlNfVZLDm/emDGGMz45gz4RfXjxlBe98hlKtTYd3rzrOdzhzb1WhyEiNuB5YBKQCawQkXnGmI31jhmINVf3McaYQhGJq3eJSmNMsrfS1xy/F/5OZlkmVx55ZVsnRSml2ow3i6TGAVuNMduNMTXAbODcRsf8GXjeGFMIYIzJ8WJ6DtmCjAUIwkkJzZ+dSymlOgtvBozeQP0aqUz3tvoGAYNE5GcRWeouwqoVKCKp7u3n7e8DRORq9zGpubm5LZr4+hakL2Bk7EidIEkp1aW1daW3LzAQOBGYCrwkIt3c+/q4y9UuBZ4Wkf6NTzbGzDLGpBhjUmKbmOzocGSVZbG5YLN21lNKdXneDBhZQEK99Xj3tvoygXnGGLsxZgfwO1YAwRiT5X7fDiwCRnkxrQe0IH0BgDanVUp1ed4MGCuAgSKSJCL+wCXAvEbHzMXKXSAiMVhFVNtFJFJEAuptPwbYSBtYkL6AAd0GkBie2BYfr5RS7YbXAoYxxgFcB3wDbAI+MMZsEJGZIlLbRPYbIF9ENgILgVuNMfnAECBVRNa6tz9cv3VVaymoKmBVziotjlLKS0SEyy67rG7d4XAQGxt70KHAG+vbty95eXnNOsbpdDJq1Kj9fta1115LcnIyQ4cOJSgoiOTkZJKTk/noo488Ss8ZZ5zRakO1tyavDg1ijPkS+LLRtnvrLRvgZver/jG/AEd6M22e+CHjB1zGpcVRSnlJSEgI69evp7KykqCgIL777ru6XtDe9swzzzBkyBBKSkr22Vc7zHpaWhpnnXXWPsOUOBwOfH0P/PisP0x5Z6JjSTVhQfoCeob0ZEiUdm5Sndsjyx9hc8HmFr3m4KjB3D7u9oMed8YZZ/DFF19wwQUX8N577zF16lR+/PFHAAoKCrjyyivZvn07wcHBzJo1ixEjRpCfn8/UqVPJysri6KOPbjCG0ttvv82zzz5LTU0N48eP57///S82W8PpCDIzM/niiy/45z//yZNPPunR/SxatIh77rmHyMhINm/ezO+//855551HRkYGVVVV/P3vf+fqq68GrNxMamoqZWVlnH766Rx77LH88ssv9O7dm08//ZSgoCBP/4ztSlu3kmq3KuwV/JL9CxMTJ+pUrEp50SWXXMLs2bOpqqpi3bp1dfNQANx3332MGjWKdevW8e9//5srrrgCsGbGO/bYY9mwYQNTpkwhPT0dsHoyv//++/z888+sWbMGm82233GfbrzxRh599FF8fJr3CFy1ahXPPPNM3ZhUr776KitXriQ1NZVnn32W/Pz8fc7ZsmUL1157LRs2bKBbt258/PHHzfrM9kRzGAfwc/bP1LhqmJig9Req8/MkJ+AtI0aMIC0tjffee48zzjijwb6ffvqp7gE7ceJE8vPzKSkpYfHixXXDfZ955plERkYCMH/+fFauXMnYsWMBa/j0+uM4AXz++efExcUxZsyYZo84O27cOJKSkurWn332WebMmQNARkYGW7ZsITo6usE5SUlJJCcnAzBmzBjS0tKa9ZntiQaMA5ifPp9uAd0Y3X10WydFqU7vnHPO4ZZbbmHRokX7/ZXuKWMM06ZN46GHHjrgMT///DPz5s3jyy+/pKqqipKSEi677DLefvvtg14/JCSkbnnRokV8//33LFmyhODgYE488USqqqr2Oafx0OuVlZXNvKv2Q4uk9sPutLM4YzEnxJ+Ar4/GVKW87corr+S+++7jyCMbtnU57rjj6oqUFi1aRExMDOHh4Rx//PG8++67AHz11VcUFhYC1kRKH330ETk51ihDBQUF7Ny5s8E1H3roITIzM0lLS2P27NlMnDjRo2DRWHFxMZGRkQQHB7N582aWLl3a7Gt0NPo03I8Ve1ZQai/V5rRKtZL4+PgG047WmjFjBldeeSUjRowgODiYN954A7DqNqZOncqwYcOYMGECiYlWP6mhQ4fy4IMPcuqpp+JyufDz8+P555+nT58+LZ7myZMn8+KLLzJkyBCOOOIIjjqq88/E6dXhzVtTSw5v/uDSB5m3bR6LL15MoG9gi1xTqfZGhzfveg53eHMtkmrEZVwsTF/IhF4TNFgopVQ9GjAaWZ+3npzKHO2sp5RSjWjAaGRB+gJsYuP4+OPbOilKKdWuaMBoZH76fFJ6pBARENHWSVFKqXZFA0Y924u2k1aSpsVRSim1Hxow6lmQYc19oVOxKqXUvjRg1DN/53yGRw+nR0iPtk6KUl1Cex3e/I033mDq1KkNtuXl5REbG0t1dfV+r//6669z3XXXAfDiiy/y5ptv7nNMWloaw4cPbzKdaWlpdZ0SAVJTU/fbR6UtaMBw212+m/X567WznlKtqP7w5kCbDG++P1OmTOG7776joqKibttHH33E2Wef3WCojwP561//WjdQYnM1DhgpKSk8++yzh3StlubVnt4iMhl4BrABLxtjHt7PMRcBMwADrDXGXOrePg24233Yg8aYN7yZ1oUZCwGdilV1Tbv//W+qN7Xs8OYBQwbT4667DnpcexzePDw8nBNOOIHPPvuMiy++GIDZs2fzz3/+k88++4wHH3yQmpoaoqOjeeedd+jevXuD82fMmEFoaCi33HILK1eu5MorrwTg1FNPrTsmLS2Nyy+/nPLycgD+85//MGHCBO644w42bdpEcnIy06ZNY9SoUTz++ON8/vnnB/x7zJgxg/T0dLZv3056ejo33nijV3IlXsthiIgNeB44HRgKTBWRoY2OGQjcCRxjjBkG3OjeHgXcB4wHxgH3iUikt9IKVnPavuF96detnzc/RinVSHsd3nzq1KnMnj0bgOzsbH7//XcmTpzIsccey9KlS1m9ejWXXHIJjz76aJP396c//YnnnnuOtWvXNtgeFxfHd999x6pVq3j//ffrHvAPP/wwxx13HGvWrOGmm25qcM6B/h4Amzdv5ptvvmH58uXcf//92O32JtN1KLyZwxgHbDXGbAcQkdnAuTScm/vPwPPGmEIAY0yOe/tpwHfGmAL3ud8Bk4H3vJHQ4upiUnencsWwQ8tCKtXReZIT8Jb2Orz5mWeeyTXXXENJSQkffPABf/jDH7DZbGRmZnLxxReza9cuampqGgx33lhRURFFRUUcf7zVr+vyyy/nq6++AsBut3PdddfVBbbaOTaacqC/R216AwICCAgIIC4ujj179hAfH3/QazaHNwNGbyCj3nomVo6hvkEAIvIzVrHVDGPM1wc412sFm4szF+MwDi2OUqqNtMfhzYOCgpg8eTJz5sxh9uzZdUVX119/PTfffDPnnHMOixYtYsaMGYeU1qeeeoru3buzdu1aXC4XgYGHNxRR42HUHQ7HYV1vf9q60tsXGAicCEwFXhKRbp6eLCJXi0iqiKTm5uYeciIWpC8gNiiW4TFNt15QSnlHex3efOrUqTz55JPs2bOHo48+GrCGNa+tmK8dPfdAunXrRrdu3fjpp58AGhSPFRcX07NnT3x8fHjrrbdwOp0AhIWFUVpaut/rHejv0Vq8GTCygIR66/HubfVlAvOMMXZjzA7gd6wA4sm5GGNmGWNSjDEpsbGxh5TIKkcVP2f/zMTEifhIW8dPpbqmpoY3X7lyJSNGjOCOO+5oMLz54sWLGTZsGJ988sl+hzcfMWIEkyZNYteuXYecrkmTJpGdnc3FF19cN1XzjBkzuPDCCxkzZgwxMTEHvcZrr73GtddeS3JycoPK+WuuuYY33niDkSNHsnnz5rrJmUaMGIHNZmPkyJE89dRTHv09WovXhjcXEV+sAHAy1sN+BXCpMWZDvWMmA1ONMdNEJAZYDSRjtZhaCdROd7cKGFNbp7E/hzq8eW5FLo+lPsaFgy5kbI+xzT5fqY5Khzfveg53eHOv1WEYYxwich3wDVb9xKvGmA0iMhNINcbMc+87VUQ2Ak7gVmNMPoCIPIAVZABmNhUsDkdscCyPHt90KwellFJe7odhjPkS+LLRtnvrLRvgZver8bmvAq96M31KKaU8p4X2SnVhnWXGTXVwLfFda8BQqosKDAwkPz9fg0YXYIwhPz//sJvuerVISinVfsXHx5OZmcnhNElXHUdgYOBhd+TTgKFUF+Xn59dkL2WlGtMiKaWUUh7RgKGUUsojGjCUUkp5xGs9vVubiOQCOw964IHFAE1P2dV56b13XV35/rvyvcPe++9jjPFobKVOEzAOl4iketo9vrPRe++a9w5d+/678r3Dod2/FkkppZTyiAYMpZRSHtGAsdestk5AG9J777q68v135XuHQ7h/rcNQSinlEc1hKKWU8ogGDKWUUh7p8gFDRCaLyG8islVE7mjr9LQ2EUkTkV9FZI2INH/Kwg5ERF4VkRwRWV9vW5SIfCciW9zvkW2ZRm86wP3PEJEs9/e/RkTOaMs0eouIJIjIQhHZKCIbROTv7u2d/vtv4t6b/d136ToMEbFhTSM7CWt+8RVYU8ZubNOEtSIRSQNSjDGdvgOTiBwPlAFvGmOGu7c9ChQYYx52/2CINMbc3pbp9JYD3P8MoMwY83hbps3bRKQn0NMYs0pEwrCmgD4PmE4n//6buPeLaOZ339VzGOOArcaY7caYGmA2cG4bp0l5iTFmMdB4qt9zgTfcy29g/UfqlA5w/12CMWaXMWaVe7kU2AT0pgt8/03ce7N19YDRG8iot57JIf4hOzADfCsiK0Xk6rZOTBvobozZ5V7eDXRvy8S0ketEZJ27yKrTFck0JiJ9gVHAMrrY99/o3qGZ331XDxgKjjXGjAZOB651F1t0Se455rtaGe0LQH8gGdgFPNGmqfEyEQkFPgZuNMaU1N/X2b///dx7s7/7rh4wsoCEeuvx7m1dhjEmy/2eA8zBKqbrSva4y3hry3pz2jg9rcoYs8cY4zTGuICX6MTfv4j4YT0w3zHGfOLe3CW+//3d+6F89109YKwABopIkoj4A5cA89o4Ta1GRELclWCISAhwKrC+6bM6nXnANPfyNODTNkxLq6t9WLpNoZN+/yIiwCvAJmPMk/V2dfrv/0D3fijffZduJQXgbkr2NGADXjXG/KttU9R6RKQfVq4CrOl63+3M9y8i7wEnYg3rvAe4D5gLfAAkYg2Pf5ExplNWDB/g/k/EKpIwQBrwl3pl+p2GiBwL/Aj8Crjcm+/CKsvv1N9/E/c+lWZ+910+YCillPJMVy+SUkop5SENGEoppTyiAUMppZRHNGAopZTyiAYMpZRSHtGAodRBiIiz3oiea1pyVGMR6Vt/9Fil2jPftk6AUh1ApTEmua0ToVRb0xyGUofIPZfIo+75RJaLyAD39r4issA9qNt8EUl0b+8uInNEZK37NcF9KZuIvOSeq+BbEQlyH3+Dew6DdSIyu41uU6k6GjCUOrigRkVSF9fbV2yMORL4D9aIAQDPAW8YY0YA7wDPurc/C/xgjBkJjAY2uLcPBJ43xgwDioA/uLffAYxyX+ev3rk1pTynPb2VOggRKTPGhO5nexow0Riz3T24225jTLSI5GFNWGN3b99ljIkRkVwg3hhTXe8afYHvjDED3eu3A37GmAdF5GusCY/mAnONMWVevlWlmqQ5DKUOjznAcnNU11t2srdu8UzgeazcyAoR0TpH1aY0YCh1eC6u977EvfwL1sjHAH/EGvgNYD7wN7CmBxaRiANdVER8gARjzELgdiAC2CeXo1Rr0l8sSh1ckIisqbf+tTGmtmltpIisw8olTHVvux54TURuBXKBP7m3/x2YJSJXYeUk/oY1cc3+2IC33UFFgGeNMUUtdD9KHRKtw1DqELnrMFKMMXltnRalWoMWSSmllPKI5jCUUkp5RHMYSimlPKIBQymllEc0YCillPKIBgyllFIe0YChlFLKI/8PgxWE9z4xDpcAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.19057846069335938 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "plt.plot(history2.history['accuracy'])\n",
+    "plt.plot(history2.history['val_accuracy'])\n",
+    "plt.plot(history4.history['accuracy'])\n",
+    "plt.plot(history4.history['val_accuracy'])\n",
+    "plt.title(\"Model Accuracy\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Accuracy')\n",
+    "plt.legend(['Resnet Train', 'Resnet Validation', 'Model4 Train', 'Model4 Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "loaded-chain",
+   "metadata": {
+    "papermill": {
+     "duration": 1.403455,
+     "end_time": "2021-04-25T15:07:56.150249",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:54.746794",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6.11 Model 1, Model 2 v/s Model 4 :\n",
+    "\n",
+    "#### Loss v/s no. of epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "closing-rachel",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:07:59.368715Z",
+     "iopub.status.busy": "2021-04-25T15:07:59.367433Z",
+     "iopub.status.idle": "2021-04-25T15:07:59.536928Z",
+     "shell.execute_reply": "2021-04-25T15:07:59.536174Z"
+    },
+    "papermill": {
+     "duration": 1.646844,
+     "end_time": "2021-04-25T15:07:59.537109",
+     "exception": false,
+     "start_time": "2021-04-25T15:07:57.890265",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAEWCAYAAABi5jCmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAABvcklEQVR4nO2dd3hVRfrHP3NLckt6hRSaIIQQCEVp0hWxoYKK2LGtoqg/XQF1FdZd7A0U+yoqCroCVnQtVEGUjvSakJAQ0ttNctv8/jg3lwQSUkiDzOd5znPOmTNnzjv3Jud7Z96Zd4SUEoVCoVAoytE1twEKhUKhaFkoYVAoFApFJZQwKBQKhaISShgUCoVCUQklDAqFQqGohBIGhUKhUFRCCYNCUQNCiA5CCCmEMNQi721CiN+awi6ForFQwqA4qxBCJAkh7EKIsBPSN3te7h2aybQ6CYxC0ZwoYVCcjRwCJpafCCESAEvzmaNQnFkoYVCcjXwC3FLh/Fbg44oZhBCBQoiPhRCZQohkIcQ/hBA6zzW9EOIlIUSWEOIgcFkV9/5HCJEuhDgihPi3EEJ/OgYLIaKEEN8IIXKEEPuFEHdVuHa+EGKDEKJACJEhhHjFk24SQswXQmQLIfKEEOuFEJGnY4dCAUoYFGcn64AAIUSc54V9PTD/hDyvA4FAJ2AYmpBM8ly7C7gc6A30A6454d55gBPo7MkzGrjzNG1eCKQCUZ7nPSOEGOm5NhuYLaUMAM4BvvCk3+qpQywQCtwDlJymHQqFEgbFWUt5q+EiYBdwpPxCBbF4TEpZKKVMAl4GbvZkuQ54TUqZIqXMAZ6tcG8kcCnwkJSyWEp5DHjVU169EELEAoOBaVLKUinlFuB9jrd6HEBnIUSYlLJISrmuQnoo0FlK6ZJSbpRSFtTXDoWiHCUMirOVT4AbgNs4oRsJCAOMQHKFtGQg2nMcBaSccK2c9p570z3dN3nAO0DEadgaBeRIKQursecO4Fxgt6e76HJP+ifA/4CFQog0IcQLQgjjadihUABKGBRnKVLKZDQn9KXA4hMuZ6H92m5fIa0dx1sV6WjdMxWvlZMClAFhUsogzxYgpYw/DXPTgBAhhH9V9kgp90kpJ6KJz/PAl0IIq5TSIaX8p5SyOzAIrfvrFhSK00QJg+Js5g5gpJSyuGKilNKF1k8/SwjhL4RoDzzMcT/EF8ADQogYIUQwML3CvenAT8DLQogAIYROCHGOEGJYHezy9TiOTUIIE5oArAWe9aT19Ng+H0AIcZMQIlxK6QbyPGW4hRAjhBAJnq6xAjSxc9fBDoWiSpQwKM5apJQHpJQbqrk8BSgGDgK/AZ8BH3iuvYfWRbMV2MTJLY5bAB9gJ5ALfAm0rYNpRWhO4vJtJNrw2g5orYclwAwp5S+e/GOAHUKIIjRH9PVSyhKgjefZBWh+lJVo3UsKxWkh1EI9CoVCoaiIajEoFAqFohJKGBQKhUJRCSUMCoVCoaiEEgaFQqFQVOKMi/IYFhYmO3To0NxmKBQKxRnFxo0bs6SU4bXJe8YJQ4cOHdiwoboRiAqFQqGoCiFEcs25NFRXkkKhUCgqoYRBoVAoFJVQwqBQKBSKSpxxPgaFQlE3HA4HqamplJaWNrcpiibAZDIRExOD0Vj/QLtKGBSKs5zU1FT8/f3p0KEDQojmNkfRiEgpyc7OJjU1lY4dO9a7HNWVpFCc5ZSWlhIaGqpEoRUghCA0NPS0W4dKGBSKVoAShdZDQ3zXrUcYMnbCr/8CW05zW6JQKBQtmtYjDDkHYPVLkJ9Sc16FQtGgCCG46aabvOdOp5Pw8HAuv/zyU9x1Mh06dCArK6teeZ544gliY2Px8/Or8r4PP/yQxMREEhMT8fHxISEhgcTERKZPn15l/hN56qmn+OWXX2rOeAbQepzPVs9M8OLM5rVDoWiFWK1Wtm/fTklJCWazmZ9//pno6Oiab2xArrjiCu6//366dOlS5fVJkyYxadIkQBOX5cuXExYWVimPy+VCr9dXef/TTz/dsAY3I43WYhBCfCCEOCaE2F5DvvOEEE4hxDWNZQtQQRhO/WtDoVA0Dpdeeinff/89AAsWLGDixIneazk5OVx11VX07NmTAQMGsG3bNgCys7MZPXo08fHx3HnnnVRcWGz+/Pmcf/75JCYm8re//Q2Xy3XK5w8YMIC2beuy0J6Gn58fjzzyCL169eL333/n6aef5rzzzqNHjx7cfffdXptuu+02vvzyS0ATlhkzZtCnTx8SEhLYvXt3nZ/bnDRmi2Ee8AbwcXUZPGvVPo+2hm7jYvUov2oxKFox//x2BzvTChq0zO5RAcy4Ir7GfNdffz1PP/00l19+Odu2beP2229n9erVAMyYMYPevXvz1VdfsWzZMm655Ra2bNnCP//5Ty644AKeeuopvv/+e/7zn/8AsGvXLj7//HPWrFmD0Whk8uTJfPrpp9xyyy0NWjeA4uJi+vfvz8svv6zVt3t3nnrqKQBuvvlmvvvuO6644oqT7gsLC2PTpk28+eabvPTSS7z//vsNbltj0WjCIKVcJYToUEO2KcAi4LzGssOLbwDofZQwKBTNRM+ePUlKSmLBggVceumlla799ttvLFq0CICRI0eSnZ1NQUEBq1atYvFibcntyy67jODgYAB+/fVXNm7cyHnnaa+OkpISIiIiGsVuvV7P+PHjvefLly/nhRdewGazkZOTQ3x8fJXCMG7cOAD69u3rrcOZQrP5GIQQ0cDVwAhqEAYhxN3A3QDt2rWr7wO17iTVlaRoxdTml31jMnbsWP7+97+zYsUKsrOz612OlJJbb72VZ599tgGtqxqTyeT1K5SWljJ58mQ2bNhAbGwsM2fOrHbOgK+vL6AJi9PpbHQ7G5LmHJX0GjBNSumuKaOU8l0pZT8pZb/w8FqFE68aa7hqMSgUzcjtt9/OjBkzSEhIqJQ+ZMgQPv30UwBWrFhBWFgYAQEBDB06lM8++wyAH374gdzcXABGjRrFl19+ybFjxwDNR5GcXOuo0vWmXATCwsIoKiry+hTONppTGPoBC4UQScA1wJtCiKsa9YlKGBSKZiUmJoYHHnjgpPSZM2eyceNGevbsyfTp0/noo48AzfewatUq4uPjWbx4sbfHoHv37vz73/9m9OjR9OzZk4suuoj09PRTPnvq1KnExMRgs9mIiYlh5syZdbY/KCiIu+66ix49enDxxRd7u7LONkRFL3+DF675GL6TUvaoId88T74a5bdfv36y3gv1LLkXDq2Ch3fU736F4gxk165dxMXFNbcZiiakqu9cCLFRStmvNvc3mo9BCLEAGA6ECSFSgRmAEUBK+XZjPfeUWMO0FoOUms9BoVAoFCfRmKOSJtacy5v3tsayoxLWcHCVQVkhmAKa5JEKhUJxptF6QmKAmv2sUCgUtaCVCoMasqpQKBTV0cqEQc1+VigUippoNcKwLn0dN26YRbZOp4RBoVAoTkGrEQa90LMtdze7fX1UV5JC0cQ0V9jt22+/nYiICHr0qHrE/MqVKxk4cGClNKfTSWRkJGlpaVXes2LFCq/d33zzDc8991yV+aoL711OXl4eb775pvc8LS2Na65p3FiitaXVCEO3kG4A7LQEqBaDQtHEVAy7DTRZ2O3bbruNH3/8sdrrQ4YMITU1tdKs6V9++YX4+HiioqJqLH/s2LG1Xq/hRE4UhqioqBYzk7rVCIO/jz/t/Nuxy2xWwqBQNAPNEXZ76NChhISEVGuTTqfjuuuuY+HChd60hQsXMnHiRP78808GDhxI7969GTRoEHv27Dnp/nnz5nH//fcDcOjQIQYOHEhCQgL/+Mc/vHmKiooYNWqUNwT3119/DcD06dM5cOAAiYmJPProoyQlJXlbNqWlpUyaNImEhAR69+7N8uXLvc8bN24cY8aMoUuXLkydOrWGT71+tJ6FeoDuod35q+CIEgZF6+WH6XD0r4Yts00CXFJ1d0pFWmrY7YkTJ3LXXXcxbdo0ysrKWLp0Ka+88goGg4HVq1djMBj45ZdfePzxx70RYKviwQcf5N577+WWW25h7ty53nSTycSSJUsICAggKyuLAQMGMHbsWJ577jm2b9/Oli1bAEhKSvLeM3fuXIQQ/PXXX+zevZvRo0ezd+9eALZs2cLmzZvx9fWla9euTJkyhdjY2DrX+1S0KmGIC43jx6QfyS/KJLC5jVEoWhktNex2v379KCoqYs+ePezatYv+/fsTEhJCSkoKt956K/v27UMIgcPhOGU5a9as8dbh5ptvZtq0aYAWCfbxxx9n1apV6HQ6jhw5QkZGxinL+u2335gyZQoA3bp1o3379l5hGDVqFIGB2huse/fuJCcnK2E4HbqHdgdgpyOHgTXkVSjOSmrxy74xaalhtydOnMjChQvZtWuXt4vrySefZMSIESxZsoSkpCSGDx9eYzmiilA7n376KZmZmWzcuBGj0UiHDh2qDdVdG8rDeUPjhfRuNT4GgLgQLajULlkK7lMvA6hQKBqelhp2e+LEicyfP59ly5Zx5ZVXApCfn+91kM+bN6/GMgYPHuz1VZTXpbyciIgIjEYjy5cv99rp7+9PYWFhlWVV/Dz27t3L4cOH6dq1a73rV1dalTAE+gYSbQxgp48RbDnNbY5C0epo6rDbEydOZODAgezZs4eYmBivj+JE4uLisFqtjBw5EqvVCmhhuh977DF69+5dq1/ls2fPZu7cuSQkJHDkyBFv+o033siGDRtISEjg448/pls3bYRkaGgogwcPpkePHjz66KOVypo8eTJut5uEhAQmTJjAvHnzKrUUGptGDbvdGJxW2G3g4W8msOfYVr6/YjFEdm9AyxSKlokKu936ON2w262qxQAQF9iZw0YjhfmNv9qTQqFQnIm0OmHoHt4TgN1ZarEehUKhqIpWJwxxbbXhbTvz9jWzJQqFQtEyaXXCEBLYgTZOJzuLUpvbFIVCoWiRtDphQKcjziXYWaZmPysUCkVVtD5hALoLC8nuEoodxc1tikKhULQ4Wqcw+AQjgd05u5vbFIWiVdAcYbdTUlIYMWIE3bt3Jz4+ntmzZ5+Ud9asWSQmJpKYmIher/cez5kzp1b23HnnnezcubNOdTgTaFUhMcrpbmkLtqPsyt5F38i+zW2OQnHWUzHsttlsbpKw2waDgZdffpk+ffpQWFhI3759ueiii+je/fj8pSeeeIInnngC0NZPKA9oV46UEiklOl3Vv6Hff//9RrO/OWmVLYYw/2jCXW52Zp99Sq9QtFSaOux227Zt6dOnD6CFn4iLi6s0I7k6kpKS6Nq1K7fccgs9evQgJSWFe++9l379+hEfH8+MGTO8eYcPH075hFs/Pz+eeOIJevXqxYABA2oMlNeSabQWgxDiA+By4JiU8qTlk4QQNwLTAAEUAvdKKbc2lj2VsIbRvayMXdlqLoOidfH8n883eBdqt5BuTDt/Wo35mjPsdlJSEps3b6Z///61qtO+ffv46KOPGDBgAKB1OYWEhOByuRg1ahTbtm2jZ8+ele4pLi5mwIABzJo1i6lTp/Lee+9VWpfhTKIxu5LmAW8AH1dz/RAwTEqZK4S4BHgXqN23drpYw4krs7M6Pwmbw4bFaGmSxyoUrZnmCrtdVFTE+PHjee211wgICKiVre3bt/eKAsAXX3zBu+++i9PpJD09nZ07d54kDD4+Pl6fSd++ffn5559r9ayWSKMJg5RylRCiwymur61wug6IaSxbTsIaTne7HTdu9ubuJTEisckerVA0J7X5Zd+YNHXYbYfDwfjx47nxxhsZN25crcsvD6QH2spsL730EuvXryc4OJjbbrutyrDZRqPRG3a7scJhNxUtxcdwB/BDdReFEHcLITYIITZkZjbA/ANPiwFQfgaFoglpyrDbUkruuOMO4uLiePjhh+ttc0FBAVarlcDAQDIyMvjhh2pfVWcNzT4qSQgxAk0YLqguj5TyXbSuJvr163f64WCtYUS6XIQYLOzK2XXaxSkUitpxqrDbt99+Oz179sRisVQKuz1x4kTi4+MZNGhQlWG33W43RqORuXPn0r59e2+Za9as4ZNPPiEhIYHExEQAnnnmmZO6sWqiV69e9O7dm27duhEbG8vgwYPrWfszh0YNu+3pSvquKuez53pPYAlwiZRyb23KPN2w2wDYi+GZKO7pPpBMk5VFY6tfx1WhONNRYbdbH2ds2G0hRDtgMXBzbUWhwfCxgtFKd52FA3kHKHOVNenjFQqFoiXTmMNVFwDDgTAhRCowAzACSCnfBp4CQoE3PQ4bZ23VrEGwhtHdJXBJF3tz9pIQnlDzPQqFQtEKaMxRSRNruH4ncGdjPb9GrOHEeUYW7MrZpYRBoVAoPLSUUUlNjzWcKFsegb6BamSSQqFQVKAVC0MYojiLuJA4JQwKhUJRgVYsDOFgy6J7SBz78vZhd9mb2yKFQqFoEbQaYXAVFVHw889It1tLsIaD20mcfzucbif78/Y3r4EKxVlMSw27vXLlSgYOHFgpzel0EhkZSVpaWpXlr1ixwmv3N998w3PPPVdlPj8/v1PamZeXx5tvvuk9T0tL45prrjnlPU1FqxGGomXLODLlAUp3eLqNrOEAxPtq8VVUd5JC0XhUDLsNNGnY7Z07d7Ju3Trmzp170toJQ4YMITU1tdKs6V9++YX4+HiioqJqfMbYsWOZPn16vew7URiioqL48ssv61VWQ9NqhMF6wQUgBEWrVnoSwgCIkTr8jf7sylYzoBWKxqQlht3W6XRcd911LFy40Ju2cOFCJk6cyJ9//snAgQPp3bs3gwYNYs+ePSfVad68edx///2AFlNp4MCBJCQkVIqqWlRUxKhRo+jTpw8JCQl8/fXXAEyfPp0DBw6QmJjIo48+SlJSEj16aHOBS0tLmTRpEgkJCfTu3Zvly5d7nzdu3DjGjBlDly5dmDp1al2+glrT7CExmgpDSAimngkUrVpF+H33eVsMwpZFXGicCo2haBUcfeYZynY1bNht37hutHn88RrztdSw2xMnTuSuu+5i2rRplJWVsXTpUl555RUMBgOrV6/GYDDwyy+/8Pjjj3sjwFbFgw8+yL333sstt9zC3Llzvekmk4klS5YQEBBAVlYWAwYMYOzYsTz33HNs377duzhQUlKS9565c+cihOCvv/5i9+7djB49mr17tXnAW7ZsYfPmzfj6+tK1a1emTJlCbGxsjZ9/XWg1wgDgN3QoWW/MxZmTg8EjDBRnEhcSx4LdC3C4HRh1xuY1UqE4S2mpYbf79etHUVERe/bsYdeuXfTv35+QkBBSUlK49dZb2bdvH0IIHA7HKeu3Zs0abx1uvvlmpk3TItlKKXn88cdZtWoVOp2OI0eO1LiIz2+//caUKVMA6NatG+3bt/cKw6hRowgMDAS0mFHJyclKGE4Hv6FDyXr9DYrXrCHw0ku0xOIsurfvhd1t52DeQbqGdG1eIxWKRqQ2v+wbk5YadnvixIksXLiQXbt2ebu4nnzySUaMGMGSJUtISkpi+PDhNdpVHna7Ip9++imZmZls3LgRo9FIhw4dqgzbXVt8fX29x40V3rvV+BgATPHx6ENCKFq5CvQGMIdoLYZQLdiUckArFI1LSw27PXHiRObPn8+yZcu48sorAcjPz/c6yOfNm1dj3QYPHuz1VZTXpbyciIgIjEYjy5cv99rp7+9PYWFhlWVV/Dz27t3L4cOH6dq16X60tiphEDodfkOGULx6NdLl0vwMxZm0D2iPRYXgViganVOF3d64cSM9e/Zk+vTplcJur1q1ivj4eBYvXlxl2O2ePXty0UUXkZ6eXqnM8rDby5YtIzExkcTERJYuXVqlXXFxcVitVkaOHOldpGfq1Kk89thj9O7du1a/ymfPns3cuXNJSEio5OS+8cYb2bBhAwkJCXz88cd069YNgNDQUAYPHkyPHj149NFHK5U1efJk3G43CQkJTJgwgXnz5lVqKTQ2jRp2uzE43bDbBUuXcuThR2i/4DMsW/4B0g23/8CtP9yKS7qYf+n8BrRWoWh+VNjt1scZG3a7ubAOHgw6HUWrVmlDVou1FeG6h3ZnT84eXG5XDSUoFArF2U2rEwZ9YCDm3r0pXrkK/CIqCUOpq5RD+Yea2UKFQqFoXlqdMIA2Oql0504cTiuU5oHTTlyI1uxSfgaFQtHaaZ3CMGwoAMX78rUEWxYdAzti0pvUyCSFQtHqaZXC4Nu1K4aICIq2e0YOFGei1+npGtJVCYNCoWj1tEphEELgN2woxVv3I91U8jPsztmNW7qb10CFQqFoRlqlMABYhw7FbSvBluUDxVoY37iQOGxOG8kFyTXcrVAo6kJzhN0ux+Vy0bt37yqfdd9995GYmEj37t0xm83e+Q61jXJ66aWXkpeXV6c6nAm0qpAYFbEOHAgGA8VpvlgrtBhAmwHdMbBjc5qnUJxVVAy7bTabmyTsdjmzZ88mLi6OgoKCk66VB7tLSkri8ssv9wa0K8fpdGIwVP+arG7C3JlOq20x6P38sPTrS1G62duV1CmoEz46HxWCW6FoBJo67DZAamoq33//PXfeeWet7VyxYgVDhgxh7NixdO+u/Vi86qqr6Nu3L/Hx8bz77rvevOWtk6SkJOLi4rjrrruIj49n9OjR3rUnzkRabYsBwG/oMI6t+wPHkVSMgFFn1BzQOcoBrTg7Wf3FXrJSihq0zLBYP4Zcd26N+Zoj7PZDDz3ECy+8UG1MourYtGkT27dvp2NHrefggw8+ICQkhJKSEs477zzGjx9PaGhopXv27dvHggULeO+997juuutYtGhRpe6zM4lGazEIIT4QQhwTQmyv5roQQswRQuwXQmwTQvRpLFuqo3zYatFfx30KcSFx7MrepRzQCkUDU1PY7Ztvvhk4Oex2+cu1urDbiYmJ/Prrrxw8eLBSmd999x0RERH07du3zraef/75XlEAmDNnDr169WLAgAGkpKSwb9++k+7p2LEjiYmJAPTt27fS+gpnGo3ZYpgHvAF8XM31S4Aunq0/8JZn32T4dOqEMdBI0e5sgj1p3UO788XeL0gtTKVdQLumNEehaHRq88u+MWnKsNtr1qzhm2++YenSpZSWllJQUMBNN93E/Pk1x0MrD6QHWtfSL7/8wu+//47FYmH48OFVhs0+MRz2mdyV1GgtBinlKiDnFFmuBD6WGuuAICFE28aypyqEEFi7hVOcXIbbbgc4HoJbdScpFA1OU4bdfvbZZ0lNTSUpKYmFCxcycuTIWonCieTn5xMcHIzFYmH37t2sW7euzmWcaTSn8zkaSKlwnupJOwkhxN1CiA1CiA2ZmZkNaoRfrw5IJ5SsXw9Al6AuGHQGNdFNoWgEmjLsdkMxZswYnE4ncXFxTJ8+nQEDBjTKc1oSjRp2WwjRAfhOStmjimvfAc9JKX/znP8KTJNSnjKm9umG3T4R97KX2Hv/+wTfcAOR/3gKgOu+vY5A30DeG/1egz1HoWguVNjt1seZHHb7CFBxodIYT1qToguJwhJRRtGq1d607qHd2Zm9kzNtrQqFQqFoCJpTGL4BbvGMThoA5EspG6cteCqs4fhFlWE/nIr98GFAE4YCewFpxWlNbo5CoVA0N405XHUB8DvQVQiRKoS4QwhxjxDiHk+WpcBBYD/wHjC5sWwBbRTDseSTZz5iDcevrTbCoLzVUB6CW/kZFApFa6QxRyVNlFK2lVIapZQxUsr/SCnfllK+7bkupZT3SSnPkVIm1ORbOF12rU3nv89uOFkcrOH4+LvwaRNM0aqVAJwbci56oVczoBUKRauk1YTE6NwnAh+zgU3/O1z5gjVM23Vvi+2PP3GXlOCr9+WcoHNUi0GhULRKWo0w+JgNJAyL5sDmY+Rl2I5fMPiCbyB+XfyRZWXY/vwT0PwMu3J2KQe0QqFodbQaYQDoOTIWvUHH5p9OCKttDcMSKRFmM0UrVwGanyGnNIcMW0YzWKpQnF201LDbH330UaVgfgBZWVmEh4dTVlZWZfnz5s3j/vvvB+Dtt9/m449PDu6QlJREjx4njdI/KU/55D2ADRs2VDnHozloVcJgCfAhblBbdq87SlFuhS/dGo7Ono11wACKVq5ESlkpBLdCoTg9KobdBpol7HZVXH311fz888/YbMd7Eb788kuuuOKKSiEuquOee+45KXBfbTlRGPr168ecOXPqVVZD06qEAaD3Re2QErb+WsHXYA2D4iz8hg3FceQI9kOH6BrSFZ3QKWFQKBqIlhh2OyAggGHDhvHtt9960xYuXMjEiRP59ttv6d+/P7179+bCCy8kI+Pk3oOZM2fy0ksvAbBx40Z69epFr169vOs8gCYAQ4YMoU+fPvTp04e1a9cCMH36dFavXk1iYiKvvvoqK1as8LZqqvs8Zs6cye23387w4cPp1KlTowlJqwu7HRBmpku/CHasTqPvJR0wWY1gDYfD6/C7aggARStXETrpNjoFdmJXjhqZpDh7WD7vXY4lH6w5Yx2IaN+JEbfdXWO+lhp2e+LEiXz66adMmDCBtLQ09u7dy8iRIykoKGDdunUIIXj//fd54YUXePnll6stZ9KkSbzxxhsMHTqURx999PjnExHBzz//jMlkYt++fUycOJENGzbw3HPP8dJLL/Hdd98BWoyocqr7PAB2797N8uXLKSwspGvXrtx7770YjcYaP/+60OpaDAB9Lm6Po8zF9pWpWoI1HGzZGNu2wbdLZ4pXa36GXuG92HB0A/ll+c1orUJxdtBSw25fdtllrFmzhoKCAr744gvGjx+PXq8nNTWViy++mISEBF588UV27NhRbRl5eXnk5eUxdKgWyr+8LgAOh4O77rqLhIQErr32WnburLkXorrPo9xeX19fwsLCiIiIqLIlc7q0uhYDQGi0Hx0SQtm6LJVeF7bDaA0HJNhysA4dSs7Hn+AuLub6btezaN8i/rv3v9yZUPsVoBSKlkptftk3Ji0x7LbZbGbMmDEsWbKEhQsX8sorrwAwZcoUHn74YcaOHcuKFSuYOXNmvWx99dVXiYyMZOvWrbjdbkwmU73KKefE8N5Op/O0yquKVtliAK3VUFrkYNeaNO9cBooz8Rs6DBwOiteto1tINwZFDWL+zvmUuaoeoaBQKGpPSw27PXHiRF555RUyMjIYOHAgoIXbLneQl0d7rY6goCCCgoL47bffALx1KS+nbdu26HQ6PvnkE68vxN/fv9ouruo+j6ai1QpD285BtO0cyOafD+MyHRcGS5/e6KxW77DVST0mkV2azbcHvj1FaQqFoja01LDbF110EWlpaUyYMAEhhNema6+9lr59+xIWFlZjGR9++CH33XcfiYmJlZzkkydP5qOPPqJXr17s3r3buwhQz5490ev19OrVi1dffbVWn0dT0ahhtxuDhgy7nfRXFt/P3caocUF0WzsCxv8HEq4hdcoDlPz1F52XLwPg+u+vp9hRzNdXfo1ep2+QZysUTYUKu936OJPDbjc77XuEEhptZdOaEqQUUKxNivEbNhTn0aOU7d2HEIJJPSaRXJDM8pTlzWyxQqFQND6tWhiEEPS5uD25GWUk2c+DYm11OOsQbWRBeVC9C9tdSIxfDB9s/0CFyFAoFGc9rVoYADr3jSAgzMRG2wRkkSYMxsgIfOPiKPb4GQw6A7fF38ZfWX+xMWNjc5qrUNQL9YOm9dAQ33WrFwadXkfvi9qRUdaJtLTjo3f9hg7FtnkzLs/Y4Ss7X0mIKYQPtn9Q6X63zYZt02Zy5n9K2uNPcGj8NeQtXtKkdVAoToXJZCI7O1uJQytASkl2dvZpD4ltlfMYTqTbwLb8+eUWNh2Kozx6i9+woWS/8w7Fa9cSMGYMJoOJm9qN4+df3mP3vpfwP3SM0p07sR88BG43APqQEHRmM0f/+U/MPRPw7dy5+SqlUHiIiYkhNTWVzMzM5jZF0QSYTCZiYmJOq4xWPSqpIhtfeoV1+xO57vHzCG/nj3Q62Tv4Anw6tMcnOkYTgaQkb35DeDim+HhM3btj6qHtDZGRuLKyODj2SgyRkXT44nN0Pj4NbqtCoVDUlbqMSlItBg89uuay6YCNTT8lc/GdPRAGA/4XjiJ/0WKcmZmYuncnYOwVfGfcxceO1Sy49QvaWNucVI4hPJy2s2aROnkyma/NJnLqo1U8TaFQKFoutfIxCCGsQgid5/hcIcRYIUTDRm1qZnyDguhh+ZEDG4+Rd0wLwdt25kzOXfc7XZYtI/aNNwifPJmLJz5Grh98vPPkGOzl+I8cQdD1E8j54AOKf/+9qaqgUCgUDUJtnc+rAJMQIhr4CbgZmNdYRjUL1nB6Wr5Fpxds/lkLyS2MRvRBQZWyRflFMabjGL7c++Upg+tFTpuGT8eOpE1/DFdeXiMarlAoFA1LbYVBSCltwDjgTSnltUB845nVDFjDserz6NbLyO7f0ynOrz420qT4SZQ4S/hizxfV5tGZzUS9+CLO7GzSZ8xUI0IUCsUZQ62FQQgxELgR+N6TdkbFhjiUVcwLP+7G4XJXncEaDkDvXsVIl2TrrynVltU1pCuDowczf9epg+uZe8QT/uADFP7vf+Qv+ep0zFcoFIomo7bC8BDwGLBESrlDCNEJqDE+hBBijBBijxBivxBiehXX2wkhlgshNgshtgkhLq2qnIbgwLEi3lxxgNX7qhmy54mwGmjMpHO/SLavOkKZzVFtebfH305OaQ5f7//6lM8Nvf12LOedR8a//4398OFT5lUoFIqWQK2EQUq5Uko5Vkr5vMcJnSWlPOWq1UIIPTAXuAToDkwUQnQ/Ids/gC+klL2B64E361yDWjL03HCCLUa+2pxWdQZPi4HiTPpc3A5HqYu/Vh6ptrzz2pxHfGg8H+34CJf75CUFyxF6PVHPPwd6PWmPTkU2Qux0hUKhaEhqOyrpMyFEgBDCCmwHdgohahqHeT6wX0p5UEppBxYCV56QRwLlQcYDgWre2qdPWX4O1xavZvn2wxSVVfFy9rGC0QLFWYTF+NMuPpRty1Jw2Kt+6QshuL3H7RwuPMyylGWnfLYxKoo2M2dQsnUrWW+93RDVUSgUikajtl1J3aWUBcBVwA9AR7SRSaciGqjYUZ/qSavITOAmIUQqsBSYUlVBQoi7hRAbhBAb6jt7M+PQAXwPb+XilG/4YeOhqjNZw7yB9PqOaU9JoYPda6uP8T6q3Shi/WP54K+ag+sFXnYZgVeOJeutt7Bt2lyvOigUCkVTUFthMHrmLVwFfCOldKD92j9dJgLzpJQxwKXAJ+XzJSoipXxXStlPStkvPDy8Xg/q3K8/Vzw0nUh7Jrs/fIGSwoKTM1nDvcLQtnMgbToF8sc3BzmyJ7fKMvU6PbfF38b27O1syKh5Nnbkk09ibNuWtKlTcRUV1aseCoVC0djUVhjeAZIAK7BKCNEeqOLNWokjQGyF8xhPWkXuAL4AkFL+DpiAmpdKqifn9h+E7qLb8Sk8xmczpmPLz6ucoYIwCCG4cFJ3LAE+fDN7CztWV+1vGHvO2CqD61WF3s+PqBdfwJGWRsa/Z51udRQKhaJRqK3zeY6UMlpKeanUSAZG1HDbeqCLEKKjEMIHzbn8zQl5DgOjAIQQcWjC0KiRvq684kK+i7yUvIx0Pp85naKcCguSW8O8i/UABIabGT+tHzFxIaz4dA+rPt+L+4ThriaDiRvjbuS3I7+xJ2dPjc+39OlD2D1/I/+rryj44YcGq5dCoVA0FLV1PgcKIV4p7+cXQryM1nqoFimlE7gf+B+wC2300Q4hxNNCiLGebI8AdwkhtgILgNtkI88E6xzhR1DneDbHXUthTjafz5xOQZa2oLi3xVDBBF+zgcvu60mvUbH8tTyV7+ZuO2kY64SuEzAbzMzbMa9WNoTdey+mnj1JnzETx2msU6tQKBSNQW27kj4ACoHrPFsB8GFNN0kpl0opz5VSniOlnOVJe0pK+Y3neKeUcrCUspeUMlFK+VP9qlE3ruodzW9FgQyY/DglhQV8PnM6eRlHwRoBbieU5lXKr9MJLri2CyNu7saRPbl8+fxG8jJs3uuBvoGM7zKeHw79QFpRzQOrhNFI9IsvIJ1O0qZNR7qqH+6qUCjOPsr27cO2fn1zm1EttRWGc6SUMzxDTw9KKf8JdGpMwxqTK3q1RSdgdb6Fa5+chb2khM9nTiOn1BMiu0J3UkW6D47iyocSKS1y8OXzG0jdneO9dkv3WxAIPtn5Sa1s8GnfnjaPP4btzz/J+bBGjVUoFGcBUkpyv/iCQ+PGk3zzLeR8XH0wzuaktsJQIoS4oPxECDEYKGkckxqfCH8TgzuHsWTzESI6nsN1M57F5XTy+fyfyCq1eB3QVRHVJZhrpvfDEujLN3O2sn1lKgBt/dpyScdLWLRv0SmD61UkcPx4/C+6iGOz55D/9alnUCsUijMbd2kp6U/8g6NPzcBy3nn4X3QhGc88S8aLLyLd1YTqaSZqKwz3AHOFEElCiCTgDeBvjWZVE3B172hSc0vYmJxLeLsOTJjxHEKn5/PDPcnYt/OU9waGm7lmal/adQ9h5YK9rFqwB7fLzW09bqPEWVKrEUqgjXxq+6+nsfTqRdq06aRNfwx3cXFDVE+hULQg7CkpJE28gfzFiwmbfC+x771L9GuvEXzDRHL+84HWpWy3N7eZXmo7KmmrlLIX0BPo6QlhMbJRLWtkRse3wWTU8dUWbRhqaEwsE6Y9hlG4+O/H35O+79QjjHzMBi6d3JPEC2P5a+URvn19K+18OnJ156v5cPuHrD9au/5DfVAQ7eZ9SNjkyeR//TWHrrmW0j01j25SKBRnBoXLl3No/DU4jhwh5u23CH/gAYRej9DriXzyScIfepCCb78l5Z57cRW1jB+GtW0xACClLPDMgAZ4uBHsaTL8fA2M7t6G77alY3dqzbjgjt25vsM2TL56vpz1D1J37zhlGTqdYPA1XRh5SzfS9uXx5fMbuLf9g7QPaM9jqx+rdZeSMBgIf2AK7T78EHdREUnXXkfuggUqVLdCcQYjXS6OvfYaqfdOxhgTTcfFi/AfPrxSHiEEYffcQ9tZsyj+4w8O33ILzhawNnedhOEERINZ0Uxc3TuaPJuDVXs9X4TeQECAlQkXtcUaFMKiZ54i+a8tNZYTNyiKK/+vN2U2J9+/soOHrDPIteUxY+2MOr3crQP60/GrJVjOP5+j/3yaIw8+hKugpnmECoWipeHMzSXlrrvJfvsdAsePo8Nnn+ETE1Nt/qDx44h9cy5lhw6RNPGGSuvLNwenIwxn/M/ZC7qEEWL1YcmWCrOareH4yzwmzHyOwPBIvnr+aZK2bqqxrKjOQVw7vR+B4WZ2Ly7gjm3PkLXOzed/fVknmwyhocS++w4Rj/6dwmXLOHT1OEq2bq1r1RQKRTNRsm0bh8aNx7ZhA23//S+iZs1CZzLVeJ/fsGG0/2ge7uJikibeQMm2bU1gbdWcUhiEEIVCiIIqtkIgqolsbDSMeh1X9GzLLzszKCz1TFqzhkNxFtagYK6b8SzBbaP46sV/cWjLxhrLCwgzc830flw+pRdto8MYmHwV6e9YWbpgA8V51S/ocyJCpyP0jjvoMP8TkJKkG28i+z8ftLiRC4qzDyklmW++yb7hIzg2e3aL6NY4U5BSkrtgAUk33oTQ6Wj/2WcEXXNNncow9+xJhwWfobNaSb71NopWrmwka0/NKYVBSukvpQyoYvOXUhqaysjG5Mre0ZQ53fy4/aiWUCHCqiUgkGufeoaQ6Fi+fvFfHNxcs0NZCEH7+FCufrgPF/1fZ46G7ufgyjw+fmItv368i5y02juXzImJdFyyGP8RIzj24ouk3HMPzpycmm9UKOqBtNtJn/4YWXNeR+/vT/bb77B/5CjSnniCsn37mtu8Fo27pIT06dM5+s+nsQ4aSMdFX2LuUb/Vj306dKDDwgX4duxIyuT7yFu8pIGtrZnT6Uo6K+gdG0T7UIt3dFLFQHoAZv8Arn1yFqGx7fn6xVkc2PhHrcs+t2s7Lr+7N5/1/jclXdLZvz6DBU//wfdzt5K2L69W/gd9YCDRc2YT+dST2Nb9waGrrqb4jz/rXE+F4lS48vM5fOdd5H/9NWFT7qfjN1/Taen3BI4fR8F333PwirEcvvtuin//XQ2KqIB0uylavZqkCdeT/823hD0whdi33kIfFHRa5RrCwmj38cdY+/cn/fHHyXr77Sb93Fu9MAghuCoxmrUHsskoKNWEoTQPnMfHFJv9/Ln2H7OI6NCRb15+lv3r19W6/CExQ7iy9yV8GPws59wvOf+Kjhw9VMCSlzex6IWNHNh8DLf71F+4EIKQG26gw+cL0VksHJ40iax336tvlRWKSthTU0maeAO2zZuJeuF5wu+7DyEEvh070nbmTDqvWE7YA1Mo3bGTw5Nu59C48eR//XWLGndfHW67vVGGgDqzs8l69z0OjL6YlLvuxpmTQ+y77xI+eTJC1zCvVb2fldi33yJg7BVkvjabjH/9q8nC54gzTf379esnN2yoee2DunAoq5gRL63giUvjuMu8HL5/GB7eDQFtK+UrLS5i8TMzyDi0n8sfnEaX/oNqVb7dZefGpTdytPgoi8YuItgQyp7f09n882EKskoJCDfTvkco0ecGEdUlCLOfT7VluYuLSX/yKQqWLiX6lZcJuLTRlslWtAJKtm4l5d7JSJeLmNfnYD3//GrzusvKKPj2W7I/nIf9wAEMkZGE3HwTQdddhz4goNr7mgNXURG5n35Gzrx5uAoKsPTujXXYUPyGDcO3SxeEqPugSikltvXryVu4kIKffwGHA8v55xN8/QT8L7wQ4VP9/+3pIN1uMl95hez3/0PwLTfT5vHH61WOEGKjlLJfrfIqYdC4cu4aHE43Sy/KhS9uhr+thrY9T8pXZitm0bMzOLp/L5c9MJWuAy+oorSTOZh/kOu/u56e4T1596J30Qkdbrfk4OZMdv52hPQD+TjtmnM5JMpKVJcgos8NJqpLEJaAyn9w0uEg+eZbKNu7lw6LvsS3Y8fT/wAUrY6C//1E2tSpGCIiiH3nbXw71S78mXS7KV69muwP52Fbtw6dxULgNeMJnTQJY9u2NRfQiLjy8sj5ZD45n3yCu6AA67ChmLp2o2j1asp27QLAENUWv2HD8Bs2DGv//ujM5lOXmZ9P/tdfk7vwc+wHD6ILCCDo6qsImjCh1p9ZQ5C7cCHWgQPxad++XvcrYagH89YcYua3O1l1vYl2X42DmxZD51FV5rWX2Fj07EzS9+3m0il/p9ugobV6xqK9i5j5+0we6vMQdyTcUemay+km83AhR/bmkrY3j/QD+TjKtGZjcBsLUecGE90liKhzg7AG+uJIT+fQ1eMwRETQ4YvPazUcTlE7pJTkL16MPiQE/xE1LTty5iGlJOfDeRx78UXMPXsS89abGEJC6lVW6c6dZM+bR8HSH9BZrcS8+grWQbVrSTckzuxscubNI/fTz3DbbPhfdCGh99yDOf64A9iRkUHRypUUrVyl+UpsNoSvL5b+53uEYjg+Mdrqw1JKSrdtI3fh5xQsXYosK8PcqxdB119PwCVjzsj/NyUM9SCrqIz+z/zK9PMM3LX1Wrj6Xeg1odr89hIbi5/7J2l7dnHJ/Q8Td8HwGp8hpeSRlY+w/PByPr7kYxLCE6rN63JpQpG2N4+0fXmk7c/DUaoJRWCEmbadgwiwZ+B87yWiRvWh/TNP17nOipNx2+0cfWoG+V99BUDIrbcS8fdHEEZj8xrWQEink6OzZpG3YCH+o0cT9cLzDfKSsycnk3r/FMoOHiRy2jSCb76pXt01dcWRkUHOBx+Q+/kXyLIyAi65hNB7/obp3HNPeZ/bbsf253qPUKzEcfgwAD6dz8E6YCC2jRsp27ULncVCwNgrCJ4wAVNcXKPXpzFRwlBPbvvwT9KOZvBT2U0wehYMuv+U+R2lpSx5/p+k7trBmPv+j+5Dav51mV+Wz7XfXotBZ+C/V/wXq/GU6x15cbvcZKUWccQjFBmH8ikpPL5gkL/FRUS3toS38yMsxp+wWD+sgb61Kluh4czKIvX+KZRs2ULY/ffjyssjd/58zH36EP3qqxgjI5rbxNPCVVTMkUcepnjlKkLuuJ2IRx5pMEdpeflp06ZR9OuvBF17DW2efLLR+t0dR46Q9f775H+5COl2Ezh2LKF33YVvp/p1q5YdOuQVCduGjfiecw7B119PwOWXo/er3f9oS0cJQz35avMRHvp8Mwctk9ANnAwX/bPGexxlpXz1wtMc3vEXY+59iPhhVXc/VWRTxiYm/W8Sl3W8jGeGPFMvW6WUFOfZyTycz4E5n5BToKe0U28K84+PWrAE+BAW60dYrD/hsf6ExfgREG5Gp2s50UxsmzdjCA3Fp127ZrWjdPduUiZPxpWTS9RzzxEw5mIA8r/7nvQnn0RnsRD9yitY+1fvnG3JODIySLnnXsr27qXNk08SfH31reHTQbrdZM6ZQ/bb72Du15eYOXPq3U1VFfbkZLLefZf8r78BIQi6+mpC777rlOEm6op0OkGvb5IWT1OihKGe2OxO+v37F9b6TiEofjRcNbdW9znKSvn6pVkk/7WF0X+bQsKI0ZWuS7cbR1kpjrIyHKWlOMpKWfjXZ3y75ysmnXsL/cxtiRlwMWY//3rZ7czM5OC4cej9/Gn78QLy8txkHi4iK6WQzNQictOKvUNiDT46QqP9CI32IyzGj9AY7djX3PTzFW0bNpB82yR0vr5Ev/YafkNq58hvaAp/+YUjU6eh9/cn5s25lfqlQVttK/WBB7EnJxP+fw8ReuedZ9RLo3T3blL+dg/uwkKiZ7+G35Ahjf7M/O+/J/3xJzCEhhLz5lxM3bqdVnll+/eT9c67FHz/PcJoJOi66wi943aMbdo0kMVnP0oYToP/+3wLd+26ja6du6C/6b+1vs9hL+Obl2aRtHUToTHtNCEo1cTAaa85HIZOp6NdQiJd+g+m83kDsAQE1snu4j/+5PCkSQSMGUPUyy9VenG5HG5y0ovJSi0kK7WI7CNFZKUWUVbs9ObxDzV5hSIsWtsHhpkRjdS6cGRkcGjcePR+fgizmbJ9+2jzjycInjixUZ5XFVJKst99j8xXX8XUsycxb7yOMaLq7iJXUTHpT/6Dwh9+xG/UKKKefabFDdGsSPnQyvxFiyn48Uf0QUHEvvP2ab+g60LJX9tJvf9+XIWFRD3/HAEXXVTnMkp37SLrrbcp/PlnhNlM8PXXEzrpNgzh4Y1g8dmNEobTYMWeYzD/GnqHuQh8cE2d7nXa7axe8BGF2ZkYfU3aZjJh9PWt8jw/fy+Pb3mR6DIXN5Ylsj/Lh/yMowidjtj4npzbfzBdzh+IJTCoVs/PevsdMl97jTYznqrxBat1RZVVEors1CLyMmyU/0kYfHT4h5rxD/HFL8SEf3D53oRfiAm/YF/0hrr3UbvtdpJvvhn7vv10+OJzDG3akvbIIxStXKk5e6c+itDr61xunWwoKyP9H09S8O23BFx+OW3//a8anbBSSnI/+YSMF17EGBVFzJzZTfqirQ2Oo0fJ/+or8hYvwXH4MDqrlYBLLyXs/vswRkY2vT3HjpE6ZQqlW7cR9sAUwu69t1atrZJt28h6622Kli9H5+dH8M03EXLLLRiCg5vA6rMTJQyngdPl5sd/X8VA/S5C/9GI8WFcTvjPRfxkS+GRYDPD7ZKXbttAXuoR9q77jb3rfiPvaDpC6Ijp3kMTif6DsAZV/48h3W5S7rkH2+/raL9gQb1itTjsLnLTi8lKLSLnSDGFOaUU5ZZSmFNaydkNgND8GP4hJvyCTfiH+GIN8sXkZ8RkrbD5GfE1G7ytj/QnnyLvv/8les5sAkZr3W7S5SLjuefJ/eQT/EaOJPrFF9BZG8fpV/FlFf7QQ4T+7e46dQ3ZNm3iyEP/hys/nzYzZhA07upGsbO2uO12ipYtI2/RYorXrAG3G8v55xM0fhz+o0fXOE6/0e0rK+PoU0+R//U3+I8ZQ9Szz1Rrk23DBrLefIvitWvRBwYSctutBN94Y4tunZ0pKGE4Tda8eS99M/5L2bQ0Ai2NM6qCVS/Bsn/BNR+wMH0ts9J+YmhYL14d8wE+eh+klGQdTmLvH2vY+/tv5KSlghDEdIuni6cl4R8adlKxztxcDo0bj9Dr6bjoS/SBdeuSOhVOu4ui3DIKc0spyimlMKfMsy/V0nNKcTmqjgArBPhajBhlCSL9MNaoUAITuuLrZ8Q/2ERQGwvBkRbsPywm89ln8O3Wldi33mrwX7klO3aQet/9uPLziXrh+Xp1b4A2gunII3/H9scfBF17LZH/eAKdb9OOAivdvZu8RYsp+OYbXPn5GNq0IWjc1QRefTU+sbFNaktNSCnJ+c9/OPbyK/jGdSN27lzvZDgpJbbffyfrzbewbdiAPjSU0Em3EXT9xLNmRFBLoMUIgxBiDDAb0APvSymfqyLPdcBMtPUdtkopbzhVmU0hDGnfP0fU+mdZdPE6xg9shLHLGTvgnWHQ7VK49iMoyeWLt3ryr7BghkQP4dURr+Krr/ySyUpJZu+6Nez7Yw1ZKckAhMa0o0Ov3rTv2YeYuHiMvlpXiG3zZpJvvgW/YcOIeeP1JnOUSikpszkpLXZoW5GDsmIHpcVaWlFyOjkr1+EOaQvtOnvzOCuIid6gw9/qxnjoL/zc+cRMvIyI3p0JirRgsp7eXIKC//1E2rRp6IODiX1z7mmPS5dOJ5mz55D93nuYuncnes7sU46OkW430m6vvDk8rbAK/4fe/8lK/5qeE7eb4j/+IH/RYkp37kQYjfhfdCGB48ZjHTig0bvgTpfCFStIe+TvCLOZmDlzcBXkk/XWW5Ru3YYhIoLQO+8g6Nprm72VczbSIoRBCKEH9gIXAanAemCilHJnhTxdgC+AkVLKXCFEhJTy2KnKbQphkJs/RXw9mQcjPmT25HENW7jLAe+NhII0uO8PLcw3wLzL+bIsjX+aHAyOHszsEbNPEodyso+kcHDTepK3bSZ113ZcDgd6o5HobvF06Nmb9j17o1+ximPPPU/EtGmETrqtYetQD5yZmRy65lqEjw8d//uFN/qklJKSQgd5GTbyMmzklu9T8ijIKUOK4y86k9VIUKSFoEgzZn8fTFYjvhaDt8vK12rEZDXgazViMOq8giilJOvNN8l6/Q3MiYnEvPE6hrCTW1v1pXDZMtKmTQcpMcbGVn7xl5Uh7XbcDgc4HDUXVkt8u8cRNG48gZdfdtqRPJuasv37SZl8n3dSmTEqitC77yJw3Dh0jTTvQdFyhGEgMFNKebHn/DEAKeWzFfK8AOyVUr5f23KbQhjY9zN8eg3j7DN5Y+o9RAU14K+XFc/BimdhwnyIu+J4+h/vwA9TWTz2OWb+9RYDowYye8RsTIZTO0Qd9jKO7NxO0rbNJG/b7G1NWAKDCC9zErQ/icTnXiSsCYYoVod0OEieNInS7TvosHBBrR22ZekZ7HvwcXLTCtFdNhF7uzjyjtrIzyyhpMiO21n9367eIPAxuDE6bOiLstEX5+HbNhy/Pr0wmjThMPjoMfjoMBjL91qa3qjD6KPHx2LAEuCD2c+ITn9qJ7v98GEyX3sNd0kpwsfHsxnR+foijD7H03x9ET5GhI8POh8fbUZ1eYuuUsuuijTPoW+nTmf8LFxXXh6Zc+Zgiu9B4NgrzpqZ5S2ZliIM1wBjpJR3es5vBvpLKe+vkOcrtFbFYLTupplSyh+rKOtu4G6Adu3a9U1OTm4Um72kbYZ3h3OX/WH6XnwT9ww7p4HK3QLvj4L4q2H8CVqYnwqvxsOoGSxp05EZa2fQv21/5oycg9lQe2EqzMkiedsWkrdtJnnrJkqKCgEIi2lHx77n07FXH6K6xqE3NN0/4tF/zyJ3/nyiXnqJwMsvq9O9bpuNI1OnUvTLrwTfeCORj01HGAxIKXE63Me7qgpKKNixn4Kd+yk6kEJJdiEOvQWnKQB3SBvc/iFIiz9Ouwunw+3d12qBWqG1Vsz+PlgCjFj8fTD7+2AO8MES4HP83P+4gAhBpVXRK3bnlV8TCHR6gdF09k2mUrQ86iIMzb0KmwHoAgwHYoBVQogEKWVexUxSyneBd0FrMTS6VVZtjHTvUCcf/HaI8zoE07f9ac7edJbBV5PBEgqXvHDy9cAYiOoNu7/j6iHL0AkdT655kim/TuH1Ua/XWhz8Q8LoMfxCegy/UBultOwXts16mhy9Dxu/W8L6r7/EaDLTrkcvOib2pWNiXwLCGy/UQ/7XX5M7fz4ht91WZ1EA0FksxMyZw7GXXibngw+wpxwm+pVX0FmtuI8cxr52LSVr1mL74w9EcTGBOh1tevbEevEgrBcMxpyQUO2vUSklbqfEYXfhcrgr7Z12N2U2ByUFdmwFdmyFDkoK7ZQU2DmWXIit0O6NXXW66AwCs9WIyV9rnZSLjNnv+N7kb/Re8zEbWtTsdcXZR2MKwxGg4tCIGE9aRVKBP6SUDuCQEGIvmlDUvIZmY2LR+p/Hd/VlwU4d1779O1NGdmHKyM4YauhSqJaVz8OxHTDxc7BUIzLdLtdGKhWkcWXnK9EJHf9Y8w/u//V+Xh/5OhajpU6PFDod7S4cjX9WLkdnzsR3xHBKhl1AWmEeSVs3cmCDtuBQSFQMHRL70rFXH2K6J2BooH7ekh07SH9qBpb+/Yn4+yP1LkfodEROfRSf9u05+vTTHBo3HpxOHGlpABhjYgi44nKsgwZhHTCg1kMbhRDojQK9sX7fqdPuwlZop6TAoe0L7UjPDPNKDXEpK51rx1qCyyEpLbZTUuigpEgTn4KsfEqKHKcUHp1eYDDq0PvotS6w8q4xow59hePyPD6+enzMeowmA75mAz4mA0azHh+TAR+THh+zAR+zoZJvRtF6acyuJANaN9EoNEFYD9wgpdxRIc8YNIf0rUKIMGAzkCilzK6u3CbxMQA8GwuJN1A44t/M+GYHizcdoXe7IF6bkEj70DoOoTuyEd6/EHpNhKverD5f5h6Yez5c+hKcfxcA3x38jid+e4I+EX2YO2puncUBPM7Xt94iZ95HuAsK8I2LI/iGibj69CZ59w6Stm4kZedfuBwODD6+xHbvQYfEvrTv2ZuQttH1CrTmzM3l0PjxIKHjoi8bLF5O0Zo1HHvhRXzaxWpCMHhws8dZaiycDhelRQ6PaGjiUVrkwF7qxGl343Ro3WGuiscOt/daxWNHqavS6K/qEDqBj0mP0VeP0AmETqDTCYSgynOdJ03oQK/XRElv1GEw6NB59t40ow69wbOVi1m5f8enwt5Y+Vy1jhqGFuFj8BhyKfAamv/gAynlLCHE08AGKeU3Qvtp8jIwBnABs6SUC09VZpMJw5zeWtfONR8A8O3WNJ5Y8hcut2Tm2Hiu6RtTu19WjlJ4ZyjYi+DetWAOOnX+1/tBQBTc+o03aenBpTz222Mkhify1oVv1UscQOuvz//2O3Lnz6ds3z70gYEEXjOe4IkTEeFhpO7aQdKWjRzauonctFQADEYfgttGERwVQ0h0DCFtowmJjiU4KhofU9XdW9Lp5PBdd1GycRPtP/0Uc0KPetmraFhcTjeOUhf2Uqe2lTixl5Sfuzzn2rGjzInbLZFukG6JdEvtXJ54fjyPyyVxOTVxcjnc2rHT7RWs+qI36LwioTfq0Os9AqU/Lkw1HldM01WdVvHcK3IG4dlXFjXtWFRKM/rqMfro0RlEg7e6yrs9JRKDsX5DkluMMDQGTSYM/xkNBl+49VtvUlpeCf/3+Rb+OJTDZQltmXV1D4JqmgD305Owdg7ctAg6X1jzc3+ZCWvmwKP7K3U5/XjoR6avnk6v8F68eeGbtQ7XXRXlcXRyP/2Mwl9+AbcbvxEjCL7xBqyDBiGEIC/jKCk7t5FzJJWcIynkpKWSn5GBlMf/wf1CQgmJiiY4KpaQqGhComLwCwkl64MPyPvqK0In34d12BDcLhdulxu324V0uXC7XZXSTFY/giLbEBAe0aROcUXTIaXE7ZJaK6ZcNByelo79uF/HeeLe4cJpd+GokFYuSm6XPPnY5RGsCsdu1/F7pEvilmj7Cmnl1xsCoRMYfXQYPEKh7TVhM/rqvXuhE7hOGAxxfH9yGhL6jGnPwKvqNxhGCUNDsPBGyDkIk3+vlOxyS95ddZCXf9pDmJ8vr0zoxaBzqhkTf/gP+OBi6HsrXDG7ds9N3Qjvj4Sr3obEyvGO/pf0P6atmkZCWAJvXfgWfj5+9alZJRzp6eR+/jl5X/wXV04OPh07EnzjjQRedSV6v8rlOx0O8jPSyUlL1QQjLZXctCPkpKVSZjv9BdeF0OEfFkZQZBsCI9sSGNGGoMi2nvM2mKwn11dKSWlxEUU52RTlZFOYneU5zjqelpONy+EgNCaWsHYdCIttT1hsB8LatT9liBFF60J6fEFulxu3U3pbPJqIVTiv0BpyOSUux/GXucPuwlnmqrB34yjziFtZBZErcyGl9A6Nrrg/Poz65K61Np0CiT63fn+zShgagm8fgt3fab/cq+Cv1Hwe/Hwzh7KKuXtIJx4Z3RWfigHl7DZ4+wJtQtvkteBby5Dabrc2bDW6D1z/6UmXf07+makrp9I9tDtvjHqDYFPDvNjcdjuFP/xAzvxPKf3rL23lqssv1yaCCQE6AcLTRNY6mD177f5Sh528wgKOffctvjExRD74ADpfX3RCh9Dr0en16HSevV6P0Om8+5KCfPIyjpJ/7Ch5R9PJzzhK3rGjlBTkV7LR5OdPYEQb/EPDKCsuojAni6KcnCqj11oCg/ALCcUvJBT/kDB0ej3ZqYfJSknGlp/nzWcOCNSEop1HLDzH1XWTKRRnKkoYGoJls2D1S/BkFuiq7tOz2Z3M+n4Xn/5xmPioAGZfn0jnCI8A/DAd/nhL64rqWLs1ob18/3fYPB+mHgSfk/0Jyw4vY+qqqURaInnrwrdoF9CwzteSbdvI/fRTCn74EWm31+leY0wM7T/7tNrw1XWhzGYj/9hRTSgy0jXhyDhKYXYWJj9/z0vf8/IPDcMvWNtbg4NP2SVly88jKyWZrMNJZB5OJislieyUwzjKSr15AiMiCYxsi19QMJagYPyCQ7R9hXMfs6XGvmQpJY6yUkoK8rEV5FNSUEBJYYHnOB+Xw4FfaBiB4REEhEUQEB6BOSBQjQxSNDhKGBqCP96FHx6FRw8cD1tRDT/vzGDaom3Y7E6euKw7N0UeRnx0OZx/N1z6Yt2ffXAFfHzlybOjK7Dl2BamLJuCQPDGqDfoGd6z7s+pJVJKrSUjpXeTFY6R0jNMU6IzmRCG5p4eU3ek201+5jGvYGQdTqIg6xjFeXkU5+XgqiKchcHHF2tQENagEKxBwZgDAnCUlnoFwFaYT2lBAU5H1eKqNxjQGYw4SktOKtc/LLySWASEheMfHkFgeCSWwCD0Z+BnrGhelDA0BNsXw5eT4N7fIbJ7jdmPFZby9/9uY8PeFH41P4bFZKTszlVEhIbW/dkuB7zYGc4dA+PeqTZbUn4S9/5yL1klWTw/9HlGthtZ92cpakRKSVlxMcV5uRTn5Wj73ByK8nKxedKKcnMpKcjHx2LB7B+AJSAQs38g5oDy4wDMAYHasefcx2xGCEFpcREFmccoyMrU9pkZFGQdoyAzk4KsYyd1qQHojUZ8TGZ8zGZ8TGaMZot2bLYcT/dc8zFbsAQEYgkMwhIUhDUwCKPJrFolrQwlDA3BodXw0eVwyzfQaVitbnHbS0n+5G+0T/ma68qeZBPdGNIlnPF9YxjdPRJTXYaZLbkH9izVWiz66rtFskuymbJsCtuztvNY/8eY2K3pVkBTNA2O0lJNNLI00SgpKMBeWoK9pOT4vsTmPXeU2LT00tITZtodx+DjiyVQEwlLUJB2HBTsTTMHBHoFxli+9/Gt9ZwWLThiAcW5OV4RLc7VRLUoN5vi3FxsBXkYTWb8gkOwBoXgFxystb48+/LuO8Mp4ii53S5Ki4qw5ecd3wryseXnYyvIw5afj8vp0BbH8vHFaDJhKF80y9fXs3BW+SJaFRbU8lw3eO4z+PjUaz5PS+JMConRcvGExaA4s+a89mLY+BG6ta/TsTANBj/I84l/Y/GmVJZsOsIDCzbjbzJwec+2jO8TQ9/2wTX/Wut2OWxdAMlroNPwarOFmkN5f/T7TFs1jWf+eIb0onQe6vsQOnFm/xErjmM0mQiNiSU0pm5rLJSvNV5WYtO6tvJyKfa8PL37vFzyj2WQvm8PJQUFlYYjV2mLr8kjFiZ8TBZt7xEPl8OhtahycynOy8Xtcp50v6/FijUoGGtwCJGduuAoLaEoN4djSQex5eVV+XyTn7/3HpPFSmlxoefFn1+tzUKn01pJAYHojUYKs8rqvNzuiRiMPhgqikWFfbl4SbfbM7pJIt1uQOtm1dLcnmMtj8HHB/+QMPxDw/APDcc/rHwfjsnq16wtOtViqI7ibHixE4x5HgbcU3We0nz48z1Y9ybYsqHDEBjyiPYi93ypbrfk94PZLNqYyg/bj1LicNEh1MK4PjFc3Tua2JBqJqvZbfBCJ+h9E1z2Uo3mutwunv3zWT7f8zljOozh3xf8u9qw3QpFVbjdLk1APL+6HaWlOEpLvK0Pe0mJ99xRWoq9xKbtS0uxl5agNxiwehzz5S/y8haAX3Ao1qAg75oh1T3flp9foWWRU0FotH2prdjbVWcJ9HSPBVTcB2MJDNRerKf4hS/dbhz2Mq9QHBeN48LhLCvDUb73pFW5LyvDabdrM8CFQAgd6LS9EJ6Z4Wh7vGk6HKUl3uHVblfl8CcGX19NJEIrCEdoGG07n0t4+471+n5VV1JD4HbDv0Lhgodh1JOVrxVna2Lw53tQlg+dL4Khf4d2A05ZZFGZkx/+SmfRplTWHcwBoH/HEMb3iWFUXAShfie8yBfeCEc2wf/tgFo0Y6WUfLjjQ17d+Cp9I/sye8RsAn0bbgW3M5aMHXBoFQy4t7ktUShOwu12YcvLozA7i8LszOP7rCwKs7MoyM6kOC8XpOT8q65lyMRb6/Uc1ZXUEOh0WjC9il1JBenw+xuw4QNwlGgjhoY8AlGJtSrSz9fAtf1iubZfLCk5NpZsPsLiTalMXbQNIaBnTBDDzw1nRLcIekYHoou7QptLkbYZYvrWWL4Qgtt73E4bSxv+seYf3PzDzbx14VtE+0XX80M4C3A5YdGdcGwnRPWBdv2b2yKFohI6nd4756Ztl65V5nE5HRTl5DRYgMuaUC2GU/HmIAjuAGOehTWvaXML3C5IuEZrSUTUbsGZUyGlZFtqPiv2ZLJ8zzG2puYhJYRYfbjkHF/+te8qys6/D/Ml/6pTueuPrufB5Q/iq/fljVFvEB8af9q2npH8+R4s/TvojNDlIpi4oLktUiiaBdWV1FB8NBZSN4CzVJvklngDDH4IQurXx1cbcortrN6XyfLdx1i1L4s59hm0FTn8vc1/GH5uBCO6hdMjKrBWEScP5B3g3l/uJa8sj5eGvcTQmDpOtDvTseXA630gsge0Hwwrn4PJ6yDizF79TKGoD0oYGoqlU2HTx9BvEgyaokU9bUJcbknaT3OIXfcU9wW/zdKjAUgJYX4+DO0SzpBzw7igczjh/tU7mY/ZjnH/r/ezN3cv9/S6h1u631Lv6KxnHN//HTb8B+75DfzaaKFG4q+Gq99qbssUiiZHCUND4XJoWxVhKZqMgjR4JQ5GPkl2nyms2pfJ8t2ZrN6XSa5Nm40b1zaAoV3CGNIlnH4dgk+aL1HsKObJNU/yc/LPhJpCuafXPYzvMh7jKeZHnPFk7NBiVfW74/iorh+mwfr34cGt2op5CkUrQgnD2cZ7I0G64e4V3iS3W7IjrYDV+zNZvTeLDck5OFwSX4OO/p1CGdoljAu6hNE10t87HnrLsS28uvFVNh3bRIxfDPf3vp9LOl5y9s15kBI+ugIytsOUTcfDl+cdhtmJ0P9vmt9IoWhFKGE421j9Cvz6T23YajW/dG12J38czGHVvkxW78ti/7EiACL8fbmgSxhDu4TTIzqQmGAT6zN+Z/am2ezJ3UPX4K480OcBhkQPOXtCJOz8Gr64pdJKeF4W3w27voP/2179EqsKxVmIEoazjax98EY/uOQF7dduLUjPL2H1vixW78vitwrdTkJAmwATsSEmjAHbOORaRKErg66BvXig94MMadfvzBYIRwm8cb4W5vxvq0B/wojsjB3w1iAY8QQMm9o8NioUzYAShrORN84Hvwi47bs63+p2S3amF7DvWCHJ2TYO59g47NkfKyzGGLwen7Bf0RmKkMXxtHFdTeegzrQLtdAxzEqnMCudwv0I8/Np+aKx8gVYPuvU4c4/vQ6ObICHtjev/0ihaELUBLezkbjL4bfXtCGYdewC0ekEPaID6RF98izoEruLlNyR7Dt2J98mfc4fLCJDziLfdh7LDozEXhrkzRtgMtAx3I9zwqx0CtfEolO4lQ6h1roFCGws8lO1bre4sadeA+OCh+DDS7R5Kf3vbjLzFIozBdViOFM4sgneGwFXvgm9b2y0x+SV5vHB9g/4bPdnuKSLi9tdyYCQa8nJt3Awq4iDmcUczCzmaMHxRW2EgOggsyYUYVY6VtiigszoazHnokH48g5tpvh9f0Jw++rzSaktuVqQDg9sOmX0WoXibEF1JZ2NSAmv9oC2PZtk9u7R4qO8s+0dvtr3FTqh49qu13JHjzsIt2hRZ4vLnBzKKuZgVjEHMz2C4REOm/14QDAfvc7bJVW+dQjV9pEBvg3XNZX8O3w4BoZOhZFP1Jx/91JYOBHGvQc9r2sYGxStE7cbbFlaROYW3NWqhOFsZelU2PSRZ8lPa5M8MrUwlff+eo+v93+NQWdgQtcJ3N7jdkLNVS9AJKUks7CMQ1nF2pZdzKHMYpKyi0nKtmF3Hg+RbPHR0z7USodQC+1CLMR6tnYhFqKDzJXX0D4Vbhe8O1yLcHv/+tp9Nm43vDUQdAZtAlwL/odWtECcdkhaBbu/hz0/QGE6BLXXwq50vlCLtOzr19xWVqLFCIMQYgwwG9AD70spn6sm33jgS+A8KeUp3/qtWhgOrdLG51/3MXS/skkfnVKQwtvb3ua7g9/hq/fl+m7XMyl+EsGm4FqX4XJL0vNLSMqycSiriEOe/eEcGym5JZVEQwiICjQTE2ymnUcs2oVaiAm2EBtiJsTig0HvEY6N8+DbB2H8f7Q4VrVly2fw1b1w45faP7RCcSpK8mD/L5oY7PsZ7IVgtMA5IyGmHxz+Q/sfdRSD3gfaDdREostFEN6t2X98tAhhEELogb3ARUAqsB6YKKXceUI+f+B7wAe4XwnDKXA54aUu2h/b+PeaxYSk/CTe3vY2Sw8uxWwwc2Pcjdwaf+tph/d2uyXHCss0kcixVd7n2sgoOHlhFX+TgRiznYWlk0n3ac+b7ecQbPUh0OJDsMVIkMVIkMWHILORMD9f2gSaMOortEKcdpiTqAVKnLT0tOxXnKXkp2otgt3fQ9JqcDu1LqOul0DXy7TVHY3m4/mdZXD4d01A9v0Cmbu09IAY6DxK+9/tNBxMAU1elZYiDAOBmVLKiz3njwFIKZ89Id9rwM/Ao8DflTDUwFeTtQlaj+4HQ9OE4K2KA3kHeHvr2/wv6X9YjVZu6n4TN3e/mQCfxvmDL3W4SM3VhCI1t4ScYjt5NgfDD73C0NxFPBw0hy2OWHJtDgpKHVWuaKkT0DbQTHSw1hKJDbYwIve/JO58gYxrvyO02+DjrRBF6yVzL+z8ShOD9C1aWmhn6HaZJgYx/bSgmrUhP1UTif2/wMGVUFagdV/G9ode10Pvm5usJdFShOEaYIyU8k7P+c1Afynl/RXy9AGekFKOF0KsoBphEELcDdwN0K5du77JycmNYvMZQbnT9KbF2i+QZmZv7l7e3vo2Pyf/jL/Rn5vjb+amuJvw9/Fv/Idn7tEmq/W+Ca6Y7U12uSUFJQ7yShzk2uzk2xxkFpaRmquJirbZSC8oxSxLWes7hT/ccUx2PeKZ/GcmJthCmJ8v/iYDfr7a5m8y4Gcy4O9rxM90PM3XoGv58zsUNeMo0ebA/D5XG+wR0++4GISfe/rluxyQ8qcmEnt/1NYI6Xk9XPFa5VZHI3FGCIMQQgcsA26TUiadShgq0upbDI4SeOEc6DUBLn+1ua3xsjtnN29ueZPlKcvxN/pzU/ebuKn7TY3WgkBKmD8OUjdqQ06tYXUuwu50czS/FLFiFrF/vcGHiZ+zrawNqbk2UnJKyLHZK/k9qsOoF5p4mAwEW3wIsvgQ4unGCrb4EGLVjkOsPgRZjJ40n5Yx90OhkbJe8zdl74O+t8Hwx8C/TeM9z+2G1S9pQhTVGyZ8CoGNu6BWSxGGU3YlCSECgQNAkeeWNkAOMPZU4tDqhQHgv7fBrm81B3T/eyDmvGZ3bJWzK3sXb299m2Upy/Az+nFj3I3c3P3mhl9idM8PsOB6uPhZGDj59MoqztKGAvcYD1fNrXSpzOmiqNRJUZmTwlJtKypzUlTmqHReWKqd59kc5Nns5Njs5BU7KCxzVvtYk1FHkNnH2xIpb5mUi4y/b3m61kIJ0DvovvUZLKVHcZ97Cb49Lsc3WEWJPS0cpZ5WwhvgHwVXvq45k5uK3d9r8buMFpgwv1FXGGwpwmBAcz6PAo6gOZ9vkFLuqCb/ClSLoXYUZ2kzfDd/ovVZRvXRBCL+KjBUvzZDU7I7ZzfvbH2HXw7/gtVo5YZuN3BL91sIMgWdfuHOMpjbXxv5ce+ahpmgtvRR2PChJyR3w/1yszvd5JVo/pDcYju5Nju5Nq2LK9fjJym2VxCcinu70+srCaCY93xe5jyxhxQZTnvdMQC2ys6sMQ5ki3UwNv9O3hZJsMXodcJrrZjyFowRf5Ox6SYdtmRS1sPXkyFrL/S5FUb/u1mcwhzbBQtvgLwULUR839sa5TEtQhg8hlwKvIY2XPUDKeUsIcTTwAYp5Tcn5F2BEoa6UVYEWxfAH+9oTWBrBJx3B/SdBP6RzW0dAHty9vDOtnf4OflnLAYLN8RpAlGXYa4n8dur8MvMhvWz5CbDnN4w4F64eFbDlHmauN2SEocLW/YRAhZNwJi7nz0DX+JgxGjcmbsJS/2J9sdWEGXTRr6k6GNZpevPUmdf1pa2Q8qqX/5CQIDJ6BWPILPRKyiB5vLRXEavL8Xf41cpb9kYz3QHvaMUVjwDa1/XWglj5zS/v64kF768HQ4sg/PuhDHPNfiM/BYjDI2BEoYqcLvh4DJNIPb9pK1v3GOcFok1um/dyysrgvwUrWXSJgHMQadt4r7cfbyz7R1+SvoJk8HExG4TuTX+VkJMtYz7JCWkb9W6kNa+rg0TbOgZ4Ivu1Mr/v+1gPg3hakiyD8AnV0FxNlw/v+pujvxUbVDC7m8haQ1IF9I/CnvnMeS0u5j04D7kl0KuTWuh5JU4yPe0XCod2+wUlFbf9VWOyajD32TE/wSHfJDFSKifDyFWX8L8fAi1+hLq50Oo1Ydgq89xQXE54c93YdULWhj5HuO1lfWCOzToR1clqRu0kX1Ze5q3lVAVbpf2g2ftHG0p2ms/Ar/wBiteCUNrJvuA9k+3+VNtAk7MeVo3U9zY48Nbywq1ZmveYc+WXOH4MJTkHC9P6DVxOWektkX3PTmUdR04kHeAd7a9w4+HfsRkMDGh6wSu7nI1HQI6nLxgkLMMDq2GPUs9s0vTQOig3SBtec6gdvW2o0qOboe3B8PIf8DQRxu27PqQtgXmjwekNgkvuk/N99hyYO//tJhR+38FZwmYArXPLKYfxJ6vdT1WMyu34oiuwlIHRaVOCk7wo1Q81jbtOL/EQXaxHZe76ndKkMXIENMBHrG/QwfnIfb79cXkLiHGpk1tSrHEsS1wFNsCR5BniEAicUvtN4GUEonW2gk0Gwky+3hbNuVdZEFmH4KsmmCdNEqsJbYSqmPbF/DNFG2+xPWfQtteDVKsEgYFlBZoM3v/fAdyDmprHvu3OfnFD2AwQWCs9qKtuJmCIGUdHFgOaZu0VeR8A7TIpZ2Ga0IR0qleju+D+Qd5d9u7/HDoB9zSjZ/Rj/jQeOIDO9GjtIyEo7uJPPgbwl4ERit0HgldL4Uuo+s1AqnWzL8G0jZrrYYmGEJYLQdXwsIbtZbLzUsgrHPdy7DbtK6JPT9Ayh9adyNo4hoRD7HnQcz52o+H0HMaZACD2y0pKHWQVWQnu6iMnGI7WcV2inMz6LdvDv1yviVLF8YbvnfyTVlfXBKiyeBifudiuZZuHAJgq+jGL/oLWK4bSK4uBCFAJ4RXuE7l1NfrBEFmI4EWI0FmIwns5+6cl4h2HmaV3yV8GXYPdr0/Op1Wpl4n0InyTbtfCOF5ppZHQIU0LV/Fc4NOEGg2errijk+wDPQIWJ2739I2a9+/LQeufKNuM/qrQQmD4jhutzZueuOH4LKf8PJvr+1rE/yrJFeb7n9gmbblHdbSg9rDOSM0keg4tM5dMKmFqazf/z3bk35le/5+9mLH6bElVPjQI6gz8TEXkBDZmx6hPRrGeX0qkn6DeZdVvfpbU7HjK1h8lzap6qZFEBDVMOXacuDIRm0sfeqf2lBfe6F2zRysCUTM+ZpgRPfVFjs6Xdxu2PIp/PwUlOZrI8iGTa8+jlD2Adi+GHYs1sb5C53WrdJjHMRdCVYtRpfD5SbfZqcgL4fi3KOU5h2jrDATd1EmsjgLXUkOxtIczPYsepRtJlcXwhzrA2ww9MEtpWfThMwtJS4pcbvRjt1a60RKiZR481Y8lxxPR4LD7a5yUmU5fr4GAs1Ggq1ayybQoomIxajH4mvA6qPtLUY9Vl89Fh8Dge4cuqy4D8vR9djOux9GPYXZt/5roihhUDQuUmqtkAPLtNbEoVXaC0boILijJjJSai0M6QZkhfMK6dKthRgozdPKjUyg7NzR7Gkbx3bs7MjZyfas7RzKP4T2rwjRftH0DOvJ6A6jGRYzDGNDh8yWEv5zERQd09aLPo1us3qx/j/w/SPazNgbFjaur8Pt0iYJpq7XhCJlvdb3Dtrs3HYD4dwx2lafFsvR7VpdUtZpZV32MkTG1/7+Y7s1gdi+WGvtCL025t9Zqvm/bNngdlR9r8EEljBNSGL7a92DpgYeMl0Bt1tSZHeSV+w4PgrNZie/xEGuJy3fk6b5dRzklziw2V2UOFzVlmvEyVOGj7nZ8AsrXL3YdN6LPDy2fkNalTAomhaXQ/slemCZNvQPoYmE0GkiUX6MqHAujqeFd9Viz1TjMyiyF7Ezeyfbs7ezPWs7mzI2kV2aTYgphCs6XcG4LuPoFNSp4eqz6zv4/EbNMdnv9qaJZCslrHweVjyrvYiv+bB5VpcrydNWt0v6Dfb+BMc8o8tDztG+o3Mv1l7ypxLkskJY8Ryse0t7GY/+F/S6AXT1HM0kJWRs1wQi5U/NWWwJ1boULaEeAQjTFrAqPzZaWszcnpooH31WbHdSYndRXObCZndis2v74jIX0Qc/57ydz5DZ5Tra3PBWvZ6jhEFxVuN0O1mbtpbF+xazMmUlTukkMTyRcV3GcXGHi7EYT/OF6nbDe8O1UVA6o9at0uEC6DhE62pp6Be22wU/TIX172sv0LFzWs7iQbnJ2ki3vT9qLUOXHXwDNcftuWO0yKHlKwpKCbu+gR+mawMF+twKF86s84qDimpI+RPCzq33KEElDIpWQ1ZJFt8e+JbF+xaTVJCExWBhTMcxXN35anqF96p/DCO7DQ6v1UZFJf2mOQOlS5tUF92vglCcd3pOamcZLPkb7FgCgx6Ai55uub90y4rg4ApNJPb+D4qPaa2+mPO1lkTyGs2fFZmghWuJPa+5LVZUQAmDotUhpWRL5hYW71vM/5L+R4mzhE6BnRjXZRyXd7q82oWFak1pgTay59AqTSjSt2g+Er2vJg4dLoD2gzSH7Yl+FE44925SC8VwcAVc9C8Y/EADfBJNhNsN6Zs1gdj7o9a68vHXVs87766m980oakQJg6JVU+wo5sdDP7J4/2K2ZW7DIAwMiRnCiNgRDI0ZevoiAdoIm8PrjgvF0W0eEagjQq8NR0y84fRtak4Kj2rhWFrKxEDFSShhUCg87M/dz5L9S/gx6UeO2Y4hECSEJTAsdhjDYoZxbvC5DRMyuyRPc8C7HFU73isdV9j8Ihp+op5CUQVKGBSKE5BSsjtnNytTV7IyZSXbs7cD0MbahmExwxgaM5T+bfvjq28ZQQgVioZGCYNCUQNZJVmsSl3FypSV/J7+OyXOEswGM/3b9md4zHCGxgwl3NJwcWoUiuZGCYNCUQfKXGWsP7qelSkrWZm6kvTidAA6BHSga0hXuoV049zgc+ka3JUIS4RarU1xRqKEQaGoJ1JK9uXtY1XqKv7K/Is9uXs4UnTEez3IN4iuwV3pGuLZgrvSKbBTw8/AVigamLoIgxpTplBUQAjBucHncm7w8TV+C+2F7M3dy56cPezN3cvunN18vudzylxlABh0BjoFdqJbSDf6RfZjUNQgIq0tYz0MhaI+qBaDQlEPnG4nhwsOsyd3D7tzdrMndw+7sneRU6pFru0c1JlBUYMYHDWYPpF9MBlMzWyxorWjupIUimZASsne3L2sTVvLmrQ1bMrYhMPtwFfvS9/IvgyKGsSgqEF0Duqs/BSKJkcJg0LRAihxlrDh6AbWpq1lbdpaDuYfBCDCEuEVifPanEeoKVQJhaLRUcKgULRA0ovSva2JdenrKPSsheBn9CPGP4YYv5jKe/8YoqxRyrGtaBCUMCgULRyX28X27O1sPbaVI0VHSC1KJbVQ2+xuuzefQNDG2oYY/xii/aKJ8YvhnKBziA+Np421jWppKGqNGpWkULRw9Do9vcJ70Su88nq+bukmqyRLE4kKYpFalMqaI2vILMn05g0xhWjLoYbF0yO0B/Fh8YSZG3HZU0WrQQmDQtGC0AkdEZYIIiwR9Insc9L1EmcJ+3P3sz17OzuydrAjewdr0tbg9gTwi7BEeEUiPlTbGn05VMVZR6MKgxBiDDAb0APvSymfO+H6w8CdgBPIBG6XUiY3pk0KxZmM2WAmITyBhPAEb5rNYWN3zm62Z21nR/YOdmbvZFnKMu/1aL9o2lrbEmIK0TZzCKGm0OPnnjR/o7/qmlIAjSgMQgg9MBe4CEgF1gshvpFS7qyQbTPQT0ppE0LcC7wATGgsmxSKsxGL0UKfyD6VWhgF9gJ2Ze9ie9Z2dufs5pjtGHtz95JTmkOBvaDKcgw6AyGm46IRZg4jwhJBmDmMcEs44eZw795H79NU1VM0A43ZYjgf2C+lPAgghFgIXAl4hUFKubxC/nXATY1oj0LRagjwCaB/2/70b3vywvEOl4PcslxySnPIKckhuzRbO66wZZdksy9vH9kl2bjkyYvVB/oGEm4OryQeba1taRfQjnb+7WhrbYtep2+KqioagcYUhmggpcJ5KnDyX+lx7gB+qOqCEOJu4G6Adu1U7HqF4nQw6o1eP0ZNuNwucstyySrJItOWSWZJZqV9VkkW64+uJ7MkE6fbefwZOiMx/jG082/nFYt2Ae1oH9CeNpY2SjRaOC3C+SyEuAnoBwyr6rqU8l3gXdCGqzahaQpFq0av0xNmDiPMHEa3kG7V5isfTZVckExKYQrJBckcLjjM4cLD/Hn0T0qcJd68FUUjzBxGgG8AgT6BBPoGEuQbRKBvIAE+Ad5zFU6k6WlMYTgCxFY4j/GkVUIIcSHwBDBMSlnWiPYoFIpGouJoqvPanFfpmpSSY7ZjHC48zOGCwyQXJpNSkMLhwsPszN5JXlkeDrej2rJ99b4E+gQS4BtAsCmYMNNxn0eYJYwIc4R3bzValQO9AWhMYVgPdBFCdEQThOuBSgvbCiF6A+8AY6SUxxrRFoVC0UwIIYi0RhJpjTxJNEATjlJXKfll+d4tryyPfLt2XFBWoJ170rdnbyczJZNSV+lJZZkNZs1ZXsFRHmoOJdg3mGCTtgX5BhHsG0yAbwA6oWuKj+CMo9GEQUrpFELcD/wPbbjqB1LKHUKIp4ENUspvgBcBP+C/HpU/LKUc21g2KRSKlocQArPBjNlgpo21Ta3ukVJS5CgisySTLFsWx0qOkWXLquQD2ZOzh9W21dictirL0AkdQb5B3q2icFiNVswGMxaDxWtbpc14/NikN511rRQVEkOhUJzVlDhLyC/LJ7c0V9vKcskry6v2PK8sr8qRWNUhEFiMFvx9/L1dXuU+kgCf6o8tRgsGnQGjzohRZ8SgMzSqwKiQGAqFQuGhPq2RMlcZJc6SSpvNYat87rRVulZgL6CgrIACewHJBclaN5i9wLugU23QC71XLAw6w/FNGDDqjYzvMp5b42+t70dRa5QwKBQKRQWEEJgMJkwGE8EEn3Z5pc7SSqJRLhg2pw2n24nT7cThdniPK53LyudNFQtLCYNCoVA0IuUiU5t5Iy0F5ZJXKBQKRSWUMCgUCoWiEkoYFAqFQlEJJQwKhUKhqIQSBoVCoVBUQgmDQqFQKCqhhEGhUCgUlVDCoFAoFIpKnHGxkoQQmUB914UOA7Ia0JwzjdZc/9Zcd2jd9Vd112gvpQyvzU1nnDCcDkKIDbUNInU20prr35rrDq27/qruda+76kpSKBQKRSWUMCgUCoWiEq1NGN5tbgOamdZc/9Zcd2jd9Vd1ryOtysegUCgUipppbS0GhUKhUNSAEgaFQqFQVKLVCIMQYowQYo8QYr8QYnpz29OUCCGShBB/CSG2CCHO+gWzhRAfCCGOCSG2V0gLEUL8LITY59mf/tJcLZBq6j5TCHHE8/1vEUJc2pw2NhZCiFghxHIhxE4hxA4hxIOe9Nby3VdX/zp//63CxyCE0AN7gYuAVGA9MFFKubNZDWsihBBJQD8pZauY5COEGAoUAR9LKXt40l4AcqSUz3l+GARLKac1p52NQTV1nwkUSSlfak7bGhshRFugrZRykxDCH9gIXAXcRuv47qur/3XU8ftvLS2G84H9UsqDUko7sBC4spltUjQSUspVQM4JyVcCH3mOP0L7hznrqKburQIpZbqUcpPnuBDYBUTTer776upfZ1qLMEQDKRXOU6nnB3aGIoGfhBAbhRB3N7cxzUSklDLdc3wUiGxOY5qB+4UQ2zxdTWdlV0pFhBAdgN7AH7TC7/6E+kMdv//WIgytnQuklH2AS4D7PN0NrRap9Z+e/X2ox3kLOAdIBNKBl5vVmkZGCOEHLAIeklIWVLzWGr77Kupf5++/tQjDESC2wnmMJ61VIKU84tkfA5agda21NjI8fbDlfbHHmtmeJkNKmSGldEkp3cB7nMXfvxDCiPZS/FRKudiT3Gq++6rqX5/vv7UIw3qgixCioxDCB7ge+KaZbWoShBBWjyMKIYQVGA1sP/VdZyXfALd6jm8Fvm5GW5qU8peih6s5S79/IYQA/gPsklK+UuFSq/juq6t/fb7/VjEqCcAzROs1QA98IKWc1bwWNQ1CiE5orQQAA/DZ2V53IcQCYDhayOEMYAbwFfAF0A4tbPt1UsqzzklbTd2Ho3UjSCAJ+FuFPvezBiHEBcBq4C/A7Ul+HK2fvTV899XVfyJ1/P5bjTAoFAqFona0lq4khUKhUNQSJQwKhUKhqIQSBoVCoVBUQgmDQqFQKCqhhEGhUCgUlVDCoFB4EEK4KkSg3NKQUXiFEB0qRjxVKFoyhuY2QKFoQZRIKROb2wiForlRLQaFogY861m84FnT4k8hRGdPegchxDJPcLJfhRDtPOmRQoglQoitnm2Qpyi9EOI9T6z8n4QQZk/+Bzwx9LcJIRY2UzUVCi9KGBSK45hP6EqaUOFavpQyAXgDbQY9wOvAR1LKnsCnwBxP+hxgpZSyF9AH2OFJ7wLMlVLGA3nAeE/6dKC3p5x7GqdqCkXtUTOfFQoPQogiKaVfFelJwEgp5UFPkLKjUspQIUQW2sIoDk96upQyTAiRCcRIKcsqlNEB+FlK2cVzPg0wSin/LYT4EW1xna+Ar6SURY1cVYXilKgWg0JRO2Q1x3WhrMKxi+M+vsuAuWiti/VCCOX7UzQrShgUitoxocL+d8/xWrRIvQA3ogUwA/gVuBe0ZWWFEIHVFSqE0AGxUsrlwDQgEDip1aJQNCXql4lCcRyzEGJLhfMfpZTlQ1aDhRDb0H71T/SkTQE+FEI8CmQCkzzpDwLvCiHuQGsZ3Iu2QEpV6IH5HvEQwBwpZV4D1UehqBfKx6BQ1IDHx9BPSpnV3LYoFE2B6kpSKBQKRSVUi0GhUCgUlVAtBoVCoVBUQgmDQqFQKCqhhEGhUCgUlVDCoFAoFIpKKGFQKBQKRSX+H4ttGoSHiePxAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.18545961380004883 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time()\n",
+    "plt.plot(history.history['loss'])\n",
+    "plt.plot(history.history['val_loss'])\n",
+    "plt.plot(history2.history['loss'])\n",
+    "plt.plot(history2.history['val_loss'])\n",
+    "plt.plot(history4.history['loss'])\n",
+    "plt.plot(history4.history['val_loss'])\n",
+    "plt.title(\"Model Loss\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Loss')\n",
+    "plt.legend(['Model 1 Train', 'Model1 Validation', 'Model2 Train', 'Model2 Validation', 'Model4 Train', 'Model4 Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mature-tackle",
+   "metadata": {
+    "papermill": {
+     "duration": 1.471257,
+     "end_time": "2021-04-25T15:08:02.485751",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:01.014494",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Accuracy v/s no. of epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "dirty-provider",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:08:05.340449Z",
+     "iopub.status.busy": "2021-04-25T15:08:05.339490Z",
+     "iopub.status.idle": "2021-04-25T15:08:05.524833Z",
+     "shell.execute_reply": "2021-04-25T15:08:05.525485Z"
+    },
+    "papermill": {
+     "duration": 1.628613,
+     "end_time": "2021-04-25T15:08:05.525700",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:03.897087",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAABoRElEQVR4nO2deXyUxf3H37Nnks19J+TivmM45BIQUBQVRUVFvLXV1qtaayvVHuqvtdZaW620VqviDValokWsCgiiCOE+wk1IQg4g92az2eOZ3x/PZklCEkLIJoHMm9fzep5nntnn+T67YT4z35n5jpBSolAoFAoFgKGrDVAoFApF90GJgkKhUCj8KFFQKBQKhR8lCgqFQqHwo0RBoVAoFH6UKCgUCoXCjxIFRY9ACJEhhJBCCFMb8t4mhPimM+xSKLobShQU3Q4hRK4QwiWEiG2SvslXsGd0kWkNbQkVQtiFEJ91tS0KRUeiREHRXTkIzK0/EUIMB0K6zpwTmA3UAdOFEImd+eC2tHYUivaiREHRXXkLuKXB+a3Amw0zCCEihBBvCiGOCiEOCSF+JYQw+K4ZhRDPCiGOCSEOAJc189lXhRBFQojDQojfCSGMp2DfrcBLwFbgpib3niiE+FYIUSGEyBdC3OZLDxZC/Nlna6UQ4htf2hQhREGTe+QKIS70HT8uhPhACPG2EKIKuE0IMUYI8Z3vGUVCiBeFEJYGnx8qhPhCCFEmhCgRQjwqhEgUQjiEEDEN8o30fX/mU3h3xVmMEgVFd2UtEC6EGOwrrK8H3m6S529ABNAHOB9dRG73XbsTmAmMAEYD1zT57ALAA/Tz5bkI+GFbDBNCpANTgHd82y1Nrn3msy0OyAI2+y4/C4wCJgDRwC8ArS3PBGYBHwCRvmd6gZ8CscB44ALgHp8NYcCXwDIg2feOX0kpi4GVwHUN7nszsFBK6W6jHYqzHCUKiu5MfWthOpADHK6/0EAofimlrJZS5gJ/Ri/kQC/4/iqlzJdSlgF/aPDZBOBS4EEpZY2U8gjwF9/92sLNwFYp5U5gITBUCDHCd+0G4Esp5XtSSreUslRKudnXgrkDeEBKeVhK6ZVSfiulrGvjM7+TUv5HSqlJKWullBuklGullB7fu/8TXRhBF8NiKeWfpZRO3/fzve/aG/haNr7vcC7696xQAKB8k4ruzFvAKqA3TVxH6DVkM3CoQdohoJfvOBnIb3KtnnTfZ4uEEPVphib5W+MW4BUAKeVhIcTX6O6kTUAqsL+Zz8QCQS1cawuNbBNCDACeQ28FhaD/X97gu9ySDQAfAy8JIXoDA4FKKeW6dtqkOAtRLQVFt0VKeQi9w/lS4KMml48BbvQCvp40jrcmitALx4bX6slH7ySOlVJG+rZwKeXQk9kkhJgA9Ad+KYQoFkIUA2OBG3wdwPlA32Y+egxwtnCthgad6L4afFyTPE3DGf8D2AX0l1KGA48C9QqXj+5SOwEppRN4H721cDOqlaBoghIFRXfnB8A0KWVNw0QppRe9cPu9ECLM58t/iOP9Du8DPxFCpAghooB5DT5bBPwP+LMQIlwIYRBC9BVCnM/JuRX4AhiC3l+QBQwDgoFL0P39FwohrhNCmIQQMUKILCmlBrwGPCeESPZ1hI8XQliBPUCQEOIyX4fvrwDrSewIA6oAuxBiEHB3g2ufAklCiAeFEFbf9zO2wfU3gduAK1CioGiCEgVFt0ZKuV9Kmd3C5fvRa9kHgG+Ad9ELXtDdO58DW4CNnNjSuAWwADuBcvRO3KTWbBFCBKH3VfxNSlncYDuIXrjeKqXMQ2/Z/AwoQ+9kPsd3i4eBbcB637U/AgYpZSV6J/G/0Fs6NUCj0UjN8DB6/0W1710X1V+QUlaj98NcDhQDe4GpDa6vQe/g3uhrjSkUfoRaZEeh6HkIIZYD70op/9XVtii6F0oUFIoehhDiXHQXWKqvVaFQ+FHuI4WiByGEeAN9DsODShAUzaFaCgqFQqHwo1oKCoVCofBzxk1ei42NlRkZGV1thkKhUJxRbNiw4ZiUsun8lxM440QhIyOD7OyWRigqFAqFojmEEG0afqzcRwqFQqHwo0RBoVAoFH6UKCgUCoXCjxIFhUKhUPhRoqBQKBQKPwETBSHEa0KII0KI7S1cF0KIF4QQ+4QQW4UQIwNli0KhUCjaRiBbCguAGa1cvwQ9Ln1/4C70+PAKhUKh6EICNk9BSrlKCJHRSpZZwJtSj7OxVggRKYRI8sW6VygUioChSY06bx0urwunx4nL66LOW6enaS7qw/8IIRD+tYv0c8CfJhAIIZBS4tbcxzevG5fm8h/Xp3s0Dy6vni6RGDAghMAojAghMAiDfozAaND3BmHwbyPjR9Instn1kzqMrpy81ovGSwwW+NJOEAUhxF3orQnS0tKaXlYoFGcAmtSorKuk3FlOqbOUyrpKPNKDlBJNamhSQyL955Lj6fWf90rv8cK7SYHesGBv7tz/Ga8Tj+bp4m+jffx63K/PalFoM1LKl4GXAUaPHq0i+CkUHYCUEo/maVSLrd97NA8aGpqm6XtfgSylbLSvL7S90ovdZafcWU5ZXRlltWWU15VT5izT05xlVNRV+Av4jsBkMGE1WhttFqPFvw+1hBJtjCbIGORPb7SZGn/Gfw+DRa/9I/2LoErfv/rvrT6tIWaDWd+MZv+xxWg5nt7gmslgwiAMjb5PDQ2v5kXSIK3J9x5uCe+w76/F7zXgT2iZwzReQzeF4+vrKhSKNuJwOzjiOKJvtUeOHzuOUOIoobS21O+yqC/w3Zobr/QGzKZwSzjRQdFEB0WTHp7OiPgRRAVF+dOig6KJtEZiNpj9LhqDMPhdKP7zBukC3c1iNekFt9FgDJj9nYUQApNoUAx3g1fqSlFYAtwnhFiIvvB5pepPUPQ0pJTUemr9m8Pj0PduR4vnZbVljQr+aveJyyKEmkOJC4kjPiSeEfEjsBqtmAwmf421/thkMPm3puf1fm6jMGJA92nX+7kbXfP5u21mm17YB+mFveLMJGCiIIR4D5gCxAohCoDfAmYAKeVLwFL0tWz3AQ7g9kDZolB0JU6Pk7zqPPKr8jlUfYi8qjwOVen7o7VHT3BDtIbZYCYqKIqEkAQyIjIYkzSG+JB4EkISiA+J9282sy2Ab6Q4mwnk6KO5J7kugXsD9XyForPwaB4q6yopc5Y1W/iXOEoa5Y8OiiYtLI1xyeNItCViM9sINgUTYgrR92Z931yayXBGdAMqzmDUX5hC0QSnx8mhqkMcqz1GRV0FFXUVVNVV+Y8r6yobpTfnvomyRpEWnsaYxDGkhaeRHp5OWngaaWFphFnCuuCtFIq2oURB0WOpcFZwoPIABysPcqDygP+40F7YrEsnzBxGhDWCSGskkUGRZERkEGmNJMISQYQ1guigaFLCUkgNSyXCGtEFb6RQnD5KFBRnNVJKjjiOsLdiLwcqDnCw6iAHKg6QW5VLmbPMn89qtJIRnsHw2OHM6juL3hG9SbAl+EUg3BKuXDeKHoH6K1ecNUgpKbAXsKtsFzmlOews20lOaU6jwj/CGkGfiD5MSZ1Cn4g+9I7oTe+I3iTbks+KIY4KxemiREFxRuLVvByqPkROaY6+lelbtUv37xuFkb6RfZnUaxKDYwYzIGoAfSL6EB0U7Q9VoFAoTkSJgqJL8Wge7C47drdvc9mpcddQ7a6mxlXTbHqZs4y95Xup9dQCYDFYGBA1gBkZMxgcM5gh0UPoF9UPq9HaxW+nUJx5KFFQdCpur5ttx7axrngd2cXZbD66mTpvXaufMQojoZZQQs2h2Mw2Iq2RXN3/agZHD2ZwzGB6R/RWk6UUig5CiYIioLi9braXbmd98XrWFa9jy5EtOL1OBIJB0YO4dsC1pISlEGr2FfoWG2HmMGxmG6EWXQSCjEHK5aNQdBJKFBQdiltzs+PYDtYXr2d98Xo2H93sd/MMjBrINQOu4dzEcxmVMEoN21QouiFKFBSnhSY19pbvZW3RWr4r+o6NJRv9IjAgagBX97+acxN0EYgMiuxaYxUKxUlRoqA4ZYrsRX4R+L7oe/+Qzz4Rfbiy35WMSRzDqIRRRAVFdbGlCoXiVFGioDgpVa4q1het94tAblUuALHBsUxInsD45PGMTRxLgi2haw1VKBSnjRIFRSPcXjd51Xnsr9jPrrJdrC1ay47SHWhSI9gUzLmJ5zJn4BzGJY2jb2Rf1QGsUJxlKFHoodR6ao/H/Kk44I/9k1eV5198xSiMDI8dzo8yf8S4pHEMjx2O2aiGfioUZzNKFHoADreD5fnL2VW6y1/4Nwz6ZhRG0sLT6BPRhwvTLqRPZB/6RvQlIyKDYFNwF1uvUCg6EyUKZylSSrYc3cJHez9iWe4yaj21WAwWekf0JjM2kyv7XUmfiD70jexLWliaagEoFApAicJZx7HaYyzZv4TFexeTW5VLiCmES3pfwpX9riQzNlMFfVMoFK2iROEswK25WV2wmsX7FrO6YDVe6WVk/EjuGHYHF2dcTIg5pKtNVCgUZwhKFM5gDlQe4D97/8OS/UsodZYSGxzLrUNv5cp+V9I7ondXm6dQKM5AlCicQUgpyavOY83hNXx28DM2H92MSZiYnDKZq/pfxcReE9VCMAqF4rRQJUg3p7KuknXF6/i28Fu+K/yOw/bDgD57+GejfsbMvjOJDY7tYisVCsXZghKFboZbc7Pt6Da/CGwv3Y4mNWxmG2MTx3L70NsZnzye1LBUNXFMoVB0OEoUugF5VXl8W/gt3xZ+y7riddS4azAIA8Nih3FX5l1MSJ7AsNhhas0AhUIRcAIqCkKIGcDzgBH4l5Ty6SbX04HXgDigDLhJSlkQSJu6C4eqDrHs4DKW5S5jX8U+AHqF9uLS3pcyIXkC5yae26WhpaWm4TlyBFNsLMKk6g4KRU8hYP/bhRBGYD4wHSgA1gshlkgpdzbI9izwppTyDSHENOAPwM2BsqmrOWw/zOe5n7Ps4DJyynIAGBk/knlj5jGp16Qudwl5jh2jZs0a7Ku/oWbNGrzl5WAyYe6VjCUtHUtaGpb0NMxpafp5Si+ExdJl9irOTDSHA1deHu7DhxEWK8bwMAzh4RjDwzGGhXXZ35SUEul2I2tr8Vbb0aqr8FZV462qRKuqxltdhValp2nVVXgrq/BWV6NVVYHBgG3CBEKnTiFkxAiE+cxt1QspZWBuLMR44HEp5cW+818CSCn/0CDPDmCGlDJf6KVhpZQyvLX7jh49WmZnZwfE5kBQUlPC/w79j2W5y9h6dCsAw2OHMyNjBhdlXESiLbHLbJNuN7VbtugisHo1zp26XhtjYgideB5BwzPxHD2KK+8Q7kN5uA4dQqupOX4DgwFzUlIjoQgZPYrgzMwueqMzA095OfYVK7GvWE7dgYMIiwWDxYKwWhG+vcFqQZh9aVYrwmLGYLUiLFYMwUEYbDZ9Cw09ftxw62Kxlh4P7sOHceXm4srNpS43F9dB/dhTXNzqZ0VwMMawMIwR4RjCdLEwhIdhDI/AEBwMSKRXA00DqSE1CZqG1LxQfyw1/djrRbrdaHV1SKcTWVfnP9bq6pBNjjlZeSgEhrCw4zb57NNq7DjWZyPdbgzh4YROnEjo1KmETpqIMTKyw77X00EIsUFKOfpk+QLpF+gF5Dc4LwDGNsmzBbga3cV0FRAmhIiRUpY2zCSEuAu4CyAtLS1gBncUpbWlfHHoC5blLmNjyUYkkkHRg3hg5ANcnHExqWGpXWabu6gI++rV1Kz+hprvvkOz28FoJHhEFnEPPoht0kSCBg9GGAwnfFZKibe8HNehQ7jz8nAdysOVp2+1ny1Dq6wEwDZ5EnE/eYDgYUM7+/W6La7cXKq/Wk718uXUbtoEmoYpMZHg4cORXq9eOLlceKurkMdcSJdLL8BcdUiXW7/elkKrHrMZY0iILhDh4Zh79fK39CxpaZjT0jEnJSKM7ZvhLqVEq6zEXVyMu7gYT3Exrrx8vwi48vPB7fbnN4SHY+mdgW3sGCwZGVgyMjCnpCLdbr0mXl2Nt7LqxNp5VRXuIyVo+/bhrapCq63VW9MGg/436tvq0zAajx/70oXZjAgK8omtFWNkJIYgXWBFkBWDNch33eI7tmIM87VewsIbiFMYhtDQZv9vAHjtNdR8960u+F9/TdXSpWA0EjJiBKFTpxA6dSqW3r1P6g3QXC7cBQXN/j+L+8lPiJh5Wbt+s7YSyJbCNeitgB/6zm8Gxkop72uQJxl4EegNrAJmA8OklBUt3be7thQ0qbGqYBXv7XqPtUVr0aRGn4g+zOg9gxkZM7p0MplWU8Oxl1+h+qsvce3bD4ApMZHQSZOwTZqIbfx4jGFhp/0cT3k5lR9+SOkr/8JbWUnY9AuJve9+ggYOOO171+OtrqZ240a0ujq9FujVQPPtvZ7G55oX6fGC5sUUH0/YBRdgsNk6zJbWkF4vtVu2Yl+xnOqvluM6cAAA6+DBhE2dSugF0wgaMuSU3IVSSnC70Wpr0Wpq/JvXXtPovOnmrarSC5m8PF1Y6jGbsaSk6CKR7nMJ+kTDEB6Op6QEd1GRvi8uxlNUjLukBE9REe6SEqTT2cg+YbFgSU/3F/qWjAwsvTOw9O6NMTKyR42Wk5qGc9s2qleuxL5iJXW7dgFgTksjdMr5hE2diik2Vi/sfa3w+ha5u6iokfgbQkP17zU9jchrr8U2fny7bGprS6FL3UdN8ocCu6SUKa3dt7uJQo27hv/s+w/v5LxDfnU+CSEJXNH3Cmb0nkH/yP5d/h/BsXEjhY/Mw11QgG38OGyTJhM6aSKWvoFbC8Frt1P2xhuUvb4AraaG8EsvJfa+e7H2bp8wai6XXvP65FPsK1ciXa523ccQEkLYJTOIvPpqgkeO7PD312prqfnuO6qXL8e+YiXe0lIwmbCNOZfQaRcQNnUK5l69OvSZp0L94AG95nliLVQ6HC1/2GjEFB+POTERU2IC5oREzEmJmBISMScmYEpMxBQX1+6Wx9mOu6gI+8qVVK9cieO7tSf8DRsjI48Lc8MWXXp6hwlqdxAFE7AHuAA4DKwHbpBS7miQJxYok1JqQojfA14p5W9au293EYWC6gLe2/UeH+39CLvbzjlx53DT4Ju4IP2CbjF0VLpcHP3bi5S++irm5GSSn/4DIaNP+vfQoXgrKih97XXK3noLWVdHxJVXEnvPPVhSTl4wSk3DsW49lZ9+QvXn/0OrrsYYE0P4JZcQNn06xohwvQAyGvXmvNHY+NxkOp5uMODMyaHio4+o/mwZmsOBJT2diKuuIuLKWZgT29evI71enDtzqFn7HY7v1uLYuBHpdGIIDSV08mRCL5hG6KRJGMNb7SbrFkgp8R475q+5avbqBgV+EqbYGFXgdxCaw0HN2u/9f4eWtFSMEYEfadjlouAz4lLgr+hDUl+TUv5eCPEkkC2lXOJzMf0BkOjuo3ullHUt3pCuFQUpJRuPbOTtnW+zPH85BgxMz5jOTYNvIjOu+3SuOnfvofCRR6jbtYuIa2aTMO+XGEM7x23SHJ7SUkpffoXy995DSknkNbOJ/fGPMSc0Xr5TSkldTg6Vn3xK1dKleEpK9Nr99OmEz5yJbfy40x4eq9XUUPW/L6j86CMc69f7R41Ezr6a0GnTMFitLX5WSolr/35qvltLzfdrcaxbr488Aaz9+xMybhxhU6cQMnq0GpWl6HZ0C1EIBF0hCi6vi89zP+etnW+RU5ZDhDWCawdcy5yBc7p09FBTpNdL2YI3OPrXv2IIDyfp//6PsGlTu9osP+6SEo699BIV//4AYTQSNXcuMXf+EM3hoOrTT6n89L+49u8Hs5nQSZOImHkZoVOn+kacdDyuvDwqFi+m8j8f4ykqwhARQcRllxFx9dUEDdX9/a6Cwzi+X+sXAu/RYwCYU1KwjR9HyNhx2MaNxRSrQo0oujdKFDqA8vJi3t/3AQsPfsix2mP0iejDTUNuYmafmd1uRTJXQQFF836JIzubsOkXkvjEE5iio7varGZxFRRwbP7fqfz4Y4TRiPSNUgkZPZrwyy8n7KLpmKKiOs0e6fVSs3YtlR8tpvqLL5AuF9b+/dGcTtz5+gA6Y2wstrFjdSEYNw5LSqtdXwpFt0OJwmlSU3yYTVdfQp1089nPxnP1+B8yPnl8l3ccN0VKSeVHH1Hy+6dACBJ+9SsirpzV7exsjroDByl/5x3MSYmEX3YZ5qSkrjYJb1UVVUuXUvXfpRjCw/1CYOnX74z4ThWKllCicBp47TVkX3sJloKjWMxBWGPjSX9jQbcotBriKS2l6Ne/wb58OSFjxpD8h6e6dHRLj0TT4NhuyP8eireBxwmaPgwW6QXN4zvWfOkeX7pvixsIFz8FljN0ISRPHez4D2x+B6L7wIW/heDOa+Up2k53mLx2RiJdLvbeexe23KMsv28sd078KXk/vJNDN9+iC0M3KXSrv/qKol//Bs1uJ37eI0TfckuLk2oUHYjLAYUbIW+tLgT568BZoV+zRoDFBgaTPnlKGH3HRt+xscGxCYSAjW9AyQ64YRGEdE93X7NU5EP2a7DxTXAcg8g0yP0Gdv0XLv0TDJmlv5/ijEO1FBogpaTwkXlULVnC61fYeOSJz4kJjqF223byfvADjKGhpL35Rpf5k92FhdhXraL6q+XUrF6Ndchgev3xj1j79+8Se3oE1SWQvxbyvtf3RVv02j5A7EBIGwupYyF1HMT0PfWCcOcS+PCHEJUON32oF67dFSnhwApY9y/Y85meNmAGnPtD6DMVSrbBkvv172jQTLj0WQjvXq3rrqbO48Xu9FBT56XW7aXO46XOo1Hn1nB5vdS5Nf28Qbr/2KNx8dBERqW3ryWm3Eft4Mhzf6H05ZdZNMlA5i/+j6v7X+2/VrtjB3l3/ABDSAjpbyzA0gnhNqTbjWPTJmpWrcL+9dfU7dWjqZp79SLi6quIvfPOtg991LwgDIGpvXndkLMEvn8ZjuzUa8FGMxgtvmOL79wMBnPjY5MVUsfAsGsgonu0wpASvnoCtn8EFYf0NFMQJI/0icA43eaOqtkf+hbeux7MIbowJHSz8CC1FbDlPVj/LyjdByExMPJWGH37iSLm9cB3L8LKP+i/+/Qn9bwNWrFSSqqcHo5UOfFoEiFAIHz7+j/RhufCn65JqHXpBarT7aXW5cXh9uL0pdW6vThcx6/Vur1oUmIyCIwGg28v9L1R35vq033nhgb/RzQpkVIfMy+lfl7/Dvo5SCReTWKv81BT58Fe58Fe56XGd17t9FDj0o/d3vaVt0KA1WTg8cuHcv2Y9pU9ShROkbJ33qHk/37HypEWvr85i9dnLDihY9GZk0Pe7XcgrFZdGDIyOtwOz9Gj2Fd/g/3rr6lZs0aPTWQ2EzJ6FKGTzyf0/Mltip/ip7YCvnkO1r6k/wc+53rInAORHRB/yVEGGxbAuleguhCiekP/6br/3OvWN80NXpdeWHhdvvP6zQWuGijdCwjImKjbNuQKCOq6sOFsfR8+uhP6XgB9p+ktgaRzwBTAuQclO+Ht2fr3Mfdd/bvoaoq3w/pX9O/D7YCUc+HcO2HolbqYt4DT7eVI7k7Cv3yYyJK1FISP5L3Eh9nmjKOwopaiilpqXN42m2HBzQTDdi4xrGegIZ8yGcYxGcExIvS9jOAoEZTKcI7JCMoJxWo2EWIxEWQyYDAIvJrEo+mFt8er4dUkbt+5Vzv9MlAICLWYsFlN2KxGQoPMhFqN2CwmQq16emiQ79hixGY1EWwxEmQyYjUbsJqMWE2GxscmAxaTfm6uKUJ89guYMg8Sh7fTRiUKbabqf//j8AMPkpeZwGOXVvD+lR/SJ6JPs3mdu/eQd/vtCKORtDfewNrn9GIaSSlxbt2K/euvsX+9CucOfcK3KT6e0PMnY5s8WY9NFBp6ajf21OmF9epndWEYehVUF0Pet/r1jElwzly9ALaeYtyjIzmw9h96YeGphd7nw7h7oP9FjWqEbaZ0P2z7N2xdBGUHwGiFgTN0geg3PbCFcVNqK+DF0RCRCj/8Uu8D6Cwq8nVhKM+F2a/ofvnOxOtBFm/DvvcbDLuWYCteh9dopTB1JntSr6fQNpBalweHy1dD9221bj3taHUdRZVOymrqQzhI5hhX8pjpHSzCw6KQG/g+8QYSokLpFRlMfHgQZoPw18Ilx2vlBreD+CPfkFT4PxKLv8bsseM22SiPHIbVU01QXSlmZykG6TnhNaQwImyxYIuH0Dhd3Mf+SG+dNoOUsrFo+ETCIBq3UupbEPUtm6bXAzI6TUq9E3/Zo3olataLMPyadt1KiUIbcWzYQN7td+Dum8Jtlx3iB6Pv4Z6se1r9TN3evRy67XYQgvQFr2Pt1++Un6vV1FDx8ceUv/2OHizNYCA4K0sPjzDlfKwDB7bvj0zTYPuHsPxJqMjTa7oXPgFJvhnXZQf1wnzLe1B+EEzBMPhyOGeO7hduqRDUNNj7P/j+H3Bgpe5OybwOxv6449wdUsLhjbo4bP9Q78AMjoIhV+oCkTq2faJzKvz3Z3oH6p0rIDkrsM9qDkcZvDsHCtbrHbZj7uzwR1Q63OSXOygqKcF9aC0hxdnEV2yhd10OwegBBQ5oibzrvYB/e8+nkhMrJFaTgRCLkRCLXuMNsRiJsVlIigwmOSKI5MhgkiKC6RUZTIKhDOvnj8CuTyExE674W/PfrbNK/xvb+THs+1JvnQRHwcDL9MpLnymNWyiapnfy1xwF+xGoOQL2o779ET29sgBKtkP8ELjsOUhvXzC5LqEiHz55APZ/BWkTdEGI6dvu2ylRaAN1+/aRe+NNGKIimXeDF1dYEB9e8SEW48lrpnX793PotttAk6S9/hpBA9oWCdSVn0/5O+9S8eGHaNXVBA0bRtSNNxI2dcrpx10/sBK++I3e0Zc4XPfn9p3WfF4p9YJny3t6AeyshNBEyLxWb0HUF/R11bDpHVj3T70WH5YMY34II28DW8zp2dsaXrf+PlsXQc6neoskIk23L/N6iOu4yKt+Dm+AVy6AMXfBpc90/P1bod7PfrTaybGyCtJX3k9S8Qq+SbqNRWG3cqS6jqO+zSslVpOBILORIHO928FIkC/t+DV9bxCCogoHrmO5JFZtZqgnh1GGPQwUBRiExIvgoLEPeaGZVMSMREsdS1h8OrYGBX6Ixeg7NhFsNmI0tKPCsnMJLH0Yao7BhPtgyi/BXQu7P9P7pPYv12vDtngYPBMGX6G70Vqo4beZXUvhs19AZT5k3aT/vwjk3+7pIqXulv3fr3VX7IWP6535p1khUqJwEtwlJeRePxfpcbP8senML/k3r138Gucmntvme9QdOEjebbch3W7SFrxO0MCBzeaTUuJYu5ayt97GvmIFGI2EX3QR0bfcTNA555x+s7N4O3z5W712FZEK034Nw69t+x+Rpw72LIMtC/WamubRRSUpS6+11VXp/uSxP9ZdGqf7n/RUqbPrQx23LtJHvwDMeQcGXdpxz9C88MpUfbTRfetOqU9DSonbK6l1ebG7GnQu+jsdPb4RJx7srgbHdR4qHG6OVNdxpNqJ063572nEy+9MrzHXtIL/mi7grZiHiIkIIS7UitkocLo1nG4vTo9GnW/vdNePWPHidHlIcBdwjmcLo7XtjDTsJlaWA+Ay2qiMyUJLHYut30RC+4wF6ym6J9tLbblecdn4pl7415bpf2/hKXqLdcgVvhZhB7vtXDXw9TN6J7g1TG89j7g58C3PU6X8kD6C6+DXuot31osQldEht1ai0Are6moO3XgT7oIC5Pzfcf3eX3JF3yt48rwnT/lertxcDt16G9Lp1FsMQ4b4r2m1tVQu+YTyt9+ibu8+jNHRRM65jqjrrz8hGFy7qCyAFU/B5nchKBwm/1zvCDQHtf+eNcf0UTdb3oPirbrrZtzdkNK5EVZbpLoE3r1Ob7XctfK0mtOaJqmsdVPmcGHOfpm0759gTdaf2BI5jfIaF/a6xqNYGo54cXq81Lr0grjW7W1zZ6XFZCCsvuPRaiI82ERCeBDxYVbiw4KID7cSF2bV00IthH73DGLVn/Shn9e83vokt8oCOLgKDnyt76sL9fTwFN1tkjoW0sbprpTO7CtpjgNf6wV0/GAYPAt6jeyceQ1HcuDTh/S+tdSxukspcVjgn3syNA2yX4Uvfqt/D9OfhFG3d6hoKVFoAc3lIv/Ou3Bs2ECvl/7O3ZUvUWAvYMmVS4iwtm/Eiysvj0O33obmcJD26quYoiIpe/ddKj74EK2yEuvgwUTffDPhl13aahTONuOshNXPwfcv6c3LsT+CiQ91/OQnTet+NSnQ+0r+eT6EJcIPvmhUy3W69Q5P3d3i9LtcjtpdlNe4KHO4KKvRj8sdLjQJcZTzlfVhNmv9uMU9DxAEm42EBumukmCzkSCLkWCzQT+36G6b+mv150FmI6FWI6FWMzarkbAg32gUi8l/bDa24/tc/y/478O6MN/w/vHfueYY5K4+LgJl+gJKhMRA78n6AIA+5+ujwtREsuNIqVekvvi1PrBg3N26K6uzWktNKTsAS36i/5Z9psIVLwRkvooShWaQmkbhwz+naulSkp/5I0sH1PDU90/xh0l/YGafmadll6uggLxbbsVTXq6vbiUEYdOnE33zTR27oIuU8NoMfTZt5hyY9lj3nvDUQXg1SXGVk/wyB4fLa7Ec+prLtt7HprDzecb2C47WuDhaXUe188TRKEJAdIiFaNvxLcpmIcZmISrEwkU5j5Jc9CX7rvmC0OSBRIVYCLZ0s7UD6ie5Rabpo7wOrtIniwFYwiDjPF0Eek/2tQS6oZh3Nxxlutt145sQ3gsu+aM+6a6zBFTT9L66r57U5/Nc/HvdpRWg5ytRaIaSp/9I2YIFxD/8MzxzL2fWx7PIjM3kn9P/2SGFtvvwYYp+/RuChg4lau71mJOTT/ueJ7B7Gbw3By77s975dJYgpaS0xkV+mYP88lryyxwUlDvIL6slv9xBYUXtCRN/HrB+yk/Fu7wRdhfrEucSF2ZttMX79tEhFkwt1dD3L4e3roLz58HUX3bCm54G9ZPc3E59El3vydB7CiSPAKOKWNNu8r6H/z6kj1Lqf7E+yKCD/PgtUrxd73TP+04X+Zl/DfjkTSUKTSh7621Kfv97om66iYTHHuWhlQ+x+vBqFl+xmNTwDpjI1RlICf+crHf83pfd+R2+7cTh8jRw6TTejlQ7KSivpaC8llp34wlNMTYLKdEhpEWHkBoVTGp0CKlRIfSKCiYh3EqI2QiLbtJHr9zyMfSedGqGuZ3wjwmAhLu/O72+mM7C7QQkmLtX6PYzHq9Hd8eueEoPWDjgYn2OTL8LOyZUh6bpMbN2faqPpivdqw9mmPFHfUJpJ7ROVEC8JoSMHUPUjTeS8Mt5rMxfyZd5X/LAyAfOHEEAyPlE7/y98qVuIwj2Og+HSmvIL3NwqNRBUaXTX9jXF/zNzV41GgQxNgtxYVYyYm1M6h9HanQwqVEhpEaHkBIVjM3ahj/PK/8Br0yDD26Hu74+tdrWmud1P/xNH50ZggBnjp1nGkaTPkx26FWw6k/6aLydH+vXEoZD/wt1kUgd0/b/e163L0jgp/roueoi3U2UMVHvBxx6Fdi63+JMPaalUE+Nu4ZZ/5lFmCWM9y9/v1usp9wmNC/84zx9+N6933fa6BEpJUer6zjkK/TzSms4VOYgr8xBXqmDUv/sVZ2wIJPfbRMXFkRcqFUfURPa2LUTFWJp31j35ji6WxeGuEFw+9JWQzD4Kd0Pfx8Pgy6Da1/vGDsUZw9S6tFr930Be7/UgyFqHj0Sbt8pLbciXDWw7ytdCPYs0weFmIKh3wX6kNsBF3dZaHHVUmiBFze9yBHHEZ49/9kzRxAAdiyGozkw+9WACIJXk+SXOdhVXM2ekmp2F1ez90g1eWWORuPnDQKSIoJJjwnhoqEJpEXbSI/RXTxpMSGEB3XBdxo3EK78O7x/CyybBzP/0np+KXV/rtGir2WgUDRFCH2oauIwmPhTvXA/sBL2fqHPB2raiohM16/t/0pfU6N+JvbgmfqIojNovYweJQo7ju3g3V3vct3A68iKz+pqc9qO16NHnYwfAkOvPnn+Vqiv+dcX/vX7PSXVjQr/tOgQBiSEMql/3PFCPzqElKgQLKZuOLJlyCw47wHdJdRrFIy4qeW8OxbrHcwz/qhCOyvaRlCE/jc2ZNaJrYhv/+abgNcLRt6ij2BKP++M7fw/M61uBx7NwxPfPUFMUAwPjHygq805NbYu0kMWz3n7lIcaVjrcrD1Yynf7S8kpqmJ3STUVDrf/emyolUGJYdwwJp2BiaEMTAynf3xo2/z53Y1pv4HCzfrkpISh+qicpjirYNkv9Rg8Z9HoLUUn0lwroqpIb7GeBfNBzsD/+e3jnZx3yCnL4c/n/5kwyylGBe1KvG74+o966OZBJ59L4XB5yM4tZ83+Y3y3v5TthyvRJASZDQxJCueSYYkMTAhjQGIYAxPCiAntgMl03QWjCa55TZ/YtuhmveO5aYybFU+BvQSuf/eMrckpuhlBEV0b6r2D6TH/KyalTKLaVc309OldbcqpseltfaGXS59tthbi8mhsKajg232lrNl/jE155bi9ErNRMCI1ivun9ee8frFkpUZ2T7dPR2OLhTlv6RP8PrxDH1lU3wdTtEWfLDT6DkgZ1bV2KhTdlICOPhJCzACeB4zAv6SUTze5nga8AUT68syTUi5t7Z6BXHmt2+F2wt9GQniyHs5B6IuF5BRV8e3+Y6zZV8r63DIcLi9CwLDkCCb0jWFCv1jOzYgixNJjNP9ENr6pBxab+JC+mLzmhVen6yEy7suG4MiutvCswONyUbR3F4d37QQgMimZqMRkopKSsQR3z85VqWk4qiqpqSinprwMe3mZvvedO6oqMRgMGM1mjGYzJrPFtzf70iy+NJP/msFoQvN68Ho8aB7f3uvF63Gjeb0Nrh1PQwiMJhNGk1nfmxvsjSb/8xvmSew/kKjE9k2K7fLRR0IIIzAfmA4UAOuFEEuklDsbZPsV8L6U8h9CiCHAUiAjUDadcWx8A6oOc3DiM3z1zUHWHijl+4Nl/lAOfeNsXDMqhQl9YxnXJ5rIkE5cjKa7M/IWPRT2N8/pwdbsR/Tzq14+KwVBSonbWYvTbqe2uopaezVOezXO6mpczloi4hOI7pVKVFIvTOb2jxBz1zkp2rub/J3bKNi5naJ9u/G63XortkkFMyQikqikZCITfUKR3IuoxGQiE5MwW09/voWUEo/bRV1NDXWOGlwOB3U1dupqHdQ5anzpDhxVFdSUl/lFoKayAqlpJ9wvyBaKLSqakHDdFeSqdeCt8uBxu/C6XXjdbjxut753uZDyxHs0RBgMGI0mDCYjBpMZo9GIwWTS04x669XrceP1ePC6fXuPfv+WuPCH97ZbFNpKIKuSY4B9UsoDAEKIhcAsoKEoSCDcdxwBFAbQnjMCTZPkFFexfu9hrlz1NHsZwrUfAeTQO9bGzMwkxvWJYVyfGBLC1USmVrnkGSjeBovv1jvoMybpCwOdAUgpqaup0QuyinJqKstx+I5rq6uorfYV+vZqaqurcNrtaN4T4z41RRgMRCYkEt0rjZheKcSkpBGTkkZ0cgrmoBP/ntxOJ4f35FCwczsFOdso2rsHzetBCAPxvfuSdfFMUocMo9fAoRjNJiqKiygvLqS8qJAK3/7gpmx2VFY0um9odAwR8YkYTSbwrbiGlEj0pdd0D0bTdInm9TYq8E/2zkIYCA4PxxYZhS0qmti0DEKjov3ntshoQqOiCImMwmw5tf41zev1CYULzev1FfjHBUC0M/6U9L1nQ8HQPB48brdfsAJJIEWhF5Df4LwAGNskz+PA/4QQ9wM24MIA2nPqfPsiFG7Sp6H3nRaQ+QGaJtlVXM3aA6V8d6CUdQfLqKx1c6fxUyLNZWzo8yR/HT6CsX2iSYpQoQ1OCZMVrntT73h2VuphkgM0OsTrcXMs7xAetxupedG8GlLT9GOp+c69SE1D0zSk14umabjr6qip8BX4leV+EXBUlOP1nFjgGU0mgsMjCA4NIyg0jOheKQSFhvnPg8LCGp0Hh4VjslipPFJM6eF8ygryKD2cT2lBPgc3rdfdGD7CYuN0keiVgsFkpiBnOyX796J5vQiDgYQ+/Rh12SxShgyj18AhWENsJ9gXl96buPQTl6itczh0kSgupKJI31ceKcHtqkMgQAjfTyMQBoFBGBql6ccCg9FIVFIvrCEhWENsWEJsWENsWG02PS24/lg/NwcFB2aZTMBgNGIwGpsV09NB+N1KXeP+DVifghDiGmCGlPKHvvObgbFSyvsa5HnIZ8OfhRDjgVeBYbJJu0wIcRdwF0BaWtqoQ4cOBcTmE3hxDBzbrR+HJevikHUjxJ768psNyS9zsGbfMb7Zd4xv95f617RNiw5hfJ8YJqZZuXTFDIxJ58At/znNl1BwdA/Yi/UAch2E1DSO5uWSt20zh7ZvoSBnO566uvbdTAhCwiOwRUQSEhml12J9W0hkFKG+vS0yCmuIrcMKOa/HQ0VJEWUF+T6hyKPscAFlhQVoXg8JffuTOngYqUOGkzxwcLftI1C0jS7vUwAOAw0DC6X40hryA2AGgJTyOyFEEBALHGmYSUr5MvAy6B3NgTL4BOwlum+67wX64tlr/qr7qFPHwYgb9dglbVj0vsLh4tv9pXyz7xhr9h3jUKkDgPgwK1MGxnFe31jG9Y2hV6SvJbDqWX1Fqmm/CuDLnXl4PR72b/ieQ1s26bXaXqlEp6QSmZDUeq0qbkCHLN9ZeaSYQ9s2k7dtC3nbt1BbXQVAdK9Uhk2ZTsrgYViDgxEGIwajAWEw6McGAwafO0EYDBgapJusVkLCI/w+5s7EaDIR0yuVmF6p9G+QLjUNr9d7Wn0PijOXQIrCeqC/EKI3uhhcD9zQJE8ecAGwQAgxGAgCjgbQprbjduqLgkekwdAr9a2qCLYu1NcsXnI/fPaIvjLZiBv1GYy+GpzT7WXDoXK/CGw7XImUEGo1Ma5PNLdNyGBiv1j6xYeeWOurrYBvX9BX2uouq511MVXHjrJt+edsW/4/asrLsAQH46qt9V+vdylE90rxCUUaMb1SiUrudcp+4oY4qirJ37HVJwSbqTxSAkBoVDS9R4wmfXgWqcMyCYvufkHNTgdhMGBS6zH0WAImClJKjxDiPuBz9OGmr0kpdwghngSypZRLgJ8Brwghfore6Xyb7C4R+mp8jZXQ+ONp4Un6DMbzHoT8dbD5bdi+GLa8C1EZHO03m6cLR/LpISN1Hg2TQTAyLYoHLxjAxP4xZKZEnnzlrbV/1/3fUx8N2KudCUhN49DWTWz+4jMObFiHRNI7axTn3HkfvUeMwuNy6a4On9uj9HABx/Jy2bdu7fFRIUIQEZ9ATK9UbFHRaJ4GQwO9TYYNNrrmxeOq84uANcRGypDhjLrsStKGZxGdnBIwP7VC0dX0uCipbSZ/Pbx6ob784YCLW87nqsG17WOKvv4X6VUb0BDsjLoQ+/ifMeyccwk9lXARjjL4ayb0napPwDoDcDud2CvKsJeVYi8vQwih19qTerWrA85RVcn2FV+w9atlVJYUExwewfCp08m8cAYR8Ykn/bzH7aa86HAjsSgryMNRVYnRZMZgMvqGCeodeQajUU83GvXzBkMHY1LSSB+eRUKffl3i3lEoOpLu0KdwZmPXa4mNWgrNsCrXwa++SiKv7GfcNdzAT6PWMGzTa/DZV1A4F87/RdtXcVrzPLjs3aaVUF16jOrSo9jLy7CXlVFTXuov/Osn/NQ5alr8fFhMHFHJvYhOTiE6uRdRySlEJ6cQFh3TaLielJLDu3ey9YvP2LP2G7weDymDhzFxzs30GzPhlHzbJrOZuLQM4tIyTufVFWcQXreG0+GmzuHxbe5Ge6lJTFYjFqsRk9WI2XJ8b7bqm8lixGw1YLIaMRoNSCnxejS8bg2P+8S9x+3Vj12aP5/Xo2+aVx4/9ki8Xt/eozU6NhgFliCTvgUbsQTXH5uwBDU8N2IJMmG2GhEdFW6+FZQotIRfFJqvnR6z1/F/n+7k482F9Im18d6d4xjfNwa4BCY/AN/8RV9wfesivbN60sOtLwBjPwLrXoZhsyF+cMe/zymQv2Mr337wLgU7tzdKNxiN2KKiCY2KJqZXKmnDziE0OobQqGhCo2IIjY5G83opKzxMeWEBZUWHKTtcwM5VXzXqAzBZrXprIjmF8Lh4Dm7K5lheLpbgEDIvvITMC2cQm5re2a+tCDCaV6O22k1NZR2OSheOahde9/FCVPMeL0A1r4bXK9GapHvc2vFCv0bfe9ytTyI7VQxGgebtAA+KAKPJ4NsEBqO+N5oMGIwGNE3iqvXgcnpwO09ciKq5+50/dyDDJgd22U4lCi1hLwEE2OIaJWua5N8b8nlq6S4cLg8/uaA/90zpS5C5gXshNA5mPKWv5LTqWT3kwqZ34Nwf6H0SzbU+vvmrHod9StetE9xQDGxR0Uy64TZi09L1Aj8qmuCw8DZNyGk6Tl1KSU1FuS4UhQV+0Sjet5vd360mPqMP0++6n8Hnnd/hY757Mm6XF6fdjdPuxl3nwV2n4a7z+jePy9vovGG65pWYg47XpBtvpuPH9XksRtwur17YV9VRU+nCUeXCUek7rqyj1u7Wew5PgsEoMJgMGBvujXphajQbsIaYiEwIwRpiwhpixhpiIqjBsX9vM2ENNiGEwO1q+M7aCe/e8Nzj0jCYBCazAZPZiNGsF+wmy/G9yWzAaDbqe59d/sLfJwSGU6jVS03iqvP6RcJV6/XtfZtTP49LC3wwTyUKLWEv0YOrNYikue9INY9+tJ11uWWMyYjmqauH0S++lR8pPBlmPgfn/QS+/pO+BuyGBfpSfBN+AiHRer6qQr1Vcc7c054DcapIKcnfsY3vPniXghxdDKbe9iOGX3DRaY3caYgQwteaiCZ1aGaja5rmxdBJq8gFEk2TuBwef2FiONmAgjaih3LQcDuPF1x1Dje1dje11W5/oV9rd/n2x489rjbUoAV+N4rJeryANxgFjkpXY8FweppGsmgRg0EQHG7BFmEhLDqIhIxwQiIs2MIthERYCYmwEBJmweR7ltFkwGASGAwiIJ349W6a7oowCKzBuoh1NV1vQXelugRCEwB9iOnfV+7nHyv3EWIx8cfZw7l2VGrbawJRGXDlfJj4IKx8Wm8VrH8Vxt8H4+6G1X/WFws//xeBepsT0MVgK9/++10O79pBaFQ0027/EcOnXYzJ0nkxlM4EQfC4vdRU1FFTUYe9vA6777im4XGlC6kdLzENBqHXLC1GzJbjtUqTxYDJUn9sRAia1FY1vVbv0vxpJ6tdm4OMBIeaCQq1EBJuISbZRlComaBQM8FhFoJCzJiDG/vQ60XAZDa0uRCu97PrAtGkheH0YrIaCAm3YouwEGQzd4r/W9HxKFFoCXsJhMbz3f5SHlu8jQPHapiVlcyvLhtCXFg7a9Cx/eGaV2HSQ3pc/5VPwff/gDo7jLi57R3Sp4GUkrztW/jug/e6VAy6A1KT1Nrd/gK/plIv5B0VddgrXLoIVDipqzkx3ITZasQWacUWaaXXwChskVZCwixoXonHrbsgTti7NLxuL3UODw63F7dLAykbdHQaCfbVns1BzRTivnOrzURwqJngUL3wNZo7Z06BEAKT2YjJbCQ4tFMeqegClCi0hP0IO9xJzH1lLanRwbxxxxjOHxB38s+1hYShcP07cHgjrPi9vp/8cMfcuwWOi8G7HN61k9DoGKbd8WOGT73ojBIDPVCcRx/94dHwuhuO6mhw7kurP3fVek4s/CtdJ3YoCggJs2CLtBIWE0RS3wh/4R8aacUWpe8t3aCZr1AEAvWX3RxSIu0lrC43cvk5yTwzO5NgSwDcHL1Gwk0f6iGHAzQZqqK4iP0bvmf3t6sp2rf7jBEDKSX28jrKimooL6ppsHfgqj15NNDmsAQ1qN0PiMIWYfWdW/yFfnC4BWMH9QcoFGciShSao7Ycobk5RiS/umxwYAShIR0oCFLTKN6/l33Za9mf/T2lBXkAxKam62Iw7eJuFdNG0yTVpbWUFTkaFf7lxQ7cdceH6QWHmYlOsjFgTAKR8SG6v94/4sOgd1Y2OK8fCVI/MsRsNXbrjkaFortw0v8lQojLgf82jVx6NnOkMJd4oH+fvmfEmgVuVx3527eyL3stBzaso6aiHGEwkDJ4GMOnXUzf0WOJTDj5bOCOQkp9/LWjytXsVtvkWGvQQWuLtBKVGMLgCUlEJdmITrIRlRRCcGj3bdUoFGcTbak6zQH+KoT4ED1+0a4A29TlLFu7lVuAqaOHdbUpLeKoquTgpmz2rV9L7taNeOrqMAcF0ztrFH1Hj6X3iNEEh3bMmOb6Qr622o2zxk1ttcs3JLLBMMhqN067i9pqN44qF17PiXWI+mGKIb4tNiWU4HALEXHBvsLf1i2G5CkUPZmT/g+UUt4khAgH5qJHM5XA68B7UsrqQBvY2RypdrJ9924wQnxSRleb0wipaRzcvIFNyz7h0NbNSKkRGh3D0MkX0G/0WFKGZp6Wa8hV6+FofjVH86o5cqiasqIaf8Hf0gxPk8Wgj4IJNRMcZiYqyeYv9EPCLX4RsIVbsYaY1DBFhaKb06ZqmZSySgjxARAMPAhcBfxcCPGClPJvAbSv03l19UGiZLl+cpK4R83h9Xj02Pkd2E9Q53CwY+UXbPr8UyqKiwiNjmHsVdfS79zxxPfu265nuZwejuXrhf+RQ7oQVBxx+MfEh0ZZiUkJJSE9jKAwi28IpPn4cZguBOZA97coFIpOpS19ClcAtwP9gDeBMVLKI0KIEPT1ls8aUSivcfHW2kPMj/OCPaRNC+g0ZO/33/LZ/OcICg2j94hR9B5xLmnDMrEEtW8ZzbLCw2z+/FO2r/wSt7OW5AGDOW/OzfQfM+GUlupz2t2UFto5mlft38pLGgtAXFoYA8cmEJcWTlxaGCHhyoevUPRE2lKyzAb+IqVc1TBRSukQQvwgMGZ1Da+vOYjD5WV0TB0Qf0qjgrZ+uYwv//V3Evr0JTQ6lpxvvmbrl8swmkykDBlOnxGj6T1iNFFJrQezkppG7tZNbPpsCQc3b8BoMjFwwmRGzLicxL79W/1sncNNWaE+gqd+X1pYQ22Vy5/HFmklPj2M/ucmEJcWRnx6uBIAhULhpy2i8DhQVH8ihAgGEqSUuVLKrwJlWGdT5XTz+re5XDIskTBPWYvRUZsipeT7jxax5v236T1iNJf/dB5maxBej5vDu3ZyYON6Dm7KZsUbr7DijVeITEyi94jR9BlxLimDh/nnCrhqHexYtZxNyz6lvLAAW2QUE669kcwLZ2CLjGr0TLfLS+lhu17wNxCBmorjawSbrEaik2ykD4shOslGdLKNuFTVAlAoFK3TFlH4NzChwbnXl3ZuQCzqIt78Npdqp4d7p/aDxSUQN+ikn5Gaxoo3XmHTsk8YMmkqF/34Ab9bx2gykzbsHNKGncOUW35IRUkxBzdnc3BTNtu+/JxNn32CyWolbdg5hEXHkPPN17hqHST27c+l9/2MAeMnYjTpncZul5fi/ZUc3lNO4Z4KSnKr/B2/JrOBqCQbKQOjiE7WC//oJBth0UGqU1ehUJwybREFk5TS73+QUrqEEGdVdbOmzsOr3xxk2qB4hvWK0OMe9T6/1c94PW4+m/8Xdn+7ilEzr+L8G29vNax0ZEIiIy6eyYiLZ+Kuc5K/cxsHN2VzYGM2uZs3MGDcREZecgVJ/Qfidnkp3FdJ4Z4KDu8pp+SgLgLCIIhPDyPrwlQSekcQnWwjPDb4lEL0KhQKRWu0RRSOCiGu8K2pjBBiFnAssGZ1Lu9+n0e5w8190/qB26mvkRyW0GJ+l7OWJX9+ikNbNzH5xts594rZp/Q8szWIPiPOpc+Ic5l2u6Suto6jeQ7ycir47uMNjUQgLk0XgeQBUST1jVCzchUKRUBpSwnzY+AdIcSLgADygVsCalUn4nR7eXn1ASb2i2VkWhSUH9IvhDYvCo6qShb/8QlKDuzj4h8/wLCp09v1XM2rkbezjJw1ReRuP4bmkQgBcenhnHNBKr3qRUBN5lIoFJ1IWyav7QfGCSFCfef2gFvVibyfnc/R6jr+NneEnmA/ou+b6WiuOnqED576DdVHjzDr4cfoO2rsKT+v8mgtOd8Wsuu7Ymoq6ggKNTNsci9SB0eT3C9SiYBCoehS2lQCCSEuA4YCQfUTpaSUTwbQrk7B5dF4aeV+zs2IYmxv3ypo9mJ932Ti2rH8Q3z41G9wO53M/tX/kTJoaJuf43F5ObD5KDvXFHJ4dwVCQOqQGCZd15+MzFiMJhWVU6FQdA/aMnntJSAEmAr8C7gGWBdguzqFjzYWUFjp5A+zM4/PCraX6PsG7qPDu3P4zx+fwGixMOeJPxKXltGm+x/NqyZnTSF71pdQ5/AQFhPE2Ct6M2h8EqFR3T/QnkKh6Hm0paUwQUqZKYTYKqV8QgjxZ+CzQBsWaDxejb+v3E9mSgST+8cev2A/Agiw6QvqHNi0nk+ee5qwmBhmP/p/RMS33AEN4Kxxs3d9CTvXFHIs347RZKDPiDgGn5dEyoAoNUxUoVB0a9oiCk7f3iGESAZKgaS23FwIMQN4HjAC/5JSPt3k+l/QWyCgt0bipZSRbbn36fLJ1kLyyhz86rJRjWMHVReDLRaMJnZ8/RWfv/Q88Rl9uHre44REtG7annXFrHxnN+46LzEpoUyaM4ABYxIIsnWf9QsUCoWiNdoiCp8IISKBPwEb0SPmvHKyDwkhjMB8YDpQAKwXQiyRUu6szyOl/GmD/PcDI07J+naiaZIXl+9jUGIYFw5uUvO3H0HaEvl20Vus/WgRacPOYdbDj2EJDmnxfh63l2/e38uO1YUk9Y1g4nX9iUsL69CgeAqFQtEZtCoKQggD8JWUsgL4UAjxKRAkpaxsw73HAPuklAd891oIzEIPotccc4HfttXw02HZjmL2H63hxRtGnDDxy11ZzLI90ewpWsTwaRdxwQ/u9s8sbo6KIw4+f2U7x/LtjLgojbGz+qjlHBUKxRlLq6IgpdSEEPPx1eCllHVAXWufaUAv9DkN9RQAzY7hFEKkA72B5S1cvwu4CyAtLa2Nj28eKSV/W76PPnE2LhnW2AtmLy/j4/Umims0zr/pDkbNvKrV2v6+DUdY/lYOBoPgsnsyyciMbTGvQqFQnAm0pUr7lRBitgisL+R64AMppbe5i1LKl6WUo6WUo+Pi4k7rQV/lHCGnqIp7p/TD2KCVcCT3AO88+hCltWZmXdSP0Zdf3aIgeD0aqxft4fNXthOVaOO6x85VgqBQKM4K2tKn8CPgIcAjhHCiz2qWUsrwk3zuMJDa4DzFl9Yc1wP3tsGW00JKyd9W7CM1OpgrspL96fuyv2fpC3/CGhLC9elbiB96RYv3qDpWy+evbOfIoWrOmZbK+Kv7qnkGCoXirKEtM5rbu9DveqC/EKI3uhhcD9zQNJMQYhAQBXzXzue0mW/2HWNLfgVPXTUcs9GAlJINny7m63deJ6F3P668fQ6h737cYoiLg1uO8tUbOUhNMuOuYfQdeeorsykUCkV3pi2T1yY3l9500Z1mrnuEEPcBn6MPSX1NSrlDCPEkkF0fYA9dLBZKKZtfBLgD+dvyfSRFBDF7VC+8HjdfvfoPti3/HwPGnseMe3+KueBbPWMTUfB6Nb7/zwE2fZFHbGooM+4aRkRcy6ORFAqF4kylLe6jnzc4DkIfVbQBmHayD0oplwJLm6T9psn5422w4bT5/kAp6w6W8fjlQ9CcDj587g/k79jK2KvmcN51N+phr+vjHoUdj3tkL3fy+Ss7KD5QybDJvTjv2n6YzGpdYoVCcXbSFvfR5Q3PhRCpwF8DZVCg2HfUTkpUMDPSTLz3q4epPFLCjHt+ytDzLzieqbpx3KOCXWV8/soOvB6Ni34wlP7ntj6bWaFQKM502hOSswAY3NGGBJobx6YzPriCD3/7c4TBwLW/+f2JQe3sR8AcApZQ3C4v/3t1B8FhZi758XCiEm1dY7hCoVB0Im3pU/gb+ixm0IewZqHPbD6j2Ll6BZ//469EJiZz1SO/JTKhmTWY7SV6f4IQ5KwppLbazYy7lCAoFIqeQ1taCtkNjj3Ae1LKNQGyJ2CEx8SRcc5ILrnvZwTZQpvP5BMFr0dj0//ySOoXQXL/yE61U6FQKLqStojCB4CzfmKZEMIohAiRUjoCa1rHkjJkGClDhrWeyV4C8YPZs64Ye3kd598wsHOMUygUim5Cm2Y0A8ENzoOBLwNjThdTXYJmS2Dj53nEpISSPiymqy1SKBSKTqUtohDUcAlO3/HZN0jfXQt1lRwoH0hFiYNRM9JVlFOFQtHjaIv7qEYIMVJKuRFACDEKqA2sWV2A/QhSwoacFCLig9VsZcVZg9vtpqCgAKfTefLMijOeoKAgUlJSMJvbt45LW0ThQeDfQohC9LhHicCcdj2tO2MvIc81gmPlFqbenH5CSG2F4kyloKCAsLAwMjIyVOv3LEdKSWlpKQUFBfTu3btd92jL5LX1vvhE9b2uu6WU7nY9rTtjL2GDfTah4QYGjm1muKpCcYbidDqVIPQQhBDExMRw9OjRdt/jpH0KQoh7AZuUcruUcjsQKoS4p91P7KYU7q2gyD2UrKlxKuqp4qxDCULP4XR/67aUfnf6Vl4DQEpZDtx5Wk/thmzYGEKQoZIhU/t3tSkKhULRZbRFFIwNF9jxrb1sCZxJnc/R/GryiqM4J3IF5qCz6tUUim6BEIKbbrrJf+7xeIiLi2PmzJmndJ+MjAyOHTvWrjyPPfYYqamphIY2P3n19ddfJysri6ysLCwWC8OHDycrK4t58+a1ybbf/OY3fPnlmT9avy0dzcuARUKIf/rOfwR8FjiTOp+Nyw5hNroYntzS8tEKheJ0sNlsbN++ndraWoKDg/niiy/o1atXp9pw+eWXc99999G/f/PegNtvv53bb78d0IVlxYoVxMY2XlHR6/ViNDYfJfnJJ5/sWIO7iLaIwiPo6yP/2He+FX0E0llBRYmDfRuPMDJ+HdbIiK42R6EIKE98soOdhVUdes8hyeH89vKhJ8136aWX8t///pdrrrmG9957j7lz57J69WoAysrKuOOOOzhw4AAhISG8/PLLZGZmUlpayty5czl8+DDjx4+n4bIrb7/9Ni+88AIul4uxY8fy97//vcUCG2DcuHHter/Q0FB+9KMf8eWXXzJ//nyWL1/OJ598Qm1tLRMmTOCf//wnQghuu+02Zs6cyTXXXENGRga33norn3zyCW63m3//+98MGjSoXc/vbE7qPpJSasD3QC76WgrTgJzAmtV5bPz8EEaTgXNCPm1xxTWFQnH6XH/99SxcuBCn08nWrVsZO3as/9pvf/tbRowYwdatW3nqqae45ZZbAHjiiSeYOHEiO3bs4KqrriIvLw+AnJwcFi1axJo1a9i8eTNGo5F33nknIHbX1NQwduxYtmzZwsSJE7nvvvtYv369v+Xz6aefNvu52NhYNm7cyN13382zzz4bENsCQYstBSHEAGCubzsGLAKQUk7tHNMCT3WZk91rixk6KZmQvfsh9LKuNkmhCChtqdEHiszMTHJzc3nvvfe49NJLG1375ptv+PDDDwGYNm0apaWlVFVVsWrVKj766CMALrvsMqKiogD46quv2LBhA+eeey4AtbW1xMcHZsKp0Whk9uzZ/vMVK1bwzDPP4HA4KCsrY+jQoVx++eUnfO7qq68GYNSoUf53OBNozX20C1gNzJRS7gMQQvy0U6zqJDZ/odc6siaGwW6PaikoFAHmiiuu4OGHH2blypWUlpa2+z5SSm699Vb+8Ic/dKB1zRMUFOR3SzmdTu655x6ys7NJTU3l8ccfb3GmuNVqBXRR8Xg8Abezo2jNfXQ1UASsEEK8IoS4AH1G81mBo8rFzm8KGTA2gXBLuZ4YpkRBoQgkd9xxB7/97W8ZPnx4o/RJkyb53T8rV64kNjaW8PBwJk+ezLvvvgvAZ599Rnm5/n/1ggsu4IMPPuDIEX0J3bKyMg4dOhRw++sFIDY2FrvdzgcffBDwZ3Y2LYqClPI/UsrrgUHACvRwF/FCiH8IIS7qJPsCxtbl+Xg8GiMvTtdDZoNqKSgUASYlJYWf/OQnJ6Q//vjjbNiwgczMTObNm8cbb7wB6H0Nq1atYujQoXz00UekpaUBMGTIEH73u99x0UUXkZmZyfTp0ykqKmr12b/4xS9ISUnB4XCQkpLC448/fsr2R0ZGcueddzJs2DAuvvhiv/vqbEI07M0/aWYhooBrgTlSygtOlj8QjB49WmZnZ588YyvU1Xp489FvSR0cxYy7hsPm9+A/P4b7N0JM3w6yVKHoHuTk5DB48Bm3gq7iNGjuNxdCbJBSjj7ZZ08pnoOUslxK+XJXCUJHsf3rAly1HkbNyNATVEtBoVAogFMUhbMBt8vLlq/ySRsSTVxamJ5oLwGzDawtLNOpUCgUPYSAioIQYoYQYrcQYp8Qotm54kKI64QQO4UQO4QQ7wbSHoCcNUXUVrsZdUn68UR7iepkVigUCto2o7ld+GIkzQemAwXAeiHEEinlzgZ5+gO/BM6TUpYLIQK6so3Xo7Hpf4dI6htBUr/I4xfsR5TrSKFQKAhsS2EMsE9KeUBK6QIWArOa5LkTmO+LvIqU8kgA7WHPuhLs5XWMbLrUZnUxhKqV1hQKhSKQotALyG9wXuBLa8gAYIAQYo0QYq0QYkZzNxJC3CWEyBZCZLd38QhNk2z8/BAxKaGkD4tpfNF+BELPmnBOCoVC0W66uqPZBPQHpqCH03hFCBHZNJNvxNNoKeXouLi4dj3owKajVJQ4GNW0leCuhbpK1VJQKAJIV4XOvuOOO4iPj2fYsGHN5v36668ZP358ozSPx0NCQgKFhYXNfmblypV+u5csWcLTTz/dbL6WQnTXU1FRwd///nf/eWFhIddcc02rn+kMAikKh4HUBucpvrSGFABLpJRuKeVBYA+6SHQ4BqMgbUg0fUc2Kfzrh6OGqZaCQhEoGobOBjotdPZtt93GsmXLWrw+adIkCgoKGs2G/vLLLxk6dCjJycknvf8VV1zR5vUWmtJUFJKTk7vFDOmAdTQD64H+Qoje6GJwPXBDkzz/QW8hvC6EiEV3Jx0IhDF9suLok9VMK8Pu68ZQHc2KnsBn86B4W8feM3E4XNJ8bbkhXRE6e/LkyeTm5rZok8Fg4LrrrmPhwoU88sgjACxcuJC5c+eybt06HnjgAZxOJ8HBwbz++usMHDiw0ecXLFhAdnY2L774IgcPHuSGG27Abrcza9bx7tP68/LyctxuN7/73e+YNWsW8+bNY//+/WRlZTF9+nTuvfdeZs6cyfbt23E6ndx9991kZ2djMpl47rnnmDp1KgsWLGDJkiU4HA7279/PVVddxTPPPHPS7/5UCFhLQUrpAe4DPkcPtf2+lHKHEOJJIcQVvmyfA6VCiJ3ooTR+LqVsf5Ss9lBdrO+V+0ihCCjdNXT23LlzWbhwIQB1dXUsXbqU2bNnM2jQIFavXs2mTZt48sknefTRR1u9zwMPPMDdd9/Ntm3bSEpK8qcHBQWxePFiNm7cyIoVK/jZz36GlJKnn36avn37snnzZv70pz81utf8+fMRQrBt2zbee+89br31Vn/cpc2bN7No0SK2bdvGokWLyM/PpyMJZEsBKeVSYGmTtN80OJbAQ76ta/DPZlbuI0UPoA01+kDRXUNnjx49Grvdzu7du8nJyWHs2LFER0eTn5/Prbfeyt69exFC4Ha7W73PmjVr/O9w8803+1seUkoeffRRVq1ahcFg4PDhw5SUlLR6r2+++Yb7778fgEGDBpGens6ePXsAPRhgRIS+INiQIUM4dOgQqampLd7rVAmoKJwR2EtAGMAWe/K8CoXitOiuobPrWws5OTnMnTsXgF//+tdMnTqVxYsXk5uby5QpU056n0aDWHy88847HD16lA0bNmA2m8nIyGgx3HZbqA/JDYEJy93Vo4+6HnsJ2OLA0PIyfgqFomPorqGz586dy9tvv83y5cv9/QGVlZX+zvAFCxac9B7nnXee3w3V0JVVWVlJfHw8ZrOZFStW+O0MCwujurq62Xs1/D727NlDXl7eCf0ZgUKJgv2I6k9QKDqJzg6dPXfuXMaPH8/u3btJSUnh1VdfbdauwYMHY7PZmDZtGjabDdBDbf/yl79kxIgRbaqNP//888yfP5/hw4dz+PDxgZY33ngj2dnZDB8+nDfffNO/VnNMTAznnXcew4YN4+c//3mje91zzz1omsbw4cOZM2cOCxYsaNRCCCSnFDq7O9ARobMb8c/z9ZbCTV0/FEyhCAQqdHbPo9NCZ5+VqLhHCoVC4adni4KmQY1yHykUCkU9PVsUastA86jZzAqFQuGjZ4uCmrimUCgUjejZoqAmrikUCkUjergo1Mc9Ui0FhUKhgB4vCvXuIzX6SKEIJF0ROjs/P5+pU6cyZMgQhg4dyvPPP39C3t///vdkZWWRlZWF0Wj0H7/wwgttsueHP/whO3fuPHnGM4ieHebCfgQsoWBtPe65QqE4PRqGzg4ODu6U0Nkmk4k///nPjBw5kurqakaNGsX06dMZMmSIP89jjz3GY489BujrH2zevLnRPaSUSCkxGJqvP//rX/8KmP1dRc8WBbUMp6KH8cd1f2RX2a4Oveeg6EE8MuaRk+br7NDZSUlJ/milYWFhDB48mMOHDzcShebIzc3l4osvZuzYsWzYsIGlS5fy9NNPs379empra7nmmmt44oknAJgyZQrPPvsso0ePJjQ0lAceeIBPP/2U4OBgPv74YxISzjwvRA93H6llOBWKzqIrQ2fn5uayadOmRs9sjb1793LPPfewY8cO0tPT+f3vf092djZbt27l66+/ZuvWrSd8pqamhnHjxrFlyxYmT57MK6+8cipfT7ehZ7cU7CWQMLSrrVAoOo221OgDRVeFzrbb7cyePZu//vWvhIeHt8nW9PR0xo0b5z9///33efnll/F4PBQVFbFz504yMzMbfcZisfj7SEaNGsUXX3zRpmd1N5Qo9Lugq61QKHoMnR062+12M3v2bG688UauvvrqNt+/PigewMGDB3n22WdZv349UVFR3Hbbbc2Gvjabzf7Q2YEIad1Z9Fz3kcsBdVWqT0Gh6EQ6M3S2lJIf/OAHDB48mIceav86XlVVVdhsNiIiIigpKeGzzz5r973OBHpuS8E/ce3M6whSKM5UWgudfccdd5CZmUlISEij0Nlz585l6NChTJgwodnQ2ZqmYTabmT9/Punp6f57rlmzhrfeeovhw4eTlZUFwFNPPXWC6+pknHPOOYwYMYJBgwaRmprKeeed1863PzPouaGz876H1y6CGz+E/hee/v0Uim6KCp3d81Chs9uDv6Wg3EcKhUJRjxIFFSFVoVAo/PRsURAGCInpaksUCoWi29BzRaG6WF+G02A8eV6FQqHoIfRcUVDLcCoUCsUJBFQUhBAzhBC7hRD7hBDzmrl+mxDiqBBis2/7YSDtaYS9WImCQqFQNCFgoiCEMALzgUuAIcBcIURzkagWSSmzfFvnhRy0H4EwJQoKRWfQXUNnf/3114wfP75RmsfjISEhgcLCwmbvv3LlSr/dS5Ys4emnn242X2ho69GXKyoq+Pvf/+4/Lyws5Jprrmn1M51BIFsKY4B9UsoDUkoXsBCYFcDntR1NU+4jhaITaRg6G+jU0Nk7d+5k7dq1zJ8//4S1DyZNmkRBQUGj2dBffvklQ4cOJTk5+aTPuOKKK5g37wQnSJtoKgrJycl88MEH7bpXRxLIGc29gPwG5wVAcyEKZwshJgN7gJ9KKfObZhBC3AXcBfhnNJ4WjlKQXhUhVdHjKH7qKepyOjZ0tnXwIBIfffSk+bpj6GyDwcB1113HwoULeeQRPVjgwoULmTt3LuvWreOBBx7A6XQSHBzM66+/zsCBAxu904IFC8jOzubFF1/k4MGD3HDDDdjtdmbNOl7/rT8vLy/H7Xbzu9/9jlmzZjFv3jz2799PVlYW06dP595772XmzJls374dp9PJ3XffTXZ2NiaTieeee46pU6eyYMEClixZgsPhYP/+/Vx11VU888wz7fjVWqarO5o/ATKklJnAF8AbzWWSUr4spRwtpRwdFxd3+k9VE9cUik6nu4bOnjt3LgsXLgSgrq6OpUuXMnv2bAYNGsTq1avZtGkTTz75JI+eRPgeeOAB7r77brZt2+YXI4CgoCAWL17Mxo0bWbFiBT/72c+QUvL000/Tt29fNm/ezJ/+9KdG95o/fz5CCLZt28Z7773Hrbfe6g/Ct3nzZhYtWsS2bdtYtGgR+fkn1KNPi0C2FA4DqQ3OU3xpfqSUDcMk/gvoWMlrCbUMp6KH0pYafaDorqGzR48ejd1uZ/fu3eTk5DB27Fiio6PJz8/n1ltvZe/evQghcLvdrb7fmjVr/O9w8803+1seUkoeffRRVq1ahcFg4PDhw5SUlLR6r2+++Yb7778fgEGDBpGens6ePXsAPRhgREQEoMeAOnToEKmpqS3e61QJpCisB/oLIXqji8H1wA0NMwghkqSURb7TK4CcANpzHLseWVF1NCsUnUt3DZ1d31rIyclh7ty5APz6179m6tSpLF68mNzcXKZMmXJSu+pDZzfknXfe4ejRo2zYsAGz2UxGRkazobfbitVq9R8HIkR3wNxHUkoPcB/wOXph/76UcocQ4kkhxBW+bD8RQuwQQmwBfgLcFih7GqEipCoUXUJ3DZ09d+5c3n77bZYvX+7vD6isrPR3hi9YsOCk73beeef53VANXVmVlZXEx8djNptZsWKF386wsDCqq6ubvVfD72PPnj3k5eWd0J8RKALapyClXCqlHCCl7Cul/L0v7TdSyiW+419KKYdKKc+RUk6VUnZsD1hLVJeAJQwstpPnVSgUHUZrobM3bNhAZmYm8+bNaxQ6e9WqVQwdOpSPPvqo2dDZmZmZTJ8+naKiokb3rA+dvXz5crKyssjKymLp0qXN2jV48GBsNhvTpk3zL7Dzi1/8gl/+8peMGDGiTbXx559/nvnz5zN8+HAOHz7uKb/xxhvJzs5m+PDhvPnmmwwaNAiAmJgYzjvvPIYNG8bPf/7zRve655570DSN4cOHM2fOHBYsWNCohRBIembo7H/fDkVb4CcbO8YohaIbo0Jn9zxU6OxTxV6iXEcKhULRDD1XFFQns0KhUJxADxUFNZtZoVAomqPniYLLAXVVShQUCoWiGXqeKKjhqAqFQtEiPVcUVJ+CQqFQnEDPFQXVUlAoOo2uCJ1dj9frZcSIEc0+69577yUrK4shQ4YQHBzsn8/Q1mill156KRUVFaf0Dt2dQIa56J7Uh7hQoqBQdBoNQ2cHBwd3Sujsep5//nkGDx5MVVXVCdfmz58P6AHzZs6cyebNmxtd93g8mEwtF5MtTYY7k+l5olBdDMIIITFdbYlC0emsfn8Px/LtHXrP2NRQJl034KT5Ojt0NkBBQQH//e9/eeyxx3juuefa9D4rV67k17/+NVFRUezatYs9e/Zw5ZVXkp+fj9Pp5IEHHuCuu+4C9FZJdnY2drudSy65hIkTJ/Ltt9/Sq1cvPv74Y4KDg9v6NXYbeqb7yBYHBuPJ8yoUig6jK0JnP/jggzzzzDMYDKdW1G3cuJHnn3/eH5n0tddeY8OGDWRnZ/PCCy80G8xv79693HvvvezYsYPIyEh/xNQzjZ7XUlAT1xQ9mLbU6ANFZ4fO/vTTT4mPj2fUqFGsXLnylGwdM2YMvXv39p+/8MILLF68GID8/Hz27t1LTExjb0Pv3r3JysoCYNSoUeTm5p7SM7sLPVMUVH+CQtEldGbo7DVr1rBkyRKWLl2K0+mkqqqKm266ibfffvuk968Pige6O+nLL7/ku+++IyQkhClTpjQb+rppSOv6pUfPNHqe+6i6RK24plB0EZ0ZOvsPf/gDBQUF5ObmsnDhQqZNm9YmQWhKZWUlUVFRhISEsGvXLtauXXvK9ziT6FktBc0LNUfV2swKRRfRWujsO+64g8zMTEJCQhqFzp47dy5Dhw5lwoQJzYbO1jQNs9nM/PnzSU9P73CbZ8yYwUsvvcTgwYMZOHAg48aN6/BndCd6Vuhs+1F4th9c8icYe1fHGqZQdFNU6Oyehwqd3Vbq12ZWHc0KhULRLD1MFNRsZoVCoWiNniUK1UoUFAqFojV6lij4Wwpq9JFCoVA0Rw8ThSNgCQOL7eR5FQqFogfSw0ShWHUyKxQKRSv0MFFQy3AqFF1Bdw2d/cYbbzB37txGaceOHSMuLo66urpm779gwQLuu+8+AF566SXefPPNE/Lk5uYybNiwVu3Mzc31T8wDyM7ObnYOR2cTUFEQQswQQuwWQuwTQsxrJd9sIYQUQpx0DO1pUV2sREGh6AIahs4GuiR0dnNcddVVfPHFFzgcDn/aBx98wOWXX94obEVL/PjHP/YH7ztVmorC6NGjeeGFF9p1r44kYDOahRBGYD4wHSgA1gshlkgpdzbJFwY8AHwfKFv8qJaCooezYsHLHDl0oEPvGZ/eh6m3nXwyaHcMnR0eHs7555/PJ598wpw5cwBYuHAhjz32GJ988gm/+93vcLlcxMTE8M4775CQ0Lj8ePzxxwkNDeXhhx9mw4YN3HHHHQBcdNFF/jy5ubncfPPN1NTUAPDiiy8yYcIE5s2bR05ODllZWdx6662MGDGCZ599lk8//bTF7+Pxxx8nLy+PAwcOkJeXx4MPPtjhrYtAthTGAPuklAeklC5gITCrmXz/B/wRODHCVEfiqgFXtRp5pFB0Ed01dPbcuXNZuHAhAIWFhezZs4dp06YxceJE1q5dy6ZNm7j++ut55plnWn2/22+/nb/97W9s2bKlUXp8fDxffPEFGzduZNGiRf5C/Omnn2bSpEls3ryZn/70p40+09L3AbBr1y4+//xz1q1bxxNPPIHb7W7VrlMlkLGPegH5Dc4LgLENMwghRgKpUsr/CiF+3tKNhBB3AXcB/tgnp4x/bWYV90jRc2lLjT5QdNfQ2Zdddhn33HMPVVVVvP/++8yePRuj0UhBQQFz5syhqKgIl8vVKJR2UyoqKqioqGDy5MkA3HzzzXz22WcAuN1u7rvvPr941a/R0BotfR/19lqtVqxWK/Hx8ZSUlJCSknLSe7aVLguIJ4QwAM8Bt50sr5TyZeBl0GMfteuB/mU4VUtBoegqumPo7ODgYGbMmMHixYtZuHCh3810//3389BDD3HFFVewcuVKHn/88XbZ+pe//IWEhAS2bNmCpmkEBQW16z71NA3R7fF4Tut+TQmk++gwkNrgPMWXVk8YMAxYKYTIBcYBSwLW2Vzti3ukIqQqFF1Gdw2dPXfuXJ577jlKSkoYP348oIfMru8Mr4/a2hKRkZFERkbyzTffADRyZVVWVpKUlITBYOCtt97C6/UCEBYWRnV1dbP3a+n76AwCKQrrgf5CiN5CCAtwPbCk/qKUslJKGSulzJBSZgBrgSuklO0MgXoS/C0F1dGsUHQVrYXO3rBhA5mZmcybN69R6OxVq1YxdOhQPvroo2ZDZ2dmZjJ9+nSKiorabdf06dMpLCxkzpw5CCH8Nl177bWMGjWK2NjYk97j9ddf59577yUrK6tRh/g999zDG2+8wTnnnMOuXbv8C/hkZmZiNBo555xz+Mtf/tKm76MzCGjobCHEpcBfASPwmpTy90KIJ4FsKeWSJnlXAg+fTBTaHTp7139h87tw3Vtwiuu1KhRnMip0ds/jdEJnB7RPQUq5FFjaJO03LeSdEkhbGHSZvikUCoWiRVSVWaFQKBR+lCgoFD2AM22FRUX7Od3fWomCQnGWExQURGlpqRKGHoCUktLS0tMa9tpl8xQUCkXnkJKSQkFBAUePHu1qUxSdQFBQ0GlNZlOioFCc5ZjN5lZn4yoUDVHuI4VCoVD4UaKgUCgUCj9KFBQKhULhJ6AzmgOBEOIocOikGZsnFmh92aazm578/j353aFnv796d510KWXcyT5wxonC6SCEyG7LNO+zlZ78/j353aFnv79691N7d+U+UigUCoUfJQoKhUKh8NPTROHlrjagi+nJ79+T3x169vurdz8FelSfgkKhUChap6e1FBQKhULRCkoUFAqFQuGnx4iCEGKGEGK3EGKfEGJeV9vTmQghcoUQ24QQm4UQgVnutBshhHhNCHFECLG9QVq0EOILIcRe3z6qK20MFC28++NCiMO+33+zb0XEsw4hRKoQYoUQYqcQYocQ4gFfek/57Vt6/1P6/XtEn4IQwgjsAaYDBejrR8+VUu7sUsM6CSFELjBaStkjJvAIISYDduBNKeUwX9ozQJmU8mlfpSBKSvlIV9oZCFp498cBu5Ty2a60LdAIIZKAJCnlRiFEGLABuBK4jZ7x27f0/tdxCr9/T2kpjAH2SSkPSCldwEJgVhfbpAgQUspVQFmT5FlA/ernb6D/ZznraOHdewRSyiIp5UbfcTWQA/Si5/z2Lb3/KdFTRKEXkN/gvIB2fFlnMBL4nxBigxDirq42potIkFIW+Y6LgYSuNKYLuE8IsdXnXjor3ScNEUJkACOA7+mBv32T94dT+P17iij0dCZKKUcClwD3+lwMPRap+0zPfr/pcf4B9AWygCLgz11qTYARQoQCHwIPSimrGl7rCb99M+9/Sr9/TxGFw0Bqg/MUX1qPQEp52Lc/AixGd6f1NEp8Ptd63+uRLran05BSlkgpvVJKDXiFs/j3F0KY0QvEd6SUH/mSe8xv39z7n+rv31NEYT3QXwjRWwhhAa4HlnSxTZ2CEMLm63RCCGEDLgK2t/6ps5IlwK2+41uBj7vQlk6lvkD0cRVn6e8vhBDAq0COlPK5Bpd6xG/f0vuf6u/fI0YfAfiGYf0VMAKvSSl/37UWdQ5CiD7orQPQl19992x/dyHEe8AU9LDBJcBvgf8A7wNp6KHXr5NSnnUdsi28+xR014EEcoEfNfCxnzUIISYCq4FtgOZLfhTdr94TfvuW3n8up/D79xhRUCgUCsXJ6SnuI4VCoVC0ASUKCoVCofCjREGhUCgUfpQoKBQKhcKPEgWFQqFQ+FGioFD4EEJ4G0SS3NyR0XSFEBkNI5cqFN0VU1cboFB0I2qllFldbYRC0ZWoloJCcRJ861E841uTYp0Qop8vPUMIsdwXaOwrIUSaLz1BCLFYCLHFt03w3coohHjFF+v+f0KIYF/+n/hi4G8VQizsotdUKAAlCgpFQ4KbuI/mNLhWKaUcDryIPjMe4G/AG1LKTOAd4AVf+gvA11LKc4CRwA5fen9gvpRyKFABzPalzwNG+O7z48C8mkLRNtSMZoXChxDCLqUMbSY9F5gmpTzgCzhWLKWMEUIcQ1/UxO1LL5JSxgohjgIpUsq6BvfIAL6QUvb3nT8CmKWUvxNCLENfGOc/wH+klPYAv6pC0SKqpaBQtA3ZwvGpUNfg2MvxPr3LgPnorYr1QgjV16foMpQoKBRtY06D/Xe+42/RI+4C3IgejAzgK+Bu0JeCFUJEtHRTIYQBSJVSrgAeASKAE1orCkVnoWokCsVxgoUQmxucL5NS1g9LjRJCbEWv7c/1pd0PvC6E+DlwFLjdl/4A8LIQ4gfoLYK70Rc3aQ4j8LZPOATwgpSyooPeR6E4ZVSfgkJxEnx9CqOllMe62haFItAo95FCoVAo/KiWgkKhUCj8qJaCQqFQKPwoUVAoFAqFHyUKCoVCofCjREGhUCgUfpQoKBQKhcLP/wNtbcqQy04R9AAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- 0.195587158203125 seconds ---\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time() \n",
+    "plt.plot(history.history['accuracy'])\n",
+    "plt.plot(history.history['val_accuracy'])\n",
+    "plt.plot(history2.history['accuracy'])\n",
+    "plt.plot(history2.history['val_accuracy'])\n",
+    "plt.plot(history4.history['accuracy'])\n",
+    "plt.plot(history4.history['val_accuracy'])\n",
+    "plt.title(\"Model Accuracy\")\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Accuracy')\n",
+    "plt.legend(['Model 1 Train', 'Model1 Validation', 'Model2 Train', 'Model2 Validation', 'Model4 Train', 'Model4 Validation'])\n",
+    "plt.show()\n",
+    "print(\"--- %s seconds ---\" % (time.time() - start_time))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "behind-cooperative",
+   "metadata": {
+    "papermill": {
+     "duration": 1.66854,
+     "end_time": "2021-04-25T15:08:08.679401",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:07.010861",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6.12 Other Performance Matrix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "single-context",
+   "metadata": {
+    "papermill": {
+     "duration": 1.387915,
+     "end_time": "2021-04-25T15:08:11.507106",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:10.119191",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 1. Confusion Matrix for each model :\n",
+    "- A confusion matrix is a technique for summarizing the performance of a classification algorithm.\n",
+    "- The matrix compares the actual target values with those predicted by the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "standing-stuart",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:08:14.359135Z",
+     "iopub.status.busy": "2021-04-25T15:08:14.358344Z",
+     "iopub.status.idle": "2021-04-25T15:08:14.361316Z",
+     "shell.execute_reply": "2021-04-25T15:08:14.360852Z"
+    },
+    "papermill": {
+     "duration": 1.446937,
+     "end_time": "2021-04-25T15:08:14.361444",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:12.914507",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def plot_confusion_matrix(cm, classes,\n",
+    "                          normalize=False,\n",
+    "                          title='Confusion matrix',\n",
+    "                          cmap=plt.cm.Blues):\n",
+    "    \n",
+    "    plt.imshow(cm, interpolation='nearest', cmap=cmap)\n",
+    "    plt.title(title)\n",
+    "    plt.colorbar()\n",
+    "    tick_marks = np.arange(len(classes))\n",
+    "    plt.xticks(tick_marks, classes, rotation=90)\n",
+    "    plt.yticks(tick_marks, classes)\n",
+    "\n",
+    "    if normalize:\n",
+    "        cm = cm.astype('float') / cm.sum(axis=1)[:, np.newaxis]\n",
+    "\n",
+    "    thresh = cm.max() / 2.\n",
+    "    for i, j in itertools.product(range(cm.shape[0]), range(cm.shape[1])):\n",
+    "        plt.text(j, i, cm[i, j],\n",
+    "                 horizontalalignment=\"center\",\n",
+    "                 color=\"white\" if cm[i, j] > thresh else \"black\")\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "    plt.ylabel('True label')\n",
+    "    plt.xlabel('Predicted label')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "enhanced-columbus",
+   "metadata": {
+    "papermill": {
+     "duration": 1.77488,
+     "end_time": "2021-04-25T15:08:17.667895",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:15.893015",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Model 1:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "ordinary-depth",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:08:20.771103Z",
+     "iopub.status.busy": "2021-04-25T15:08:20.770339Z",
+     "iopub.status.idle": "2021-04-25T15:08:21.517284Z",
+     "shell.execute_reply": "2021-04-25T15:08:21.516808Z"
+    },
+    "papermill": {
+     "duration": 2.439885,
+     "end_time": "2021-04-25T15:08:21.517425",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:19.077540",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAVcAAAEmCAYAAADWT9N8AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAA3RklEQVR4nO3dd3gV1dbA4d9KgAhGCBhqAggiIEgPBKWIigKKgAooKEUQ1Itd7AW7XvWzVxQVO8UCCFKkKCAtQS4CIkQRpQmhKjVlfX/MJAaE5CSck5mcrJdnHs7s2TOzhies7LNnzx5RVYwxxgRXhNcBGGNMOLLkaowxIWDJ1RhjQsCSqzHGhIAlV2OMCQFLrsYYEwKWXIspESktIpNEZLeIjDuO41wpItODGZtXRKSdiPzsdRwmPIiNc/U3EekL3AbUB/4ClgGPq+q84zxuP+BG4CxVTT/eOP1ORBQ4TVVTvI7FFA/WcvUxEbkNeAF4AqgM1ABeA7oH4fA1gTXFIbEGQkRKeB2DCTOqaosPF6Ac8DfQK5c6UTjJd5O7vABEuds6ABuA24GtwGbganfbw8AhIM09x2DgIeDDHMc+BVCghLs+EPgVp/W8DrgyR/m8HPudBSwBdrt/n5Vj2xzgUWC+e5zpQOwxri0r/jtzxN8DuBBYA+wA7s1RvxWwANjl1n0FKOVu+869lr3u9V6e4/h3AVuAD7LK3H1Odc/R3F2vBmwDOnj9s2FL0Vis5epfZwInAF/kUuc+oDXQFGiCk2Duz7G9Ck6SjsNJoK+KSHlVHYHTGh6jqtGqOiq3QETkROAloIuqnoSTQJcdpV4FYLJb92TgOWCyiJyco1pf4GqgElAKGJ7Lqavg/BvEAQ8CbwFXAS2AdsADIlLLrZsB3ArE4vzbnQf8B0BV27t1mrjXOybH8SvgtOKH5jyxqv6Ck3g/FJEywLvAaFWdk0u8xmSz5OpfJwOpmvvX9iuBR1R1q6puw2mR9suxPc3dnqaqU3BabfUKGE8mcIaIlFbVzaq68ih1LgLWquoHqpquqp8Aq4GLc9R5V1XXqOp+YCzOL4ZjScPpX04DPsVJnC+q6l/u+Vfh/FJBVZNVdaF73t+AN4GzA7imEap60I3nMKr6FpACLAKq4vwyMyYgllz9azsQm0dfYDVgfY719W5Z9jGOSM77gOj8BqKqe3G+Sl8HbBaRySJSP4B4smKKy7G+JR/xbFfVDPdzVvL7M8f2/Vn7i0hdEflKRLaIyB6clnlsLscG2KaqB/Ko8xZwBvCyqh7Mo64x2Sy5+tcC4CBOP+OxbML5SpulhltWEHuBMjnWq+TcqKrTVPV8nBbcapykk1c8WTFtLGBM+fE6TlynqWpZ4F5A8tgn16EyIhKN0489CnjI7fYwJiCWXH1KVXfj9DO+KiI9RKSMiJQUkS4i8rRb7RPgfhGpKCKxbv0PC3jKZUB7EakhIuWAe7I2iEhlEenu9r0exOleyDzKMaYAdUWkr4iUEJHLgQbAVwWMKT9OAvYAf7ut6uuP2P4nUDufx3wRSFLVa3D6kt847ihNsWHJ1cdU9f9wxrjej3On+g/gBuBLt8pjQBKwHPgRWOqWFeRcM4Ax7rGSOTwhRrhxbMK5g342/05eqOp2oCvOCIXtOHf6u6pqakFiyqfhODfL/sJpVY85YvtDwGgR2SUivfM6mIh0Bzrzz3XeBjQXkSuDFrEJa/YQgTHGhIC1XI0xJgQsuRpjTAhYcjXGmBCw5GqMMSHgq8kqpNSJKifEeB1GgZxRu0relXwsMiKvIaH+VsTDL7LWr/+N1NTUoP3rR5atqZr+r4fljkn3b5umqp2Ddf5g8ldyPSGGqIRhXodRIF+Nv93rEI5L2dK++lHItxNKRnodQrHUJjEhqMfT9ANE1b8i4PoHfng5r6fwPFO0/0cZY8KLABIeX0MsuRpj/EXC41aQJVdjjL9Yy9UYY4JNrOVqjDEhYS1XY4wJMsFarsYYE3xiLVdjjAkJa7kaY0wIWMvVGGOCzUYLGGNM8AkQER6PMltyNcb4iLVcjTEmNMJkijNLrsYY/7BxrsYYEyJhMlqgSP+KeOOOi1j/2c0kjRqSXVb+pBP46uk+/Pj+dXz1dB9iok8AoF2TGmyZeBsLRw5m4cjB3NOvLQBRJSOZ+9pAFr01mOR3hnD/gHaFfh3DbxxK83rVOb9N8+yyx0fcw7mJjenULoGh/Xqze/eu7G2vPv807RMacE6rRnw7a0ahx5uXjIwM2rdO4PJLuwEw5Op+tGzSgDMTmnDDtdeQlpbmcYR5O3DgAG3PbEWr5k1o3qQhjz48wuuQ8qXoxu/2uQa6+Ji/o8vDB9OW0/3uTw8rG97nTOb88BuN+r/BnB9+Y3ifM7O3zf/xD1oPHUXroaN48oN5ABxMy6DzbR+ROGQUiUNGcUGr2rQ6vVqhXkevPv0YPXbiYWXtOpzL9PlLmTY3iVqnnsZrzz8DwJrVPzHpi3HMmP8Do8dN5P47biIjI6NQ483LG6++RN369bPXe13eh8XLVvL9kmXsP7Cf998d5WF0gYmKimLqjFksXvo/FiUtY/q0qSxauNDrsAJWpOMXCXzxsSKdXOcv/4Mdew4cVta1TV0+nLYcgA+nLefitnXzPM7eA05LqmSJCEqUiEQ1+LHmJvGsdsSUL39YWftzzqdECafXpllCKzZv3gDAjK8ncfElvYiKiqJGzVqcUutUli1dUrgB52Ljhg1MnzqF/gMHZZdd0PlCRAQRoUVCSzZt3OBhhIEREaKjowFIS0sjPS0N8fl/5pyKdPzWcvWnSuVPZMuOvQBs2bGXSuVPzN6W2CCORW8N5ssnL+f0U/55O0REhLBw5GB+//wWZiWtY8nqTYUed27GfjyaDud1AmDL5k1UjYvP3lalWhxbNvsn3nvvvI2HH3uKiIh//2ilpaUx5uOPOO+CTh5Eln8ZGRkktmhKjWqVOLfj+bRKTPQ6pHwpkvHnp9Xq818WIUuuIvKOiGwVkRWhOkcg1G2GLlu7hXp9XiVxyChe/zKJsY/0zK6Tmam0HjqKOr1fJqF+NRqcUtGrcP/l5f97ihKRJbikVx+vQ8nT1ClfEVuxEk2btzjq9uE338BZbdtxVpvC79cuiMjISBYlLyPltw0kLVnMyhWe/ijnW5GN31queXoPKPS3Mm7duZcqFZzWapUKJ7Jt1z4A/tp3KPvr/7RFv1CyRAQnly192L679x7k22XruaBV7cIN+hjGffw+M6d/zYtvvpf9la5K1WpszvG1esumjVSpWrh9xMeyaOH3TJ08icb1T2Vw/yuZ++1shg7qD8B/H3+E1NRtPP7fZz2OMv9iYmI4u8M5TJ8+1etQCqTIxW8t19yp6nfAjlAd/1gmf7+Wqzo1BuCqTo35av4aACrn6B5IqF+VCBG279lPbLkylDsxCoATSpXgvBa1+Pn37YUd9r/MmTmdN15+jlEfjad0mTLZ5ed36cqkL8Zx8OBBfl+/jnW/ptC0eUsPI/3HiEeeYGXKepav/oVR739Eu7PPYeQ77/P+u6OY+c103h790VG7C/xo27Zt7Nq1C4D9+/cz85sZ1KtXP/edfKToxh8+owU8H+cqIkOBoQBElcvXvqPv7067JjWJLVealDE38Oh7c3n2kwV8+OAlDOjShN//3M1Vj3wBwCVn12dIt+akZ2Ry4GA6/R/7EoAqJ5/IW3ddTGREBBERwmdzfuLrhSnBvMQ83TikHwvmz2Xn9lQSzziVW+++n9deeIZDBw9y1WUXAc5NrSf+7xXq1m/ARd0vo+NZTSkRWYJHn36RyEh/P4t9203/oXqNmlzQwRn+dnH3Htx57wMeR5W7LZs3M2TQADIyMsjUTC7r2ZsLL+rqdVgBK7Lxh9HcAqIhvDUuIqcAX6nqGYHUjygbp1EJw0IWTyj9PP52r0M4LmVLe/579ricUDI8/kMWNW0SE0hOTgra9/OImJoa1e6ugOsf+GpYsqomHGu7iLwDdAW2ZuUhEakAjAFOAX4DeqvqTnH63l4ELgT2AQNVdam7zwDgfvewj6nq6DyvJeCrMMaYwhDcPtf3+Pe9n7uBmap6GjDTXQfoApzmLkOB151wpAIwAkgEWgEjRKQ8ebDkaozxlyD2uR7j3k93IKvlORrokaP8fXUsBGJEpCrQCZihqjtUdScwgwBu1odyKNYnwAKgnohsEJHBoTqXMSaM5K/lGisiSTmWoQGcobKqbnY/bwEqu5/jgD9y1Nvglh2rPFch62hTVf8PzDTG+Ivkez7X1Nz6XPOiqioiIbnxZN0Cxhh/Cf041z/dr/u4f291yzcC1XPUi3fLjlWeK0uuxhhfyZqHIpClgCYCA9zPA4AJOcr7i6M1sNvtPpgGXCAi5d0bWRe4Zbkq2uNvjDFhRSCoE8y493464PTNbsC56/8UMNa9D7Qe6O1Wn4IzDCsFZyjW1QCqukNEHgWyZkh6RFXzfEDKkqsxxj/EXYIkl3s/5x2lrgJHHWivqu8A7+Tn3JZcjTE+clxf933FkqsxxlcsuRpjTAhYcjXGmGATEHu1tjHGBJdYn6sxxoSGJVdjjAkBS67GGBMCllyNMSbYgvwQgZcsuRpjfMVarsYYE2Q2WsAYY0LEkqsxxoRCeORWfyXXJnWqMmdy4G9+9JPa1431OoTjMufxi70O4bjUrnSi1yEUWGSYPJEUFGItV2OMCQlLrsYYE2SCEBERHi9IseRqjPGX8Gi4WnI1xviI9bkaY0xoWHI1xpgQsORqjDGhEB651ZKrMcZfrOVqjDFBJmJzCxhjTEhYcjXGmBCw5GqMMaEQHrnVkqsxxl+s5WqMMcFmT2gZY0zwORO3WHI1xpigC5OGK+Ext9cRDhw4wLntWtMmsTmtWzTmiUcfAuDb2TNpf2ZL2ia2oPN57fn1lxRvA81h6Pl1mfd4F+Y/cSHXXlAPgHsubcR3j3VhziOdGX9HB6rElAagS7O47PKZD11A4mmxnsW9ZdMGBve+kB7nJnDJeS35cNRrAOzeuYOhfbvRtV1Thvbtxp5dOwHYs2snt1zTh8vOb03frh1Yu3qVZ7Ef6fqhgzglvjItmzU6rPz1V1+mWaPTSWh6Bvffc6dH0eXPtdcMoka1SrRoeobXoeRb1ljXQBY/C8vkGhUVxcSvv2H+oqXMXZjMzBnTWLJ4IbfdfANvvfs+8xYl07N3H5757xNehwpA/bhy9O9wKuc/PJ32939Np6bVqFUpmlem/ET7+7+mw4NTmb5sE8O7NwTgu1V/ZpffOGoxLw5K9Cz2yMgS3P7AE3w5K4kPJ8xizOiR/LJmNaNee47ENmfz1dxlJLY5m1GvPQfAW688S72GjflsxkIef+FN/vuQf5LVlf0G8uWkrw8r+3bObCZPmsjCpGUkLVvBTbcO9yi6/Ok3YCATvprqdRj5J07LNdDFz8IyuYoI0dHRAKSlpZGWlp79Vsm/9uwBYM+e3VStUtXLMLPVrVaW5F+2s/9QBhmZyvzVW+maUJ2/DqRn1ykT9U8Pzt6DOcpLRaJoocabU8XKVWjQqCkAJ0afRK069di6ZROzp0+mW88rAejW80pmTfsKgF/XrqbVWe0BqFWnHpv++J3t27Z6EvuR2rZrT/nyFQ4re3vkG9x+x11ERUUBUKlSJS9Cy7e27dpToUKFvCv6jAARERLw4mdhmVwBMjIyaJvYgtNqVuWc884joVUiL732Jr0uvZgGdWoy5pOPuGW4P97XtXrDblrXq0j5E0tRulQk5zepRlyFMgDcd1ljlj/XjZ5n1uTJz3/M3ueiFvEsfPIiPr3tbG58e5FXoR9m4x/rWb1yOY2aJbAjdRsVK1cBILZSZXakbgOg7umNmPn1JAB+/CGJzRt/58/NGz2LOS8pa9cwf/5cOrRtTaeOHUhOWuJ1SGEv2C1XEblVRFaKyAoR+UREThCRWiKySERSRGSMiJRy60a56ynu9lMKeh0hS64iUl1EZovIKvfCbg7VuY4mMjKSeYuSWbl2PclJS1i1cgWvvfwi4z6fxKqU9VzZbwD33eWPr3hrNu/hpck/Mf7Ocxg7vAMrft9JRqbTGn38s+U0vm0i4xes55qOp2XvMzl5A63vmUy/l+Zy72WNvQo92769f3PbtVdx50NPEX1S2cO2SY7/CYOH3cZfe3bRq9NZfPLem9Rv2ISIyEgvQg5Ieno6O3fsYPbcBTz+5NP073s5qt59UygOgtnnKiJxwE1AgqqeAUQCVwD/BZ5X1TrATmCwu8tgYKdb/rxbr0BC2XJNB25X1QZAa2CYiDQI4fmOKiYmhnbtO/DN9Kms+HE5Ca2c/slLevZm8aIFhR3OMX303a+cN2IaFz8xk117D/HLlj2HbR/3/W9cnFD9X/st+HkbNStGUyG6VGGF+i9paWncNvQqLurRm45dugNQIbYi2/7cAsC2P7dQ4WTnplv0SWV59Lk3GDftex5/YSQ7d6QSX+MUr0LPU1xcPN16XIqIkNCyFREREaSmpnodVvgKTZ9rCaC0iJQAygCbgXOB8e720UAP93N3dx13+3lSwDtnIUuuqrpZVZe6n/8CfgLiQnW+nFK3bWPXrl0A7N+/nzmzvqFuvfrs2bOblLVrAJg90ynzi9iTnD69uApl6NqiOuMXrqd25ejs7Rc2j2PtZifh1qr0T3njmuWJKhnBjr8PFW7ALlVlxB3DqHVaPfoPvTG7vMP5FzJx/EcATBz/EedccBEAe3bvIu2QE+tnn7xH88Q2/2rp+knXbt357tvZAKxds4ZDaYeIjfVudEa4E/Ldco0VkaQcy9Ccx1PVjcCzwO84SXU3kAzsUtWsmxcb+Cc3xQF/uPumu/VPLsi1FMo4V7ffohlQKJ2DW7Zs5vohg8jIzEAzM+lxaU86X9iVF195k/59eyMREcTExPDqG28XRjgBee/GtlSIjiItI5M7P0hiz740XhqUSJ2qJ5Gp8EfqXoaPdvr7Lk6ozuVta5GWnsmBtAwGvzrfs7h/WLKArz77hNPqN6RXp7MAuOmuEQwedhvDrx/AF59+QNX46jz7mtMYWJfyM/ffei2IUKfu6Tz8zKuexX6kgf36Mve7OWxPTaVu7erc98BD9B84iOuHDqZls0aUKlWKN99+z/dDgAD6X9WHud/OITU1lVNPieeBBx9m4KDBee/ouXwPsUpV1YRjHk2kPE5rtBawCxgHdD6eCAMloe4/EpFo4FvgcVX9/CjbhwJDAapXr9Hix59/DWk8oVL7urFeh3Bc5jx+sdchHJfalU70OoQCi/T5Xe/ctElMIDk5KWgXUKZaPa079LWA6//v4Y7JeSTXXkBnVR3srvcHzgR6AVVUNV1EzgQeUtVOIjLN/bzA7UbYAlTUAiTKkI4WEJGSwGfAR0dLrACqOlJVE1Q14eTYiqEMxxhTBAT5IYLfgdYiUsbtOz0PWAXMBnq6dQYAE9zPE9113O2zCpJYIYTdAu6FjAJ+UtXnQnUeY0z4ECGo41dVdZGIjAeW4txk/wEYCUwGPhWRx9yyUe4uo4APRCQF2IEzsqBAQtnn2gboB/woIsvcsntVdUoIz2mMKeKC3aWtqiOAEUcU/wq0OkrdAzhdBsctZMlVVecRNtPeGmMKS1G4YRgImxXLGOMrYZJbLbkaY3zEJss2xpjgcx4i8DqK4LDkaozxEf/P0xooS67GGF8Jk9xqydUY4y/WcjXGmGArAm8YCJQlV2OMb2TNihUOLLkaY3zFkqsxxoRAmORWS67GGB8J8sQtXrLkaozxDbFxrsYYExphklstuRpj/CUiTLKrJVdjjK+ESW615GqM8Q+xWbGMMSY0wmSwgL+Sq0jR7W9Z9+blXodwXKpc9Z7XIRyX5a/18TqEAouvUNrrEHzFWq7GGBMCYZJbLbkaY/xDcMa6hoNjJlcReRk45vu6VfWmkERkjCnWikOfa1KhRWGMMQBSDJ7QUtXROddFpIyq7gt9SMaY4kqAyDBpukbkVUFEzhSRVcBqd72JiLwW8siMMcWSSOCLn+WZXIEXgE7AdgBV/R/QPoQxGWOKMXG7BgJZ/Cyg0QKq+scRF5IRmnCMMcVZUWiRBiqQ5PqHiJwFqIiUBG4GfgptWMaY4qqoPkh0pEC6Ba4DhgFxwCagqbtujDFBJ/lY/CzPlquqpgJXFkIsxhjj+77UQAUyWqC2iEwSkW0islVEJohI7cIIzhhTvAjOQwSBLn4WSLfAx8BYoCpQDRgHfBLKoIwxxVQ+Rgr4vYUbSHIto6ofqGq6u3wInBDqwIwxxVPYj3MVkQoiUgH4WkTuFpFTRKSmiNwJTCm8EI0xxUmwW64iEiMi40VktYj85D4YVUFEZojIWvfv8m5dEZGXRCRFRJaLSPOCXkduN7SScSZuybqCa3NsU+Cegp7UGGOOJqvPNcheBKaqak8RKQWUAe4FZqrqUyJyN3A3cBfQBTjNXRKB192/8y23uQVqFeSAxhhzPILZlyoi5XCeKB0IoKqHgEMi0h3o4FYbDczBSa7dgfdVVYGFbqu3qqpuzu+5A3pCS0TOABqQo69VVd/P78kKy4Y//uDaawaydeufiAgDBw3hPzfcxMCrrmDt2jUA7N61i3IxMcxftNTjaA934MABunTswKFDB0lPT6f7JZdx7wMPcf2Qq5k39zvKlSsHwGsj36Fxk6beBuv6z4UNuLpjPUTg3W9+5tXJq2h8SgVeGnoWJ5SMJD1TueWt70lKSaVutXK8OawdTWufzEOfJPPixBWexn73zdcye8ZUTo6tyJTvnIngXnrmMcZ++C7lT44F4PZ7H6ZDx85MGP8pb7/2fPa+P69awZfffE+DM5p4EntuDhw4QMdz2nPo4EHSM9K55NKePDDiYa/DypMIROYvucaKSM4Z/Eaq6sgc67WAbcC7ItIE5xv5zUDlHAlzC1DZ/RwH/JFj/w1uWfCTq4iMwMnwDXD6WrsA8wDfJtcSJUrw+FPP0LRZc/766y/an9WSc8/ryHsffppd5967hlPWTVR+EhUVxaSp3xAdHU1aWhqdzm3P+Rd0BuDRJ/5Lj0t7ehzh4RpUj+HqjvVof/dEDqVnMuH+Tnyd/AeP9WvJE+OWMf2HDXRqFs9j/VrSecTX7Pz7IMPfWcjFrWp6HToAl17Rj36Dr+OOG4YcVj7w2hu55j+3HFbWvecVdO95BeAk1usHXu7LxArOz9HUGbOyf47OPbstF3TqQmLr1l6Hlqd8NlxTVTUhl+0lgObAjaq6SERexOkCyKaqKiLHnLu6oAIZLdATOA/YoqpXA00A/2WlHKpUrUrTZk4/9EknnUS9+vXZtGlj9nZV5YvPxtGz9xVehXhMIkJ0dDQAaWlppKWn+XrISb34GJLWbmP/oQwyMpV5qzbTPfEUVJWTSpcEoGyZUmze4cxWuW3PAZJ/SSUtI9PLsLO1OrMt5WIq5Hu/r74YS9ce/vpFl9ORP0fpaf7+OcopyDe0NgAbVHWRuz4eJ9n+KSJV3fNVBba62zcC1XPsH++W5VsgyXW/qmYC6SJS1g2ieh77+Mb69b+xfNkyElr+0yf9/fy5VKpcmTp1TvMwsmPLyMigbWJz6tSowjnndiShlRP7ow89wFktm3LPHbdx8OBBj6N0rPp9J2edXpkK0VGULhVJp2bViT/5RO58dxFP9GvJmjd682T/ljz4UdGae/3Dd96ga4dW3H3ztezetfNf2ydP+Iyul/T2ILLAZWRkkNiiKTWqVeLcjufTKrFA92UKXTCHYqnqFpz5Ueq5RecBq4CJwAC3bAAwwf08EejvjhpoDewuSH8rBJZck0QkBngLp79iKbAgr51E5AQRWSwi/xORlSJS6B0+f//9N/369OKpZ56jbNmy2eXjx35Kz17+a7VmiYyMZN6ipaxK+Z2lSUtYtXIFIx55gqT/rWL2vEXs3LmDF/7vaa/DBODnjbt57svlTHqgExPu78Ty37aTkakM6VSfO99bRN3rxnLne4t5/T/tvA41YH0HDGHmopVMnLWQSpWr8OSIw75Fsix5MaVLl6Hu6Q09ijAwkZGRLEpeRspvG0haspiVK7zt3w6EIERI4EuAbgQ+EpHlOHOjPAE8BZwvImuBju46OF2fvwIpODnvPwW9ljyTq6r+R1V3qeobwPnAALd7IC8HgXNVtQnOBXV2fxMUirS0NK7q05Pel/elW49Ls8vT09OZOOELLu3p71YHQExMDO3O7sA306dRpWpVRISoqCiu7D+Q5KTFXoeXbfSstbS5ayIXPDiFXXsPkbJ5N1eefRoTFq0H4PMF60ioE+txlIGLrVSZyMhIIiIi6H3VIJb/kHzY9slfjqfrJb08ii7/YmJiOLvDOUyfPtXrUPKWj1ZroLlVVZepaoKqNlbVHqq6U1W3q+p5qnqaqnZU1R1uXVXVYap6qqo2UtUCf+XK7SGC5kcuQAWgRCADa90g/3ZXS7pL0DuNj3Fuhl13DfXqnc4NN9962LbZs76hbt36xMXHF0Yo+Za6bRu7du0CYP/+/cye+Q1169Vjy2bnm4mqMnniBE5vcIaHUR6uYllnEEl87Il0S6zJmLm/snnnPto1rAJAh0ZV+WXzHi9DzJetf/7zLXDGlInUrd8gez0zM5OvJ37GRT38nVy3HfFzNPObGdSrV9/boAIULo+/5jZa4P9y2abAuXkdXEQicboS6gCv5uhUzllnKDAUoHr1GnkdMiALv5/Ppx9/SMMzGtEm0fk98ODDj9Gp84V8Nm4MPXtfHpTzhMKWLZu5bsjVZGZkkJmZySWX9aLzhV3p2rkj21O3oao0atyE519+3etQs318x7lUiI4iLUO59e0F7N53iGFvzOfZqxOJjIzgYFoGN7w5H4DKMaWZ999unFS6JJmq3HBRQ5rf8jl/7U/zJPZbrh3A4u+/Y+eO7bRtWoeb77ifRd/P5acVyxER4qrX4NFnX86uv2TBPKpUi6fGKf4eBr5l82aGDBpARkYGmZrJZT17c+FFXb0OKyCB9FUWBeKMlQ3xSZw+2y9whkMcs+OneYsE/Xa+f77u5kehNMlDqMpV73kdwnFZ/lofr0MosPgKpb0OocDaJCaQnJwUtCZk5Tpn6OXPjg+4/suXnJ6cx1AszxTKLwlV3QXMBjoXxvmMMUVXcZpysEBEpKLbYkVESuPcDFsdqvMZY8JDuCTXgB5/LaCqwGi33zUCGKuqX4XwfMaYIs4ZBeDzrBmgQB5/FZzXvNRW1UdEpAZQRVVz7RxV1eVAs+CEaYwpLiLD5I5WIJfxGnAmkHXH4C/g1ZBFZIwptpwpB4P+EIEnAukWSFTV5iLyA4Cq7nTnRDTGmKALk4ZrQMk1ze03VXBuVAH+mHXDGBN2fN4gDVggyfUlnDGqlUTkcZxZsu4PaVTGmGJJisDX/UDlmVxV9SMRScaZTUaAHqr6U8gjM8YUS2GSWwMaLVAD2AdMylmmqr+HMjBjTPHk9/GrgQqkW2Ay/7yo8ASc1yb8DPh7vjVjTJGTNVogHATSLdAo57o7I1aB5zg0xpjchEluzf8TWqq6VESKxpTmxpiipQg81hqoQPpcb8uxGoHz/plNIYvIGFOsCeGRXQNpuZ6U43M6Th/sZ6EJxxhTnDl9rl5HERy5Jlf34YGTVHV4IcVjjCnmwj65ikgJVU0XkTaFGZAxpvgSIDJMsmtuLdfFOP2ry0RkIjAO2Ju1UVU/D3FsxpjiJh8vHvS7QPpcTwC247wzK2u8qwKWXI0xQVccxrlWckcKrOCfpJqlqL8yyhjjQ8XlhlYkEA1HHRdhydUYExJh0nDNNbluVtVHCi0SnCxeskS4zOZYtGz7+GqvQzgusWfe4nUIBbZu1jNeh1Bg6ZnBbmcJEcVgnGt4XKExpsgQikfL9bxCi8IYY6B4PP6qqjsKMxBjjIHiMVrAGGMKVXHpFjDGmEJnLVdjjAmBMMmtllyNMf4hApFhkl1tUKkxxlckH0tAxxOJFJEfROQrd72WiCwSkRQRGSMipdzyKHc9xd1+yvFchyVXY4xvZL1DK9AlQDcDOd9Y/V/geVWtA+wEBrvlg4Gdbvnzbr0Cs+RqjPGVYLZcRSQeuAh4210XnEmoxrtVRgM93M/d3XXc7ee59QvEkqsxxldEAl8C8AJwJ5Dprp8M7FLVdHd9AxDnfo4D/gBwt+926xeIJVdjjI8IIoEvQKyIJOVYhmYfSaQrsFVVk724EhstYIzxDSHfLb5UVU04xrY2QDcRuRBnXuqywItATNabVoB4YKNbfyNQHdggIiWAcjhzWReItVyNMb6Sz5brManqPaoar6qnAFcAs1T1SmA20NOtNgCY4H6e6K7jbp+lqgWe9suSqzHGV4I9FOso7gJuE5EUnD7VUW75KOBkt/w24O6Cn8K6BYwxfiLk2SItCFWdA8xxP/8KtDpKnQNAr2Cds1i0XKdPm0rjhvVoWL8Ozzz9lNfh5EtRi/36oYM4Jb4yLZs1Oqz89Vdfplmj00loegb333OnR9E53niwD+tnPEbSmH8aJpd2bEry2LvZu+R5mp9ePbu8QrkyTH3zBrbNfZrn77zssOP0PL8Ziz+9i+Sxd/PYjRcXWvzH8tbrL9PhzGac3bopI197CYCdO3dweY8unNW8AZf36MKuXTs9jjJ3WX2ugS5+5vf4jltGRga33DSMCZO+5oflqxj36Sf8tGqV12EFpCjGfmW/gXw56evDyr6dM5vJkyayMGkZSctWcNOtwz2KzvHBpMV0v/GNw8pWpmzmijveYd7SXw4rP3AwnUden8I9L0w4rLxCuTI8cUt3LrzuFVr0forKsWXp0LJuyGM/ltWrVvLR++8wZeZ8Zs5L4ptpU1j3awqvPP8Mbc8+l++XrqLt2efyyvP+f+tBsPpcvRb2yXXJ4sWcemodatWuTalSpeh1+RV8NWlC3jv6QFGMvW279pQvX+GwsrdHvsHtd9xFVFQUAJUqVfIitGzzf/iFHbv3HVb2829/snb91n/V3XfgEN8v+5UDh9IOK68VF0vK79tI3eW8bX7Wop/pcV6T0AWdh7VrVtO8RSvKlClDiRIlaN2mPVMmfcm0KZPo3ecqAHr3uYqpkyd6FmOgCqHPtVCEfXLdtGkj8fH/fM2Li4tn48aNuezhH0U59pxS1q5h/vy5dGjbmk4dO5CctMTrkI7bL39so27NStSoWoHIyAi6dWhMfOUYz+Kpd3oDFi2Yx44d29m3bx+zZkxl04YNbNu6lcpVqgJQqXIVtm399y8QPxGciVsCXfws5De0RCQSSAI2qmrXUJ/P+E96ejo7d+xg9twFJCctoX/fy1nx8y++/1qXm11/7eemJ8fy4VMDyMxUFi7/jdrxBX6Y57jVrXc6w24ezhWXXESZMifSsFFjIiIjD6tTFL5Kg005mB9ZkyaULYRz/Uu1anFs2PBH9vrGjRuIi4vLZQ//KMqx5xQXF0+3HpciIiS0bEVERASpqalUrFjR69COy5S5K5kydyUAgy45k4yMzDz2CK2+/a+mb3/nLb5PPPIA1arFUbFSJf7cspnKVary55bNxPr+31wQ33/hD0xIuwWOnDTBCwktW5KSspbf1q3j0KFDjBvzKRd17eZVOPlSlGPPqWu37nz37WwA1q5Zw6G0Q8TGxnoc1fGrWD4agJiTSjO0V1ve/XKBp/GkbnO+8m/443emTPqSS3pewQVdujL2kw8BGPvJh3S60PtRDXkJ8twCngl1y/UFnEkTTjpWBfdZ4KEA1WvUCHoAJUqU4PkXX+HiizqRkZHBgIGDaNCwYdDPEwpFMfaB/foy97s5bE9NpW7t6tz3wEP0HziI64cOpmWzRpQqVYo3337P06+nox/vT7uEOsTGRJMy5WEeffNrdu7Zx3N3XEZs+Wg+f/Falq/ZQLcbnBEFqyc9yEknnkCpkiW4uENjug57jdXr/uTZ4ZfSqK7zTeLJt6aS8vs2z64JYHD/K9i5YzslS5TkyWdfpFxMDDfcegfXDuzLJx+8S3z1Grz53seexpgXZyiWz7NmgOQ4nu7K/cDOpAkXqup/RKQDMDyvPtcWLRJ0/qKkkMRjcpeRGZqfg8ISe+YtXodQYOtm+X941LF06nAm//shOWjZsO4ZTfXlsTMCrt+5YaXkXOYW8FQoW67/mjRBRD5U1atCeE5jTBHn96/7gQpZn+sxJk2wxGqMyZXk44+f2dwCxhjfcF7z4nUUwVEoyTXnpAnGGJMbv7dIA2UtV2OMr4RLn6slV2OMr1jL1Rhjgkzw/5wBgbLkaozxjyLw5FWgLLkaY3wlTHKrJVdjjH84Q7HCI71acjXG+Ep4pFZLrsYYvwmT7GrJ1RjjKzYUyxhjQiBMulwtuRpj/CVMcqslV2OMz4RJdrXkaozxDeeV2eGRXS25GmP8w57QMsaY0AiT3GrJ1RjjJ+LpyyuDyZKrMcZXwiS3WnI1jsgi/m6N1AUveB1CgcUm3uh1CAV28Oc/gno8wboFjDEmNMIku1pyNcb4SrgMxQrZq7WNMaYgRAJf8j6WVBeR2SKySkRWisjNbnkFEZkhImvdv8u75SIiL4lIiogsF5HmBb0OS67GGF+RfCwBSAduV9UGQGtgmIg0AO4GZqrqacBMdx2gC3CauwwFXi/odVhyNcb4R34yawDZVVU3q+pS9/NfwE9AHNAdGO1WGw30cD93B95Xx0IgRkSqFuRSLLkaY3xF8vEnX8cVOQVoBiwCKqvqZnfTFqCy+zkOyDkEYoNblm92Q8sY4xtCvse5xopIUo71kao68l/HFYkGPgNuUdU9OR9UUFUVES1YxMdmydUY4yv5HCuQqqoJuR5PpCROYv1IVT93i/8Ukaqqutn92r/VLd8IVM+xe7xblm/WLWCM8Zcg9rmK00QdBfykqs/l2DQRGOB+HgBMyFHe3x010BrYnaP7IF+s5WqM8ZUgv/21DdAP+FFElrll9wJPAWNFZDCwHujtbpsCXAikAPuAqwt6YkuuxhhfCWZqVdV5uRzyvKPUV2BYMM5tydUY4y/h8YCWJVdjjH/YmwiMMSYU7E0ExhgTGmGSWy25GmN8JkyyqyVXY4yP5P+xVr8qFg8RTJ82lcYN69Gwfh2eefopr8MJ2IEDB2h7ZitaNW9C8yYNefThEV6HlC9FLf7rhw7ilPjKtGzW6LDy1199mWaNTieh6Rncf8+dHkXneGPElayf+SRJ4+7NLru0YzOSx9/H3uSXaN6gRnZ5QsOaLPz0bhZ+ejeLxtxNt3MaAxBfOYapI29i6Wf3kTz+Pob16VDYl5GrYE456KWwb7lmZGRwy03DmPz1DOLi42nbuiVdu3bj9AYNvA4tT1FRUUydMYvo6GjS0tI49+y2XNCpC4mtW3sdWkCKWvxX9hvItdffwJBBA7LLvp0zm8mTJrIwaRlRUVFs3bo1lyOE3geTFvLGmG95+9H+2WUrf9nEFbe/xSv39zms7spfNtHmyqfJyMikSmxZFo25h8nfrSA9I5O7n/ucZas3EF0miu8/vouZi1az+tcthX05/xJOr3kJ+5brksWLOfXUOtSqXZtSpUrR6/Ir+GrShLx39AERITo6GoC0tDTS09KK1Jsxi1r8bdu1p3z5CoeVvT3yDW6/4y6ioqIAqFSpkhehZZu/9Bd27N53WNnP6/5k7fp/J/39B9LIyMgEIKpUSZzx8bAldQ/LVm8A4O99B1m9bgvVKsaENvD8CPKErl4J++S6adNG4uP/mYchLi6ejRsLNA+DJzIyMkhs0ZQa1SpxbsfzaZWY6HVI+VLU409Zu4b58+fSoW1rOnXsQHLSEq9DypeWZ9Qkefx9JI27l5se/zQ72WapUbUCTevFs2TFb94EeBShmnKwsIU0uYrIbyLyo4gsO2JaMBOgyMhIFiUvI+W3DSQtWczKFSu8Dilfinr86enp7Nyxg9lzF/D4k0/Tv+/l2S3AomDJivW06Pk4ba96mjsGXUBUqX96Ak8sXYpPnr2GO579jL/2HvAwysOFS59rYbRcz1HVpnlNCxYq1arFsWHDP3Pfbty4gbi4As1966mYmBjO7nAO06dP9TqUAimq8cfFxdOtx6WICAktWxEREUFqaqrXYeXbz+v+5O99B2lYpxoAJUpE8MmzQxjzdRITZv3P4+hyEIjIx+JnYd8tkNCyJSkpa/lt3ToOHTrEuDGfclHXbl6HFZBt27axa9cuAPbv38/Mb2ZQr159b4PKh6IeP0DXbt357tvZAKxds4ZDaYeIjY31OKrA1Kx2MpGRzn/xGlXLU69WFdZv2g44ow5+XreFlz6c5WWIxxAena6hHi2gwHR3lu83jzFD+FCcF4FRvUaNIzcftxIlSvD8i69w8UWdyMjIYMDAQTRo2DDo5wmFLZs3M2TQADIyMsjUTC7r2ZsLL+rqdVgBK2rxD+zXl7nfzWF7aip1a1fnvgceov/AQVw/dDAtmzWiVKlSvPn2e57elBv95EDatTiN2JhoUqY+yqNvTGHn7r08d1cvYstH8/lL17H85410G/YqZzWrzfCrLyAtPYPMTOXmJ8awfddezmpamyu7JvLjmo0s/NR5L9+IVyYybd4qz64rSwHeROBbEsr+IxGJU9WNIlIJmAHcqKrfHat+ixYJOn+Rdc2a/MvILDr9oEeKTbzR6xAK7ODPY8nctzVo6bBJsxb69ewFAdePKx+V7FWXY15C2i2gqhvdv7cCXwCtQnk+Y0zRZze08iAiJ4rISVmfgQuAonWr2BhT6MJlKFYo+1wrA1+4/VMlgI9VtWjdKjbGFD5/58yAhSy5quqvQJNQHd8YE57CJLeG/9wCxpiioyj0pQbKkqsxxlf83pcaKEuuxhh/CY/casnVGOMvYZJbLbkaY/xEiAiTTldLrsYY3winx1/DfuIWY4zxgrVcjTG+Ei4tV0uuxhhfsaFYxhgTbPYQgTHGBJ//p8AOnCVXY4y/hEl2teRqjPEV63M1xpgQCJc+VxvnaozxlWC/nlBEOovIzyKSIiJ3hyDko7LkaozxlyBmVxGJBF4FugANgD4i0iAUYR/JugWMMb4hEOy5BVoBKe7k/YjIp0B3IOSvuvVVcl26NDm1dElZH6LDxwKpITp2YSjK8Vvs3gl1/DWDebClS5OnlS4psfnY5QQRyfnK6JGqOjLHehzwR471DUDi8cQYKF8lV1WtGKpji0iSX1/BG4iiHL/F7p2iFr+qdvY6hmCxPldjTDjbCFTPsR7vloWcJVdjTDhbApwmIrVEpBRwBTCxME7sq26BEBuZdxVfK8rxW+zeKerxHxdVTReRG4BpQCTwjqquLIxzi6oWxnmMMaZYsW4BY4wJAUuuxhgTApZcjTEmBCy5mqATkVYi0tL93EBEbhORC72OqyBE5H2vYzBFU3EaLVBkiEh9nCdLFqnq3znKO6vqVO8iy5uIjMB5jruEiMzAeRpmNnC3iDRT1cc9DTAXInLkEB0BzhGRGABV7VboQR0HEWmL8/jnClWd7nU8xU2xGy0gIler6rtex3EsInITMAz4CWgK3KyqE9xtS1W1uYfh5UlEfsSJOwrYAsSr6h4RKY3zy6Kxl/HlRkSW4jxz/jagOMn1E5yxkajqt95FlzcRWayqrdzPQ3B+jr4ALgAmqepTXsZX3BTHboGHvQ4gD0OAFqraA+gAPCAiN7vbisJMl+mqmqGq+4BfVHUPgKruBzK9DS1PCUAycB+wW1XnAPtV9Vu/J1ZXyRyfhwLnq+rDOMn1Sm9CKr7CsltARJYfaxNQuTBjKYCIrK4AVf1NRDoA40WkJkUjuR4SkTJucm2RVSgi5fB5clXVTOB5ERnn/v0nRev/SISIlMdpNImqbgNQ1b0iku5taMVPUfrByY/KQCdg5xHlAnxf+OHky58i0lRVlwGo6t8i0hV4B2jkaWSBaa+qByE7WWUpCQzwJqT8UdUNQC8RuQjY43U8+VAOp+UtgIpIVVXdLCLRFI1fzGElLPtcRWQU8K6qzjvKto9Vta8HYQVEROJxvlpvOcq2Nqo634OwTBEmImWAyqq6zutYipOwTK7GGOO14nhDyxhjQs6SqzHGhIAl1zAkIhkiskxEVojIOLfPraDHek9Eerqf387t5W4i0kFEzirAOX4T+ferPY5VfkSdv3PbfpT6D4nI8PzGaEx+WXINT/tVtamqngEcAq7LuVFECjRKRFWvUdXcXuzWAch3cjUmHFlyDX9zgTpuq3Ku+4jnKhGJFJFnRGSJiCwXkWsBxPGK+573b4BKWQcSkTkikuB+7iwiS0XkfyIyU0ROwUnit7qt5nYiUlFEPnPPsURE2rj7niwi00VkpYi8TQDDhETkSxFJdvcZesS2593ymSJS0S07VUSmuvvMdR8pNqbQhOs4V0N2C7ULkDUfQXPgDFVd5yao3araUkSigPkiMh1oBtTDecd7ZZzHQd854rgVgbdwxrSuE5EKqrpDRN4A/lbVZ916HwPPq+o8EamBMxv86cAIYJ6qPuKOJR0cwOUMcs9RGlgiIp+p6nbgRCBJVW8VkQfdY9+AMwP/daq6VkQSgdeAcwvwz2hMgVhyDU+lRWSZ+3kuMArn6/riHGMdLwAaZ/Wn4gxAPw1oD3yiqhnAJhGZdZTjtwa+yzqWqu44RhwdgQbyz3voy7oD2tsDl7r7ThaRIx/2OJqbROQS93N1N9btOE99jXHLPwQ+d89xFjAux7mjAjiHMUFjyTU87VfVpjkL3CSzN2cRcKOqTjuiXjCnBowAWqvqgaPEEjD3EeCOwJmquk9E5gAnHKO6uufddeS/gTGFyfpci69pwPUiUhJAROqKyInAd8Dlbp9sVeCco+y7EGgvIrXcfSu45X8BJ+WoNx24MWtFRJq6H78D+rplXYDyecRaDtjpJtb6OC3nLBFAVuu7L053wx5gnYj0cs8hItIkj3MYE1SWXIuvt3H6U5eKyArgTZxvMl8Aa91t7wMLjtzRnRBkKM5X8P/xz9fyScAlWTe0gJuABPeG2Sr+GbXwME5yXonTPfB7HrFOxZkf9ifgKZzknmUv0Mq9hnOBR9zyK4HBbnwrge4B/JsYEzT2+KsxxoSAtVyNMSYELLkaY0wIWHI1xpgQsORqjDEhYMnVGGNCwJKrMcaEgCVXY4wJgf8H6qBtaVaIOdUAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Predict the values from the validation dataset\n",
+    "Y_pred = model.predict(x_test)\n",
+    "# Convert predictions classes to one hot vectors \n",
+    "Y_pred_classes1 = np.argmax(Y_pred,axis = 1) \n",
+    "# Convert validation observations to one hot vectors\n",
+    "Y_true = np.argmax(y_test,axis = 1) \n",
+    "# compute the confusion matrix\n",
+    "confusion_mtx = confusion_matrix(Y_true, Y_pred_classes1) \n",
+    "# plot the confusion matrix\n",
+    "plot_confusion_matrix(confusion_mtx, \n",
+    "            classes = ['1','2','3','4','5'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aerial-pastor",
+   "metadata": {
+    "papermill": {
+     "duration": 1.412383,
+     "end_time": "2021-04-25T15:08:24.375531",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:22.963148",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Model 2:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "manufactured-calvin",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:08:27.230458Z",
+     "iopub.status.busy": "2021-04-25T15:08:27.229260Z",
+     "iopub.status.idle": "2021-04-25T15:08:28.893198Z",
+     "shell.execute_reply": "2021-04-25T15:08:28.892326Z"
+    },
+    "papermill": {
+     "duration": 3.095183,
+     "end_time": "2021-04-25T15:08:28.893345",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:25.798162",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAVcAAAEmCAYAAADWT9N8AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAA1aklEQVR4nO3dd3wU1fr48c+ThKb0EjpiQbpA6FVApImCCkgTUBS8ohfbT71yFRVFrxVQEFH0Yv0qKlKlSJNeQhNQJAhcOqF3TXl+f+wkBiTJJuxmJpvn7WtemTlzduYZ7t5nz549c0ZUFWOMMYEV5nYAxhgTiiy5GmNMEFhyNcaYILDkaowxQWDJ1RhjgsCSqzHGBIEl1xxKRPKJyDQROSEiky7jOL1FZE4gY3OLiDQXka1ux2FCg9g4V28TkV7AY0AV4BSwHnhZVZdc5nHvBh4Gmqhq/OXG6XUiokAlVY1xOxaTM1jL1cNE5DFgJDACKAlUAMYCnQNw+KuA33JCYvWHiES4HYMJMapqiwcXoBBwGuiWRp08+JLvPmcZCeRx9rUE9gCPA4eA/cA9zr4XgD+BOOccA4Dngc9SHLsioECEs90f+B1f63kH0DtF+ZIUr2sCrAZOOH+bpNi3EBgOLHWOMwconsq1JcX/ZIr4uwAdgd+Ao8AzKeo3AJYDx5267wK5nX0/Oddyxrneu1Ic/yngAPBpUpnzmmudc0Q522WAWKCl2+8NW7LHYi1X72oM5AUmp1FnKNAIqA3Uwpdg/p1ifyl8SbosvgQ6RkSKqOowfK3hr1Q1v6pOSCsQEbkSGA10UNUC+BLo+kvUKwrMcOoWA94CZohIsRTVegH3AJFAbuCJNE5dCt+/QVngOeADoA9QF2gOPCsiVzt1E4BHgeL4/u1uAh4EUNUWTp1azvV+leL4RfG14gemPLGqbseXeD8TkSuAj4GJqrowjXiNSWbJ1buKAYc17a/tvYEXVfWQqsbia5HenWJ/nLM/TlVn4mu1Vc5kPIlADRHJp6r7VXXzJercAmxT1U9VNV5VvwR+BW5NUedjVf1NVc8BX+P7YEhNHL7+5Tjg//AlzlGqeso5/xZ8HyqoarSqrnDOuxN4H7jRj2sapqp/OPFcQFU/AGKAlUBpfB9mxvjFkqt3HQGKp9MXWAbYlWJ7l1OWfIyLkvNZIH9GA1HVM/i+Sj8A7BeRGSJSxY94kmIqm2L7QAbiOaKqCc56UvI7mGL/uaTXi8j1IjJdRA6IyEl8LfPiaRwbIFZVz6dT5wOgBvCOqv6RTl1jklly9a7lwB/4+hlTsw/fV9okFZyyzDgDXJFiu1TKnao6W1VvxteC+xVf0kkvnqSY9mYypox4D19clVS1IPAMIOm8Js2hMiKSH18/9gTgeafbwxi/WHL1KFU9ga+fcYyIdBGRK0Qkl4h0EJHXnGpfAv8WkRIiUtyp/1kmT7keaCEiFUSkEPCvpB0iUlJEOjt9r3/g615IvMQxZgLXi0gvEYkQkbuAasD0TMaUEQWAk8Bpp1X9j4v2HwSuyeAxRwFrVPU+fH3J4y47SpNjWHL1MFV9E98Y13/j+6V6N/AQ8L1T5SVgDbAR+BlY65Rl5lxzga+cY0VzYUIMc+LYh+8X9Bv5e/JCVY8AnfCNUDiC75f+Tqp6ODMxZdAT+H4sO4WvVf3VRfufByaKyHER6Z7ewUSkM9Cev67zMSBKRHoHLGIT0uwmAmOMCQJruRpjTBBYcjXGmCCw5GqMMUFgydUYY4LAU5NVSK58KnkKuR1GptSsVDb9Sh4m6Y0I9bjw7H4B2dSuXTs5fPhwwP7xwwtepRr/t5vlUqXnYmeravtAnT+QvJVc8xQiT42+boeRKXPmvOx2CJclIjx7J6cr83jqrZxjNG1YL6DH0/jz5KnSw+/659e9k95deK6xd6QxxjuE7P81ymHJ1RjjLRIaPwVZcjXGeIu1XI0xJtDEWq7GGBMU1nI1xpgAE6zlaowxgSfWcjXGmKCwlqsxxgSBtVyNMSbQbLSAMcYEngBh4W5HERCWXI0xHmItV2OMCY4w63M1xpjAsnGuxhgTJDZawH3jhnajQ9OqxB47Tb3ebwFQpGA+Pn2pN1eVLsqu/UfpM/Rzjp86x6O9b+SudnUAiAgPo0rFSMp3eIHihfPz6Ut/PS356rJFGT5+Du9+tcSVawJ4f8woPv/kI0SEqtVqMHLsh/zr8X+yYX00qso111Zi9HsTuDJ/ftdiTEudateRP39+wsPDCY+IYN7ilWz6eQNPDBnMmdOnKX9VRd6f8AkFChZ0O9RUDbrvXn6YOZ0SkZFEr9/kdjgZln3jD50+12x9FZ/OWEPnRydcUPZE31YsXB1DzW6vsXB1DE/0bQnA258volHfkTTqO5Ln3vuBxet+59jJc2z7X2xyeZP+ozh7Po6pi9x7M+7ft5cPx41h9sIVLFqxnoSEBL7/9mtefOUN5i+NZsGytZQrX4GPxo91LUZ/fD/zRxYuj2be4pUAPDJ4EM++MILFq9Zzy62deXfkmy5HmLa7+/VnyvRZboeRadk6fhH/Fw/L1sl16fodHD159oKyTs2r89nMaAA+mxnNrS1q/O113W+uzddz1/+tvFW969ix9wj/O3A8GOH6LSEhnvPnzhEfH8+5c+coVap0citPVTl37pzn31gX2x6zjSbNmgPQsnUbpk2Z7HJEaWvWvAVFixZ1O4xMy9bxS5j/i4d5O7pMiCyanwNHTgFw4MgpIote+NU5X55c3NyoMt8v+Plvr+12c22+nrM+K8JMVekyZfnHw49St8a13HB9BQoWLEjLm24GYMiD91GzUnlitm1lwKDBrsaZFhGha+cOtG7WgIkffQBAlarV+GH6VACmTP6GvXt3uxmi8aqMtFr9aGCIyEcickhENqUoKyoic0Vkm/O3iFMuIjJaRGJEZKOIRKV4TT+n/jYR6efPpQQtuV7qotygqhds39K8Gst/3smxkxc+BC1XRDi3NK/Gd/M3ZmV4f3P82DFmzZjGqo2/sWHrLs6ePcM3X30OwKixH7Jh6y4qXV+FKd9NcjXOtMyYu5AFS1fz1XfT+Wj8eyxbspjRYz/gow/G0bpZA06fOk3u3LndDtN4VWBbrv8FLn6A4dPAPFWtBMxztgE6AJWcZSDwHviSMTAMaAg0AIYlJeS0BLPl+l/+flFBd+joaUoVKwBAqWIFiD125oL93drUYtIlWqftGldm/da9HDp6OivCTNVPC+dR4aqKFC9egly5ctHx1i6sXrkieX94eDhd7uzOjKne/VpduozvSbglIiPpeGsX1kavplLlKnwz9QfmL1nFHd3uouLV17gcpfGsALZcVfUn4OhFxZ2Bic76RKBLivJP1GcFUFhESgPtgLmqelRVjwFz8SO3BS25pnJRQTdj8Rb6dKwLQJ+OdZm+eHPyvoJX5qVZnWuY9tPmv72ue1v3uwQAypWvQPSalZw9exZVZfGiBVSqXIUd22MAX0t89szpXFepssuRXtqZM2c4depU8vrC+XOpWq06sYcOAZCYmMhbr42g/4CBboZpPEuyos+1pKrud9YPACWd9bJAyv6qPU5ZauVpcr3PVUQGisgaEVmjcf4/rxxg4ou9WPjBYK6/qgQxU5+h3631eeOTBbRuUImfJz1JqwaVeOOTBcn1b2tZnXmrfuPs+bgLjnNF3ly0blCJKQvdH7ISVa8BnTrfQdsWDWjZuA6amMjd/e/jn/8YQMvGdWjZuA6HDu7n8aeGuh3qJcUeOkinm2/kxkZRtL2xCTe368hNN7fju0n/R4Pa1WgUVYNSpcvQ6+7+boeapr59etKyeWN+27qVayuW478fTUj/RR6SbeNPmlvA3wWKJ+UPZ8nQp7b6+g013YqZuZSL+yQDenCRisB0Vf37T/aXEJa/lOap0Tdo8QTTzjkvux3CZYkIz16jDy52ZZ5sPWQ722rasB7R0WsC9uYJK3yV5mn+lN/1z08fHK2q9dKqc3EeEpGtQEtV3e987V+oqpVF5H1n/cuU9ZIWVR3klF9QL9Vr8fsqjDEmKwR/nOtUIOkX/37AlBTlfZ1RA42AE073wWygrYgUcX7IauuUpck+7o0x3hLA8asi8iW+lmdxEdmD71f/V4GvRWQAsAvo7lSfCXQEYoCzwD0AqnpURIYDq516L6pqur8nBS25XuqiVDWbdPwYY1wTwBtkVLVnKrtuukRdBS45gFxVPwI+ysi5g5Zc07goY4y5NAmduQWsW8AY4y3Z7Nbu1FhyNcZ4ilhyNcaYwBIsuRpjTOCJs4QAS67GGA8Ra7kaY0wwWHI1xpggsORqjDGBJiD2aG1jjAkssT5XY4wJDkuuxhgTBJZcjTEmCCy5GmNMoNlNBMYYExzWcjXGmACz0QLGGBMkllyNMSYYQiO3eiu51rq+HPPnv+J2GJlSpuMIt0O4LDHf+//ETS+6Mo/bEZiAEGu5GmNMUFhyNcaYABOEsDB7hpYxxgReaDRcLbkaYzzE+lyNMSY4LLkaY0wQWHI1xphgCI3casnVGOMt1nI1xpgAE7G5BYwxJigsuRpjTBBYcjXGmGAIjdxqydUY4y3WcjXGmECzO7SMMSbwfBO3hEZyDY3pZ4wxIUPE/8W/48mjIrJZRDaJyJcikldErhaRlSISIyJfiUhup24eZzvG2V8xs9cRssk1ISGBGxvXo8edtwHw08L5tGxSnyb1avHg/fcQHx/vanzjnryVXZMfY83Hg5LLihTIy/Q3evPzZw8y/Y3eFM6f94LX1K1cmlPzhnL7jVUBqFCyEMvG38eKD+8n+uMHuO+2qCy9hiSPPzSQWpXKcVPjOsllx44dpeftHWhWtxo9b+/A8ePHAIj57Vdua9uCa0oWYNw7b7kSrz8G3XcvFcpEUrd2DbdDyZTz58/TrHEDGkTVIqpWdYa/MMztkPyWNNbVn8WPY5UF/gnUU9UaQDjQA/gP8LaqXgccAwY4LxkAHHPK33bqZUrIJtdxY0ZzfeUqACQmJvLgwHv5cOLnLFuzgXIVKvDl55+4Gt+nszbQ+ckvLih7oldTFq7dQc0+Y1m4dgdP9GqavC8sTHhp0E38uHp7ctn+I6doOfhjGt33AS0enMATvZpSulj+LLuGJN163s1n30y7oGzM26/TtEVrlkRvoWmL1ox5+3UAChcpyouvvsWghx7N8jgz4u5+/ZkyfZbbYWRanjx5mDV3PqvWbmDlmvXMmT2LlStWuB1W+jLQas1A12wEkE9EIoArgP1Aa+AbZ/9EoIuz3tnZxtl/k2SyEzgkk+vevXuYO2smd/e/F4CjR46QO3durqt0PQCtWrdh2vffuRkiSzf+j6Onzl1Q1qlpZT6btRGAz2Zt5NZmlZP3PXhHfb7/6Vdij59NLouLT+TPuAQA8uSKIMylHwIaNW1O4SJFLiib88M0uvXsA0C3nn2YPXMqAMVLRFI7qh4RuXJleZwZ0ax5C4oWLep2GJkmIuTP7/ugjYuLIz4uLlv8UCT4GhL+LkBxEVmTYhmY8niquhd4A/gfvqR6AogGjqtq0tfXPUBZZ70ssNt5bbxTv1hmriUkk+szTz7G8y+/mjyjebHixYmPj2fd2jUATJn8HXv37HEzxEuKLHolB46eBuDA0dNEFr0SgDLFC3BbsyqMn7Lmb68pV6IgqyYMZNvXQ3jzy2XsP3I6S2NOzeFDhyhZqjQAkSVLcfjQIZcjynkSEhJoWLc2FcpE0rrNzTRo2NDtkPySwZbrYVWtl2IZf+GxpAi+1ujVQBngSqB9VlxH0JKriJQXkQUissXpTB4SrHOlNPuH6ZQoEUntOnVTxsKHEz9n6FOP06ZFIwoUyE94eHhWhHNZVBWA1x9qy7/Hz8PZvMCe2JM0GDCeGr3fpU+7G4gscmUWR5m+ULpfPDsJDw9nZfR6YnbuYc3qVWzetMntkPwSyD5XoA2wQ1VjVTUO+A5oChR2ugkAygF7nfW9QHknjgigEHAkM9cRzKFY8cDjqrpWRAoA0SIyV1W3BPGcrFy+jB9mTGPu7B/44/x5Tp06yaB7+/L+R58wc+4iAOb/OIeYmG3BDCNTDh09Q6mi+Tlw9DSliuYn9pivCyCqcmk+ee4OAIoVuoJ2Da8jPiGRaUu2Jr92/5HTbN4RS9MbKjB50S+uxJ9S8chIDh7YT8lSpTl4YD/FSpRwO6Qcq3DhwtzYshVz5syieg2P/0CXsb5Uf/wPaCQiVwDngJuANcACoCvwf0A/YIpTf6qzvdzZP1/1Us2a9AWt5aqq+1V1rbN+CviFv/o1gua5F0ewedsuNvyynQ8nfk7zG1vx/kefEOt8Lf3jjz8Y/dbr3DNgYDpHynozlm2lT/sbAOjT/gamL/Ulz6o936VKj3eo0uMdJi/6hUdG/sC0JVspW6IAeXP7Ph8L589Lk5rl+e1/mfqQDbib23di0pefATDpy89o2+FWlyPKWWJjYzl+/DgA586dY96Pc6ns/MDrZUJgW66quhLfD1NrgZ/x5bzxwFPAYyISg69PdYLzkglAMaf8MeDpzF5LltxE4IwVqwOszIrzXco7I99g9qyZaGIi99w3iBYtW7sVCgATn72d5rWvonihK4iZNIThHy/ijS+W8dmwO+nXsTb/O3iCPs9/m+YxKlcozqsP3oyq79N+5FfL2bwj6/s2Bw+4m+VLf+LokcPUq34Njz/9LA89+v944J5e/N9nH1OufAXe+9g3MuLQwQN0bN2E06dOEiZhfDjuXRYsX0+BggWzPO609O3Tk8WLFnL48GGurViOZ597gf73Dkj/hR5xYP9+7r+3HwkJCSRqInd27U7HWzq5HZYfAt+FpKrDgIvHov0ONLhE3fNAt0CcVzLZ4vX/BCL5gUXAy6r6t5/onV/3BgKUK1+h7sZffw9qPMFSpuMIt0O4LDHfP+V2CJelWP7cboeQIzVtWI/o6DUBy4ZXlKms1w8c63f9DS+0iVbVeoE6fyAFdbSAiOQCvgU+v1RiBVDV8Um/9BUvbv1yxuR0Af5ByzVB6xZwBt5OAH5RVe/eimOM8QwRbG4BPzQF7gZai8h6Z+kYxPMZY0JAEO7QckXQWq6quoSQmfbWGJNVvP5131825aAxxlNCJLdacjXGeIhNlm2MMYHnu4nA7SgCw5KrMcZDvD/Eyl+WXI0xnhIiudWSqzHGW6zlaowxgZYNxq/6y5KrMcYzkmbFCgWWXI0xnmLJ1RhjgiBEcqslV2OMh4TQxC2WXI0xniE2ztUYY4IjRHKrJVdjjLeEhUh2teRqjPGUEMmtllyNMd4hNiuWMcYER4gMFvBWchWBXOHZ8192/8xn3A7hspRuOsTtEC5L7IrRboeQaRHhQX1OaLZjLVdjjAmCEMmtllyNMd4h+Ma6hoJUk6uIvANoavtV9Z9BicgYk6PlhD7XNVkWhTHGAEgOuENLVSem3BaRK1T1bPBDMsbkVAKEh0jTNd2fKUWksYhsAX51tmuJyNigR2aMyZFE/F+8zJ8xICOBdsARAFXdALQIYkzGmBxMnK4BfxYv82u0gKruvuhCEoITjjEmJ8sOLVJ/+ZNcd4tIE0BFJBcwBPgluGEZY3KqUJm4xZ9ugQeAwUBZYB9Q29k2xpiAkwwsXpZuy1VVDwO9syAWY4zxfF+qv/wZLXCNiEwTkVgROSQiU0TkmqwIzhiTswi+mwj8Xfw6pkhhEflGRH4VkV+cEVBFRWSuiGxz/hZx6oqIjBaRGBHZKCJRmb0Wf7oFvgC+BkoDZYBJwJeZPaExxqQqAyMFMtDCHQXMUtUqQC18vxk9DcxT1UrAPGcboANQyVkGAu9l9lL8Sa5XqOqnqhrvLJ8BeTN7QmOMSUsgx7mKSCF8Q0cnAKjqn6p6HOgMJN0oNRHo4qx3Bj5RnxVAYREpnZnrSGtugaLO6g8i8jTwf/jmGrgLmJmZkxljTHoy2OdaXERS3qo/XlXHp9i+GogFPhaRWkA0vhFPJVV1v1PnAFDSWS8L7E7x+j1O2X4yKK0ftKLxJdOkKx2UYp8C/8royYwxJi1Jfa4ZcFhV66WxPwKIAh5W1ZUiMoq/ugAAUFUVkVQnqcqstOYWuDrQJzPGmPQEeLTAHmCPqq50tr/Bl1wPikhpVd3vfO0/5OzfC5RP8fpyTlmG+TUFuojUEJHuItI3acnMybLKnt276dj2JurVrkH9OjUZ+65vlvrhzz9Ho3q1adIgis63tGP/vn0uR5q6hIQEWjSux1133gbAogXzuLFJfZo3qkv7Ni34fXuMq/GNG9abXfNeYc2kv57AcEebOkR/M5Qz0aOJqlbhgvpP3NuWTVOGsWHys7RpXDW5/NcZL7D662dY8X9Ps+TzJ7Ms/ktJ7X2TZPTItyiQN5zDhw+7FKH/zp8/T7PGDWgQVYuoWtUZ/sIwt0PyiwiEi/i9pEdVD+C7EaqyU3QTsAWYCvRzyvoBU5z1qUBfZ9RAI+BEiu6DDPFnKNYw4B1naQW8BtyWmZNllYiICEb853XWrN/E/J+WMX7cWH79ZQtDHnuCFWvWs2zVWtp37MSrI4a7HWqqxo0ZzfWVqyRvP/7IQ4z/6BMWr4ima/eevPGfES5GB59OW0HnwWMuKNu8fR89Hv+AJWu3X1Be5ZpSdGsXRVTXl7lt8FhG/as7YSm++7UfOIpGPV6lWe/XsiT21KT2vgFf4p3/4xzKl6+QzlG8IU+ePMyaO59Vazewcs165syexcoVK9wOyy9BmLjlYeBzEdmI7yaoEcCrwM0isg1o42yD7/ek34EY4APgwcxehz8t1674sv0BVb0H31CGQpk9YVYoVbo0tev4hqcVKFCAylWqsG/vXgoWLJhc58yZM54drLx37x7mzJpJ3/73JpeJCKdOnQTg5IkTlCqdqR8wA2bp2u0cPXHhDJRbdxxk265Df6vbqeUNTJq9lj/j4tm17wjbdx+mfo2KWRSp/1J73wA8/eRjDB/xH8++Zy4mIuTPnx+AuLg44uPislXsgRyKparrVbWeqt6gql1U9ZiqHlHVm1S1kqq2UdWjTl1V1cGqeq2q1lTVTM9r7c/cAudUNVFE4kWkIL6+ifLpvcgrdu3cycb166nXoCEALzz3b778/FMKFirEjNnzXI7u0p558jFeePlVTp86lVw2asz7dL/jVvLlzUeBggWZs2CpixFmTNkShVj5887k7b2HjlEm0vf5rKpMG/sQqsqEb5fy0XfeuK6U75vp06ZQpkxZat5Qy+2wMiQhIYEmDeqyfXsMg/4xmAYNG7odkl+yyWdAuvxpua4RkcL4msjRwFpgeXovEpG8IrJKRDaIyGYReeHyQs2406dP06dnN159463kVuuwF1/i1+276N6jF+PfG5POEbLerB+mU7xEJLXr1L2g/L13R/H1d9PYvG0Xvfr0499PP+FShIF10z1v06TXf+jy0FgG3dWcplHXuh3SBe+biIgI3nztVYY+l+Vv38sWHh7Oyuj1xOzcw5rVq9i8aZPbIaVLEMLE/8XL0k2uqvqgqh5X1XHAzUA/p3sgPX8ArVW1Fr5+jvZOB3GWiIuLo0+PrnTv0YvOXe742/67evRiyvffZVU4flu5fBmzZkzjhqrXMqBfbxYvWkD3O25l088bqVff1/K4vWt3Vq1M9/PNM/bGnqBcqSLJ22Uji7Dv0AkA9sX6/sYeO83U+RupX72iGyEmu/h9s+P37ezcuYMm9etQ/fpr2Lt3D80b1ePggQOuxpkRhQsX5saWrZgzZ5bboaQvA/2tHs+tqSdXEYm6eAGKAhH+3G/r9F2cdjZzOUvAx5Klcm4GD7qPylWq8vCQR5PLY2K2Ja/PmD6V6ytXvtTLXTXsxRFs3raLjb9sZ8LEz2l+Yyu++HoyJ0+eIGbbbwAsnP/jBT92ed2MhRvp1i6K3LkiuKpMMa6rUILVm3ZyRd7c5L8iDwBX5M1Nm8ZV2LzdvREcl3rfVK9Rkx27D7D5t9/Z/NvvlC1bjsUr1lCyVCnX4vRHbGwsx48fB+DcuXPM+3EulbPJeyYnTJb9Zhr7FGid3sFFJBxfV8J1wJgUY81S1hmI7x7egP0Su3zZUr784jOq16hJkwa+z4FhL77EJ//9iG2//UZYWBjlK1Rg1DuZvm04S0VERDDq3ffp26s7YWFhFC5SmHff+9DVmCa+0p/mdStRvHB+YmYNZ/i4mRw7cYa3nupG8SL5+W70A2zcupfbBo/hl98P8O2cdaz7dijxCYk88urXJCYqkcUK8NVb9/uuMTycr35Yw9xl7k0VnNr7pl37jq7FlFkH9u/n/nv7kZCQQKImcmfX7nS8pZPbYfnFr/Gh2YCoBr8x6fTZTsZ3l0SqHT9RdevpT8tWBT2eYIhPyJJGedCUbjrE7RAuS+yK0elX8qiI8OybTpo2rEd09JqANSFLXldD73rjG7/rv3N71eh07tByTZb8r+pMlLAAaJ8V5zPGZF+BnnLQLUFLriJSwmmxIiL58P0Y9muwzmeMCQ2hklz9ekBhJpUGJjr9rmHA16o6PYjnM8Zkc75RAB7Pmn5KN7mK70p7A9eo6osiUgEopappdo6q6kagTmDCNMbkFNm4C/oC/lzGWKAx0NPZPgV4b/S9MSbb8005GBo3EfjTLdBQVaNEZB2Aqh4TkdxBjssYk0OFSMPVr+Qa5/SbKvh+qAISgxqVMSbH8niD1G/+JNfR+MaoRorIy/hmyfp3UKMyxuRIkg2+7vsr3eSqqp+LSDS+aQcF6KKq7t1GY4wJaSGSW/0aLVABOAtMS1mmqv8LZmDGmJzJ6+NX/eVPt8AM/npQYV58T1PcClQPYlzGmBwoabRAKPCnW6Bmym1nRqxMP/rAGGPSEiK5NeN3aKnqWhHJHlOaG2Oyl2xwW6u//OlzfSzFZhi+Z4B797GpxphsTQiN7OpPy7VAivV4fH2w3wYnHGNMTubrc3U7isBIM7k6Nw8UUNXQeGCTMcbzQj65ikiEqsaLSNOsDMgYk3MJEB4i2TWtlusqfP2r60VkKjAJOJO0U1W993Q/Y0z2lg0ePOgvf/pc8wJH8D0zK2m8qwKWXI0xAZcTxrlGOiMFNvFXUk2SvR8YZYzxpJzyg1Y4kB8uOS7CkqsxJihCpOGaZnLdr6ovZlkk+LJ4dn0SZkS42xFcnj1LRrodwmUp0eifboeQaXuz8b99QsCfHi2E5YBxrqFxhcaYbEPIGS3Xm7IsCmOMgZxx+6uqHs3KQIwxBnLGaAFjjMlSOaVbwBhjspy1XI0xJghCJLeGzFNsjTEhQATCRfxe/DumhIvIOhGZ7mxfLSIrRSRGRL4SkdxOeR5nO8bZX/FyrsWSqzHGUyQDi5+GACkfqvof4G1VvQ44BgxwygcAx5zyt516mWbJ1RjjGUnP0PJ3Sfd4IuWAW4APnW3BN0/KN06ViUAXZ72zs42z/yanfqZYcjXGeEoGW67FRWRNimXgRYcbCTwJJDrbxYDjqhrvbO8ByjrrZYHdAM7+E079TLEftIwxnpLBtuJhVa136eNIJ+CQqkaLSMvLjyxjLLkaYzxEuIxv4hdrCtwmIh3xTZ1aEBgFFE56GABQDtjr1N8LlAf2iEgEUAjfdKuZYt0CxhjPEHxJyd8lLar6L1Utp6oVgR7AfFXtDSwAujrV+gFTnPWpzjbO/vmqmZ+ZxpKrMcZTRMTvJZOeAh4TkRh8faoTnPIJQDGn/DHg6cu5DusWMMZ4SjDuIVDVhcBCZ/13oMEl6pwHugXqnJZcjTHeIQSyz9VVId8tsHv3btq1aUWdG6oRVas6744e5XZIGTLovnupUCaSurVruB2KX04cP849ve+iUZ0aNI6qyeqVy5ny3Tc0rVeLEgVys27tGrdDZNyw3uya9wprJj2TXHZHmzpEfzOUM9GjiapW4YL6T9zblk1ThrFh8rO0aVw1ufzh3q2I/mYoayY9w8RX+pMnt7ttldrVrqNZg9rc2LgurZs3BGDEi8No3rAONzauy523dWD//n2uxpieQPa5us3r8V22iIgIXn3tTdZt3MKiJSt4f9wYftmyxe2w/HZ3v/5MmT7L7TD89syTj9L65rasWLeJRSuiub5yVapWq85/v/iaxk2bux0eAJ9OW0HnwWMuKNu8fR89Hv+AJWu3X1Be5ZpSdGsXRVTXl7lt8FhG/as7YWFCmRKFeLDnjTTt/Rr1uo0gPCyMbu3qZuVlXNKUmT+yaHk08xevBOChRx5n8cp1LFoeTdv2HXnjlZdcjjB9WdDnmiVCvlugdOnSlC5dGoACBQpQpUpV9u3bS9Vq1VyOzD/Nmrdg186dbofhl5MnTrB86RLeff8jAHLnzk3u3LkpVLiwu4FdZOna7VQoXfSCsq07Dl6ybqeWNzBp9lr+jItn174jbN99mPo1KrJ7/1EiwsPJlycXcfEJ5Mubm/2xJ7Ii/AwpWLBg8vrZs2ezxawo3o/QPyHfck1p186drF+/jvoNGrodSkjatWsHxYoX5+EHBtCqST2GDB7ImTNn3A7rspQtUYg9B44lb+89dIwykYXYF3uCkZ/M47cfhrNj7sucPH2OeSt+dTFSX4uva+cOtG7WgIkffZBc/tLzz1Kz8tV889WX/Ovfz7sXoB+EwE/c4pagJ9eLZ6Rxy+nTp+nZ/U5ef3PkBZ/mJnDi4+PZuH4d99w3iAXL1nDlFVcy+s3X3A4rKAoXyEenljWp2mkY17QdypX5ctOjY31XY5oxdyELlq7mq++mM2H8eyxbshiAfz8/nJ+37qDrXT358P2xrsboDxH/Fy/LipbrxTPSZLm4uDh6dr+Tu3r2psvtd7gZSkgrU7YcZcqWo2593zeDW7vcyYYN61yO6vLsjT1BuVJFkrfLRhZh36ETtG5YhZ37jnD42Gni4xP5fv4GGtW62sVIoUwZ3y3yJSIjueXWLqyNXn3B/m539WTalMluhJYBkqH/vCyoyfXiGWncoKo8cP8AKlepypBHH3MrjByhZMlSlC1bjm2/bQXgp4XzqVylajqv8rYZCzfSrV0UuXNFcFWZYlxXoQSrN+1k94GjNKh5Nfny5gKgVYPKqfbbZoUzZ85w6tSp5PUF8+dStVp1tsdsS64zc/pUKl1f2a0Q/RYqLddg/6A1Et+MNAVSq+DMYjMQoHyFCqlVy7RlS5fyxeefUqNGTRrWrQ3ACy+NoH2HjgE/VzD07dOTxYsWcvjwYa6tWI5nn3uB/vcOSP+FLnnlzZE8MKAvcX/+yVVXX8M7733IjKnf8/QTj3DkcCy97uxMjRtqMWnKTNdinPhKf5rXrUTxwvmJmTWc4eNmcuzEGd56qhvFi+Tnu9EPsHHrXm4bPIZffj/At3PWse7bocQnJPLIq1+TmKis3rSLyT+uY/kXTxGfkMiGX/cw4dulrl1T7KGD9O3pu6MzPj6BO7v34Kab29GvV3ditv1GWJhQvsJVvDFqTDpHcpdvKJbHs6af5DJunU37wL4ZaTqq6oPOjDRPqGqntF5Tt249XbrS/XGQOdGZP+LTr+Rh5Zo94nYImbZ3yUi3Q8i01s0bsn5tdMCy4fU1aus7X8/1u3776pHRqc2K5bZgtlz/NiONiHymqn2CeE5jTDbn9a/7/gpan2sqM9JYYjXGpClUftAK+ZsIjDHZh+8xL25HERhZklxTzkhjjDFp8XqL1F/WcjXGeEqo9LlacjXGeIq1XI0xJsAE788Z4C9LrsYY78gGd175y5KrMcZTQiS3WnI1xniHbyhWaKRXS67GGE8JjdRqydUY4zUhkl0tuRpjPMWGYhljTBCESJerJVdjjLeESG615GqM8ZgQya6WXI0xniFYn6sxxgSe3aFljDHBESK51ZKrMcZLBAmRpqslV2OMp4RIbrXkanyuzJO93woHlo1yO4RMK9VkiNshZNofW3cH9HiCdQsYY0xwhEh2teRqjPGUUBmKFbRHaxtjTGaI+L+kfywpLyILRGSLiGwWkSFOeVERmSsi25y/RZxyEZHRIhIjIhtFJCqz12HJ1RjjKZKBxQ/xwOOqWg1oBAwWkWrA08A8Va0EzHO2AToAlZxlIPBeZq/Dkqsxxjsykln9yK6qul9V1zrrp4BfgLJAZ2CiU20i0MVZ7wx8oj4rgMIiUjozl2J9rsYYT8lgn2txEVmTYnu8qo6/5HFFKgJ1gJVASVXd7+w6AJR01ssCKYdA7HHK9pNBllyNMZ4hZHic62FVrZfucUXyA98Cj6jqyZQ3KqiqiohmMNR0WbeAMcZTAtzniojkwpdYP1fV75zig0lf952/h5zyvUD5FC8v55RlmCVXY4y3BDC7iq+JOgH4RVXfSrFrKtDPWe8HTElR3tcZNdAIOJGi+yBDrFvAGOMpAX76a1PgbuBnEVnvlD0DvAp8LSIDgF1Ad2ffTKAjEAOcBe7J7IktuRpjPCWQqVVVl6RxyJsuUV+BwYE4tyVXY4y3hMYNWpZcjTHeYU8iMMaYYLAnERhjTHCESG615GqM8ZgQya6WXI0xHiIh0+ca8jcRDLrvXiqUiaRu7Rpuh5Jhu3fvpl2bVtS5oRpRtarz7ujsN9t+5esqUq92TRrWrU3Thunepeiq8+fP07p5I5o2jKJR3RsYMfx5ABYtmEeLxvVp1rAu7W9qwe/bY1yLcdyw3uya9wprJj2TXHZHmzpEfzOUM9GjiapW4YL6T9zblk1ThrFh8rO0aVw1ufzh3q2I/mYoayY9w8RX+pMnt3faWYGcctBNIZ9c7+7XnynTZ7kdRqZERETw6mtvsm7jFhYtWcH748bwy5YtboeVYbN+XMDK6PUsXbkm/couypMnD1N/+JGlK9eyeEU08+bOZvWqFTw25CE++PgTlqyMpmv3nrz+nxGuxfjptBV0HjzmgrLN2/fR4/EPWLJ2+wXlVa4pRbd2UUR1fZnbBo9l1L+6ExYmlClRiAd73kjT3q9Rr9sIwsPC6NaublZeRqoCPCmWq0I+uTZr3oKiRYu6HUamlC5dmjpRvrl6CxQoQJUqVdm3L1O3ORs/iAj58+cHIC4ujri4eN+XVBFOnTwJwMmTJyhdKlMz0AXE0rXbOXri7AVlW3ccZNuuQ3+r26nlDUyavZY/4+LZte8I23cfpn6NigBEhIeTL08uwsPDyJc3N/tjT2RF+P4Jkezqne8CJk27du5k/fp11G/Q0O1QMkREuLVDW0SEAfcPYsD9A90OKU0JCQnc2KQBO36P4b5B/6Beg4aMHvs+3e64lXx581GgYEHmLlzqdph+KVuiECt/3pm8vffQMcpEFmLlxh2M/GQev/0wnHN//Mm85b8yb8Wv7gV6Eetz9YOI7BSRn0Vk/UVzLpoMOH36ND2738nrb46kYMGCboeTIfMWLmH56rV8P/0H3n9vDEsW/+R2SGkKDw9nycpoNm/bRfSa1WzZvImx74xi0nfT2BKzi95392PoU0+4HeZlKVwgH51a1qRqp2Fc03YoV+bLTY+O9d0OK5n1ufqvlarW9mfORfN3cXFx9Ox+J3f17E2X2+9wO5wMK1u2LACRkZHc1uV2Vq9e5XJE/ilcuDDNW7Tkxzmz2PTzRuo53xhu79qdVSuXuxydf/bGnqBcqSLJ22Uji7Dv0AlaN6zCzn1HOHzsNPHxiXw/fwONal3tYqQpCIRlYPGykO9zzc5UlQfuH0DlKlUZ8uhjboeTYWfOnOHUqVPJ6z/OnUP16t4dtXE4Npbjx48DcO7cORbO/5HrK1fh5MkTxGz7DYAF83xl2cGMhRvp1i6K3LkiuKpMMa6rUILVm3ay+8BRGtS8mnx5cwHQqkFltu446HK0KYVGp2uw+1wVmOPM8v3+pR6/ICID8T0IjPIVKly8+7L17dOTxYsWcvjwYa6tWI5nn3uB/vcOCPh5gmHZ0qV88fmn1KjhG8oE8MJLI2jfoaO7gfnp0MGD3NX1dgDiE+K5q0cv2rZr73JUqTtwYD//uP9eEhIT0MREutzRlfYdOzHq3ffp26s7EhZG4cKFGTPuQ9dinPhKf5rXrUTxwvmJmTWc4eNmcuzEGd56qhvFi+Tnu9EPsHHrXm4bPIZffj/At3PWse7bocQnJPLIq1+TmKis3rSLyT+uY/kXTxGfkMiGX/cw4Vtv9CNn4kkEniW+GbaCdHCRsqq6V0QigbnAw6qaaqdb3br11OvDdYw3/RGX4HYImVaqyRC3Q8i0P7Z+TeLZQwFLh7Xq1NUfFvjf7VK2SJ5or3Y5BrVbQFX3On8PAZOBBsE8nzEm+7MftNIhIleKSIGkdaAtsClY5zPGhAbJwH9eFsw+15LAZOcpixHAF6qaPW+VMsZkHW/nTL8FLbmq6u9ArWAd3xgTmkIkt9odWsYY78gOfan+suRqjPEUr/el+suSqzHGW0Ijt1pyNcZ4S4jkVkuuxhgvEcJCpNPVkqsxxjNC6fZXm7jFGGOCwFquxhhPCZWWqyVXY4yn2FAsY4wJNLuJwBhjAs/7U2D7z5KrMcZbQiS7WnI1xniK9bkaY0wQWJ+rMcYEQYjkVkuuxhiPCZHsasnVGOMZAiEzt0BQn/6aUSISC+wK0uGLA4eDdOyskJ3jt9jdE+z4r1LVEoE6mIjMwhezvw6rqief1+6p5BpMIrLGq4/g9Ud2jt9id092jz87s4lbjDEmCCy5GmNMEOSk5Dre7QAuU3aO32J3T3aPP9vKMX2uxhiTlXJSy9UYY7KMJVdjjAkCS67GGBMEllxNwIlIAxGp76xXE5HHRKSj23Flhoh84nYMJnuy2189SESqAGWBlap6OkV5e1Wd5V5k6RORYUAHIEJE5gINgQXA0yJSR1VfdjXANIjI1IuLgFYiUhhAVW/L8qAug4g0AxoAm1R1jtvx5DQ5brSAiNyjqh+7HUdqROSfwGDgF6A2MERVpzj71qpqlIvhpUtEfsYXdx7gAFBOVU+KSD58HxY3uBlfWkRkLbAF+BBQfMn1S6AHgKouci+69InIKlVt4Kzfj+99NBloC0xT1VfdjC+nyYndAi+4HUA67gfqqmoXoCXwrIgMcfZlhxkt4lU1QVXPAttV9SSAqp4DEt0NLV31gGhgKHBCVRcC51R1kdcTqyNXivWBwM2q+gK+5NrbnZByrpDsFhCRjantAkpmZSyZEJbUFaCqO0WkJfCNiFxF9kiuf4rIFU5yrZtUKCKF8HhyVdVE4G0RmeT8PUj2+v9ImIgUwddoElWNBVDVMyIS725oOU92euNkREmgHXDsonIBlmV9OBlyUERqq+p6AFU9LSKdgI+Amq5G5p8WqvoHJCerJLmAfu6ElDGqugfoJiK3ACfdjicDCuFreQugIlJaVfeLSH6yxwdzSAnJPlcRmQB8rKpLLrHvC1Xt5UJYfhGRcvi+Wh+4xL6mqrrUhbBMNiYiVwAlVXWH27HkJCGZXI0xxm058QctY4wJOkuuxhgTBJZcQ5CIJIjIehHZJCKTnD63zB7rvyLS1Vn/UESqpVG3pYg0ycQ5dorI3x7tkVr5RXVOp7X/EvWfF5EnMhqjMRllyTU0nVPV2qpaA/gTeCDlThHJ1CgRVb1PVbekUaUlkOHkakwosuQa+hYD1zmtysXOLZ5bRCRcRF4XkdUislFEBgGIz7sislVEfgQikw4kIgtFpJ6z3l5E1orIBhGZJyIV8SXxR51Wc3MRKSEi3zrnWC0iTZ3XFhOROSKyWUQ+xI9hQiLyvYhEO68ZeNG+t53yeSJSwim7VkRmOa9Z7NxSbEyWCdVxrobkFmoHIGk+giighqrucBLUCVWtLyJ5gKUiMgeoA1QGquEbL7wF3xjblMctAXyAb0zrDhEpqqpHRWQccFpV33DqfQG8rapLRKQCMBuoCgwDlqjqi85Y0gF+XM69zjnyAatF5FtVPQJcCaxR1UdF5Dnn2A/hm4H/AVXdJiINgbFA60z8MxqTKZZcQ1M+EVnvrC8GJuD7ur4qxVjHtsANSf2p+AagVwJaAF+qagKwT0TmX+L4jYCfko6lqkdTiaMNUE3+eg59QWdAewvgDue1M0Tk4ps9LuWfInK7s17eifUIvru+vnLKPwO+c87RBJiU4tx5/DiHMQFjyTU0nVPV2ikLnCRzJmUR8LCqzr6oXiCnBgwDGqnq+UvE4jfnFuA2QGNVPSsiC4G8qVRX57zHL/43MCYrWZ9rzjUb+IeI5AIQketF5ErgJ+Aup0+2NNDqEq9dAbQQkaud1xZ1yk8BBVLUmwM8nLQhIrWd1Z+AXk5ZB6BIOrEWAo45ibUKvpZzkjAgqfXdC193w0lgh4h0c84hIlIrnXMYE1CWXHOuD/H1p64VkU3A+/i+yUwGtjn7PgGWX/xCZ0KQgfi+gm/gr6/l04Dbk37QAv4J1HN+MNvCX6MWXsCXnDfj6x74XzqxzsI3P+wvwKv4knuSM0AD5xpaAy865b2BAU58m4HOfvybGBMwdvurMcYEgbVcjTEmCCy5GmNMEFhyNcaYILDkaowxQWDJ1RhjgsCSqzHGBIElV2OMCYL/D60TjVaLtvc/AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Predict the values from the validation dataset\n",
+    "Y_pred = resmodel.predict(x_test)\n",
+    "# Convert predictions classes to one hot vectors \n",
+    "Y_pred_classes2 = np.argmax(Y_pred,axis = 1) \n",
+    "# Convert validation observations to one hot vectors\n",
+    "Y_true = np.argmax(y_test,axis = 1) \n",
+    "# compute the confusion matrix\n",
+    "confusion_mtx = confusion_matrix(Y_true, Y_pred_classes2) \n",
+    "# plot the confusion matrix\n",
+    "plot_confusion_matrix(confusion_mtx, \n",
+    "            classes = ['1','2','3','4','5'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "hispanic-milwaukee",
+   "metadata": {
+    "papermill": {
+     "duration": 1.514449,
+     "end_time": "2021-04-25T15:08:32.029237",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:30.514788",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Model 4:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "resistant-shuttle",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:08:34.854400Z",
+     "iopub.status.busy": "2021-04-25T15:08:34.853346Z",
+     "iopub.status.idle": "2021-04-25T15:08:35.342883Z",
+     "shell.execute_reply": "2021-04-25T15:08:35.341986Z"
+    },
+    "papermill": {
+     "duration": 1.897982,
+     "end_time": "2021-04-25T15:08:35.343029",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:33.445047",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAVcAAAEmCAYAAADWT9N8AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8+yak3AAAACXBIWXMAAAsTAAALEwEAmpwYAAA5H0lEQVR4nO3dd3wUVdfA8d9JQpXQe1M6UqQHkC5SpSmiWBCFR7C3Fzs8iL1gwYoKKsWCnd6lKy00BR4FBaRK7zXhvH/MJCaUZBN2M5PlfP3Mh907d2bOYji5e+fOvaKqGGOMCa4IrwMwxphwZMnVGGNCwJKrMcaEgCVXY4wJAUuuxhgTApZcjTEmBCy5XqREJIeIjBeRAyLyzQWc5xYRmRbM2LwiIk1E5Hev4zDhQWycq7+JyM3AI0Bl4BCwAnhBVedf4Hl7APcDV6pq3IXG6XciokAFVV3vdSzm4mAtVx8TkUeAt4AXgSJAaeB9oHMQTn8p8MfFkFgDISJRXsdgwoyq2ubDDcgDHAa6pVAnG07y3eZubwHZ3H3NgS3A/wE7ge3AHe6+QcBJ4JR7jd7AM8DoJOe+DFAgyn1/O/AXTut5A3BLkvL5SY67ElgCHHD/vDLJvtnAc8AC9zzTgILn+WwJ8T+WJP4uQHvgD2Av8FSS+jHAL8B+t+67QFZ331z3sxxxP++NSc7/OLADGJVQ5h5Tzr1Gbfd9cWAX0Nzrnw3bMsdmLVf/aghkB35Ioc7TQAOgJlADJ8H0T7K/KE6SLoGTQN8TkXyqOhCnNTxGVXOp6vCUAhGRS4C3gXaqGo2TQFeco15+YKJbtwDwBjBRRAokqXYzcAdQGMgK9Evh0kVx/g5KAP8FPgZuBeoATYABIlLGrRsPPAwUxPm7awncA6CqTd06NdzPOybJ+fPjtOL7JL2wqv6Jk3hHi0hO4FNghKrOTiFeYxJZcvWvAsBuTflr+y3As6q6U1V34bRIeyTZf8rdf0pVJ+G02iqlM57TQDURyaGq21V19TnqXAOsU9VRqhqnql8C/wM6Jqnzqar+oarHgK9xfjGczymc/uVTwFc4iXOIqh5yr78G55cKqhqrqgvd624EPgSaBfCZBqrqCTeeZFT1Y2A9sAgohvPLzJiAWHL1rz1AwVT6AosDm5K83+SWJZ7jjOR8FMiV1kBU9QjOV+m7gO0iMlFEKgcQT0JMJZK835GGePaoarz7OiH5/ZNk/7GE40WkoohMEJEdInIQp2VeMIVzA+xS1eOp1PkYqAa8o6onUqlrTCJLrv71C3ACp5/xfLbhfKVNUNotS48jQM4k74sm3amqU1W1FU4L7n84SSe1eBJi2prOmNLiA5y4KqhqbuApQFI5JsWhMiKSC6cfezjwjNvtYUxALLn6lKoewOlnfE9EuohIThHJIiLtRORVt9qXQH8RKSQiBd36o9N5yRVAUxEpLSJ5gCcTdohIERHp7Pa9nsDpXjh9jnNMAiqKyM0iEiUiNwJVgAnpjCktooGDwGG3VX33Gfv/Acqm8ZxDgKWq+h+cvuShFxyluWhYcvUxVX0dZ4xrf5w71ZuB+4Af3SrPA0uBVcCvwDK3LD3Xmg6Mcc8VS/KEGOHGsQ3nDnozzk5eqOoeoAPOCIU9OHf6O6jq7vTElEb9cG6WHcJpVY85Y/8zwAgR2S8iN6R2MhHpDLTl38/5CFBbRG4JWsQmrNlDBMYYEwLWcjXGmBCw5GqMMSFgydUYY0LAkqsxxoSAryarkKgcKlmjvQ4jXapVLOV1CBckMiK1IaH+lpnDz8y3lP/etJHdu3cH7W8/MvelqnFnPSx3Xnps11RVbRus6weTv5Jr1miyVUp1lIwvjZs+2OsQLkienFm8DuGC5Mga6XUI6ZaZR+w0alAvqOfTuONkq9w94PrHl7+T2lN4nvFVcjXGXOQEkEz8NSQJS67GGH+R8LgVZMnVGOMv1nI1xphgE2u5GmNMSIRJyzU8fkUYY8KD4LRcA91SO53IJyKyU0R+S1KWX0Smi8g69898brmIyNsisl5EVolI7STH9HTrrxORnoF8FEuuxhgfEaflGuiWus9wZjdL6glgpqpWAGa67wHaARXcrQ/OHMEJyxcNBOrjLKU0MCEhp8SSqzHGX4LYclXVuTjTZCbVGRjhvh7BvxPSdwZGqmMhkFdEigFtgOmquldV9wHTOTthn8X6XI0x/pK2PteCIrI0yfuPVPWjVI4poqrb3dc7cJatB2c5os1J6m1xy85XniJLrsYYH0nzaIHdqlo3vVdTVRWRkDwiZ90Cxhj/ECAiMvAtff5xv+7j/rnTLd8KJJ0kpKRbdr7yFFlyNcb4iAS1z/U8xgEJd/x7AmOTlN/mjhpoABxwuw+mAq1FJJ97I6u1W5Yi6xYwxvhLEKc4E5EvgeY4fbNbcO76vwx8LSK9cZZ+T5gtahLQHliPs+z7HQCquldEngOWuPWeVdUzb5KdxZKrMcY/Esa5Bomq3nSeXS3PUVeBe89znk+AT9JybUuuxhh/sSe0vDd04C1smvkSS795KrEsX+6cTPjgPn4d+18mfHAfeaNzJDumTpXSHFoyhGuvrplYNvbde9g+91W+G3JXRoWezGMP9KXu5aVp06ROYtmLzzxJy4Y1aNusHn173sDBA/sB2PL3JiqXykf75vVp37w+T/e735OYUxIfH0+zhnXp3rUTAPf26UXNKuVp2qAOTRvU4deVK7wNMADHjx+nccMYYmrXoHaNqjw3aKDXIaXJH7//Tv26tRK3IgXy8O7bb3kdVgAypM81Q/g7ulSMGr+Qzve+l6ys3x2tmL34d6p3fpbZi3+n3x2tE/dFRAjPP9iZGQv/l+yYN0fOoHf/kRkS87l07d6Dz74am6yscbOWTJ0Xy5Q5SyhTrgLvD3ktcd+ll5Vl0uxFTJq9iBcGv5PR4aZq6HtvU7FS5WRlg154hbkLY5m7MJbqNWp6E1gaZMuWjSnTf2LxspUsWrqCaVOnsGjhQq/DCljFSpVYtHQ5i5Yu5+dFS8mRMyedOl/rdViBCe4TWp7J1Ml1wbI/2XvgaLKyDs2vYPT4RQCMHr+Iji2uSNx3T/dm/DhzJbv2Hkp2zOzFf3DoyInQB3we9a9sTN58+ZOVNW1xNVFRTq9NrTox7NiW6sgPX9i6dQvTp0yix+29vA7lgogIuXLlAuDUqVPEnTqF+Pwf8/nM+mkmZcuWo/Sll3odSmCs5epPhQtEs2P3QQB27D5I4QLOmlzFC+Wh01U1+OibeV6Gly5ffzGSZi3bJL7f/PdGrmnRgBs7tWLxL/M9jOxsTz32CM+88DIREcl/tF4YNIDGMbV46rFHOHHCu19kaREfH0/9OjUpXbwwV13dipj69b0OKV2++forut0Y+NIpnkpLq9Xnv+xCllzPNRuNFxKWJ3rt0a70HzI2061X9O4brxAVFUmX651/HIWKFGXB8j+YOGsh/Z97hYfuup1Dhw56HKVj6uQJFCpUmJq16iQrHzDoBRYtX83MeQvZv28fQ9541aMI0yYyMpJFsStYv3ELS5csZvVvnv4op8vJkyeZNGE813Xt5nUogQuTlmsoRwt8BrwLZGhn5s49hyhaMDc7dh+kaMHciV0AtauUZuTLdwBQIG8u2jSuSlzcacbPXpWR4aXJt1+O4qfpk/j8u8mJX0mzZctGtmzZAKheozalLyvLhj/XcUXNOimdKkMs+uVnJk8cz/Spkzlx/DiHDh2kb6/b+PAT50cgW7Zs3NyjJ+8OecPjSNMmb968NGvegmnTplC1WjWvw0mTqVMmU7NWbYoUKZJ6Zb/weYs0UCFL/eeZjSbkJs75lVs7Ol/fbu1Ynwlu8ry8wzNUvmYgla8ZyA8zlvPQS2N8nVjnzJzGh+++wcejviVHzpyJ5Xt27yI+Ph6AvzduYONf6yl9aRmvwkzmv8++yOp1m1i59k+GjficJs1a8OEnI9mx3ZkjQ1WZOH4cl1ep6nGkqdu1axf79+8H4NixY8ycMZ1KZ9ykywy+GZOJugSAcBot4Pk4VxHpgzN3ImTJlaZjR7x0O03qVKBg3lysn/Iczw2dxOBPpzP6lV707NKQv7fv5dbHUh/3O2P4Q1QsU4RcObKxfspz3DXoC2b8sjY9HyddHuhzGwsXzGPf3t00vKIcDz02gA+GvMbJkyfocX0HAGrVjeGFwe+w+Jf5vPnKc0RFZSEiIoLnB79z1s0wv+nbqwe7d+9GVal+RQ1ef/t9r0NK1Y7t27mzV0/i4+M5rafpev0NtL+mg9dhpcmRI0f4aeZ03nl/qNehBC5hboEwIKHsgxSRy4AJqhrQd6mInIU1W6UbUq/oQ2unD/Y6hAuSJ2cWr0O4IDmyZt5/kJntPkBSjRrUY1ns0qB9j4/Ie6lma/J4wPWPT7g39kJmxQolz1uuxhiTTJj0uVpyNcb4i8/7UgMVyqFYXwK/AJVEZIs7A40xxqQsTMa5hqzlmsJsNMYYc26S5pUIfMu6BYwx/uLzFmmgLLkaY3wls87hcCZLrsYY3xAsuRpjTPCJu4UBS67GGB8Ra7kaY0woWHI1xpgQsORqjDHBJiBBXFrbS5ZcjTG+IdbnaowxoWHJ1RhjQsCSqzHGhIAlV2OMCTZ7iMAYY0LDWq7GGBNkNlrAGGNCxJKrMcaEQnjkVn8l16oVSzJ22mteh5EujQZM9jqEC/J9vxZeh3BBalya1+sQ0i0zt9SCHrlk7r+PpHyVXI0xxpKrMcYEmSBERNgaWsYYE3zh0XC15GqM8ZEw6nMNj/a3MSZsiEjAW4Dne1hEVovIbyLypYhkF5EyIrJIRNaLyBgRyerWzea+X+/uvyy9n8OSqzHGV4KZXEWkBPAAUFdVqwGRQHfgFeBNVS0P7AN6u4f0Bva55W+69dLFkqsxxl8kDVtgooAcIhIF5AS2A1cB37r7RwBd3Ned3fe4+1tKOvspLLkaY3wljS3XgiKyNMnWJ+m5VHUrMBj4GyepHgBigf2qGudW2wKUcF+XADa7x8a59Quk53PYDS1jjG+kpS/VtVtV66Zwvnw4rdEywH7gG6DthcQYKGu5GmN8Jcg3tK4GNqjqLlU9BXwPNALyut0EACWBre7rrUApN44oIA+wJz2fw5KrMcZXgpxc/wYaiEhOt++0JbAGmAVc79bpCYx1X49z3+Pu/0lVNT2fw7oFjDH+EsRhrqq6SES+BZYBccBy4CNgIvCViDzvlg13DxkOjBKR9cBenJEF6WLJ1RjjK8F+iEBVBwIDzyj+C4g5R93jQLdgXNeSqzHGP8LoCS1LrsYY33AmbrHkaowxQRcmDdfwGS3w+IN9qVflUto2/XfI2xsvD6J9sxg6tKhPz24d+WfHtmTHrFq+lIrFopk8/oeMDvcsd15Vjp8GtGTmgJa816su2aIiuL1ZWeYPasXWD64l3yVZE+ve1aoC055qwbSnWjBzQEv+fq8LeXNm8STuf7Zt4Z5bOtK9TQNuatuQMZ8NTbb/82Hv0qB8PvbvdUazxC6cT8uapenRsQk9OjZh+DuvehF2qvr+pxelixemTs1qXoeSLtOmTuGKqpWoWrk8r736stfhpEmw5xbwStgk167de/DpVz8mK7vz3oeZNGcxE2YtokXrdrwz+KXEffHx8bzy3AAaN2+ZwZGerWie7PRqUY72L8+i5XMziYwQOtctyZI/99B9yAI27zmSrP7Q6eto/eIsWr84i5d/XM3CdbvZf/SUJ7FHRkXxwJPP89XUhQz7dhrfjh7GhnX/A5zEu3j+LIoWL5nsmJr1GjJq/DxGjZ9H7/sf8yLsVPXoeTtjJ0zxOox0iY+P56EH7mXs+MksX7WGb776krVr1ngdVmDEabkGuvlZ2CTXmIaNyZs3f7Ky6Ojcia+PHT2S7DfdyGEf0PaazhQoWDjDYkxJVISQPUskkRFCjqxR7DhwnNVbDrBl79EUj+tcryQ/LtmSQVGerWDholSuVgOAS3JFc1m5iuz8ZzsAb73wNPc9/oz//xWcQ+MmTcmfP3/qFX1oyeLFlCtXnjJly5I1a1a63didCePHpn6gDwgQESEBb34WNsn1fAa/OJBGNSsw9rsxPPT4AAB2bN/KtEnjuOWOPqkcnTF2HDjO0BnrWfxCW5a/3I6Dx04xd+3OVI/LniWS5lWKMGn51lTrZoRtW/7mjzWrqFajDnOnT6JQ0WJUuLz6WfV+Xb6EWzs05qFe1/PXH2s9iDS8bdu2lZIlSyW+L1GiJFu3+uNnJBDWck2FiJQSkVkissadS/HBUF0rJf2eGsSCFevo3PVGRg13+gOf7/8Yjw143jfLSeTJmYU2NYrRYMBUaj8xmZxZI7kuplSqx7W+oihL/9zjWZdAUkePHObJe2/jof4vERkVxWdD36DPQ0+eVa9y1Sv4cc4qRk+Yzw239eGxu2/1IFrjZ9bnmro44P9UtQrQALhXRKqE8Hop6ty1O1MmOl+Nfl25jAf73kbTOpWZMv4H/vv4Q0ybNM6r0GhSuRB/7z7C3sMniTutTF6xjbplU/9K2qluSX5c6l2XQIK4U6d48t6etOnUjRZtOrLl7w1s37yJWzs0oUuzK9i1Yxs9Ozdjz65/uCQ6NzkvyQXAlc1bExd3KvFmlwmO4sVLsGXL5sT3W7duoUSJEikc4SNh1OcasqFYqrodZ4ovVPWQiKzFmc4rw3rWN/y1njJlywMwfcoEypWvCMCcpf9+FX30/j5c1bodrdt3yqiwzrJ17zFql8lP9iyRHD8VT+PKhVm5aV+Kx0Rnj6JBhYLc/+nSDIry3FSVF568n8vKV+Tm3vcCUL5SVSYvXpdYp0uzK/jsh1nkzV+APbv+IX/BwogIq1fGoqdPkydf5uzb9Ku69eqxfv06Nm7YQPESJfhmzFd8NuoLr8MKiGAPEaSJu1RCLWBRqK7xYN+eLFowl31799CoRnkefKw/s2dM5a8/1xEhEZQoVYrnXns7VJe/IMs37mPi8q1MfaoFcaeV1Zv38/n8jfRqUZZ7WlWkUO5szOh/FT+t/odHRy8HoF3N4sxdu5NjJ+M9jX1l7EIm/ziGcpWq0KNjEwDu/r8BXNm89Tnr/zR5LN9/8SmRUZFky5aD54YM9+U/pttuvYl5c2aze/duyl1WkgH/HcTtvXqnfqAPREVF8eaQd+l4TRvi4+PpeXsvqlSt6nVYAfL/1/1ASTonfAn8AiK5gDnAC6r6/Tn29wH6ABQvWarOvGW/hzSeUGny38w5bCfB9/1aeB3CBalxaV6vQ7goNapfl9jYpUHLhjmLV9KKfd4PuP7KQVfHpjSfq5dCekdHRLIA3wGfnyuxAqjqR6paV1Xr5i9QMJThGGMygXC5oRWybgF37sThwFpVfSNU1zHGhA8RfD9+NVChbLk2AnoAV4nICndrH8LrGWPCgI0WSIWqzieo094aYy4Gfv+6HyibFcsY4ythklstuRpjfMQmyzbGmOBzHiLwOorgsORqjPER/w+xCpQlV2OMr4RJbrXkaozxF2u5GmNMsGWC8auBsuRqjPENmxXLGGNCxJKrMcaEQJjkVkuuxhgfCaOJWyy5GmN8Q2ycqzHGhEaY5FZLrsYYf4kIk+xqydUY4ythklstuRpj/ENsVixjjAmNMBks4K/kGhkhRGf3VUgB+/n5dl6HcEEqd37e6xAuyK6Zz3odQrpFRYZ0ndBMx1quxhgTAmGSWy25GmP8Q3DGuoaD8yZXEXkH0PPtV9UHQhKRMeaidjH0uS7NsCiMMQZAgv+ElojkBYYB1XAajL2A34ExwGXARuAGVd0nzsWHAO2Bo8DtqrosPdc9b3JV1RFnBJhTVY+m5yLGGBMIwbmxHWRDgCmqer2IZAVyAk8BM1X1ZRF5AngCeBxoB1Rwt/rAB+6faZbqbUoRaSgia4D/ue9riMj76bmYMcakRiTwLfVzSR6gKTAcQFVPqup+oDOQ0IAcAXRxX3cGRqpjIZBXRIql53MEMgbkLaANsMcNbqUbrDHGBJ24XQOBbEBBEVmaZOtzxunKALuAT0VkuYgME5FLgCKqut2tswMo4r4uAWxOcvwWtyzNAhotoKqbz+gHiU/PxYwxJiWBtkiT2K2qdVPYHwXUBu5X1UUiMgSnCyCRqqqInPfmfXoF0nLdLCJXAioiWUSkH7A22IEYYww4E7cEugVgC7BFVRe577/FSbb/JHzdd//c6e7fCpRKcnxJtyztnyOAOncB9+I0jbcBNd33xhgTdJKGLTWqugOngVjJLWoJrAHGAT3dsp7AWPf1OOA2cTQADiTpPkiTVLsFVHU3cEt6Tm6MMWkVgsdf7wc+d0cK/AXcgdOw/FpEegObgBvcupNwhmGtxxmKdUd6L5pqchWRsjhDGRrgjBH7BXhYVf9K70WNMeZchOA/RKCqK4Bz9cu2PEddJUjfzAPpFvgC+BooBhQHvgG+DMbFjTEmmTSMFPD7BC+BJNecqjpKVePcbTSQPdSBGWMuTsEc5+qllOYWyO++nOw+wfAVTrfAjTj9EsYYE3R+b5EGKqU+11icZJrwSfsm2afAk6EKyhhzcQpFn6tXUppboExGBmKMMRA+LdeApkAXkWoicoOI3JawhTqwC3Vg/3569biRK+tUo1Hd6ixZtJBfV62g3VWNadGoLq2aNWDZ0iVehwnAow/0pU7l0rRuXCexbOLY72jVqDZlCuVk1fLYxPJTp07xyL3/oU2TurRsWJP33nrNi5CTubdbQ5aOvJ/YUfdzX7eGAFQvX5TZQ/uwZMR9fPvKrUTnzJZYv1q5Iswe2ofYUfezZMR9ZMvqj2mF7+7TmzKlihJT+4rEslUrV9Ci6ZVcGVObplfGsHTJYg8jDNzx48dp3DCGmNo1qF2jKs8NGuh1SAERgUiRgDc/C2TiloHAO+7WAngV6BTiuC7Y048/wlVXt+Hn2N+Y9XMsFStV5tkBT9Hvif7MWrCUx58ayLP/9UfPxvXdezBizNhkZZUur8rQz74ipmHjZOWTxn7HyRMnmDpvKRNm/swXI4ax+e9NGRluMlXKFOaOjnVpcudQYm5/j3aNKlO2RH4+eLwL/YdOo17Pdxk3dw0P3+x8jsjICD4Z0I37B4+jTo93aHP/cE7F+eNp6lt69OSHcclvJwx46nGefHoAPy9extP/fYYBTz1xnqP9JVu2bEyZ/hOLl61k0dIVTJs6hUULF3odVkDC5YZWIC3X63HGg+1Q1TuAGkCekEZ1gQ4eOMDCn+dzy23O+N+sWbOSJ29eRIRDhw46dQ4eoGjRdE12E3T1r2xMnnz5k5WVr1iZchUqnl1ZhGNHjxIXF8fx48fImiUr0dHRGRTp2SpfVogla7Zw7MQp4uNPM2/5Bro0q0L5UgWZv2IjAD8t+ZMuzaoCcHW98vz25w5+Xb8DgL0Hj3H6dNAf606Xxk2aku+M/w8iwqGD7s/MgQMUK+aPn5nUiAi5cuUCnG87cadOZZqv2+EyFCuQ72PHVPW0iMSJSG6cZ3BLpXaQlzZt2kCBAgV54O7/sPq3VdSoWZvnX3mD518ZzI3XduCZ/k9w+vRpJk6f43Woada+03VMnzyBmKplOHbsKAOee5W8ZySEjLT6r50806cV+XPn4NiJONo2rMiy/21l7YaddGxyOePnreW6FlUpWcT5fVyhVAFUYdzrPSmY9xK+nbmKN76Y71n8qXl58Jtc26EdTz/xGKf1NDNm+TfWM8XHx3NlTB3+/HM9fe++l5j66ZqWNMP5PGcGLJCW61J3Ju+PcUYQLMN5SitFIpJdRBaLyEoRWS0igy4s1MDFx8WzauVybu/dl5/mLyFnzkt4541X+WzYRzz70musWPsXz730Gg/d1zf1k/nMymVLiIyMZNFvfzEvdi3D3h/C3xs3eBbP75t28froeYx/83bGvd6Tleu2E39a6fvS9/S5tj4Lht9NrpzZOHnK+eofFRXBlVdcyh3PfkPLez6mU9MqNK9T1rP4UzP8o6G8/Nrr/O/PTbz86uvce9edXocUsMjISBbFrmD9xi0sXbKY1b/95nVIqRICn7QlwIlbPJNqclXVe1R1v6oOBVoBPd3ugdScAK5S1Ro4k720dSdCCLliJUpQvERJ6tSLAaBjl+tYtXIFY74cRYdO1wLQ6drrWR7rjxtaaTH2u69p1rI1WbJkoWChwtSp35BVK2JTPzCERkyMpVHvD2h13zD2HzrOus27+ePv3XR85DMa9f6Ar2esYsPWvQBs3XmQ+Ss3sufAUY6dOMWUX/6gVsXinsafki9Gj6RTl+sAuLZrN2KXZo4bWknlzZuXZs1bMG3aFK9DSV0a+lt9nlvPn1xFpPaZG5AfiHJfp8idyfuw+zaLu2VI51qRIkUpXqIk69f9DsDc2T9RsfLlFC1ajJ/nzwVg3pxZlC1XPiPCCariJUvy87zZABw9coTlSxdTrkKlFI8JtUJ5LwGgVJE8dG5WhTHTVyWWiQhP9GzOx2OdpDR98Tqqli1CjmxZiIyMoEmtMqzduPO85/Za0WLFmT/X6T6aM+snypWv4HFEgdm1axf79+8H4NixY8ycMZ1KlSp7G1SALoY+19dT2KfAVamdXEQicboSygPvJZlTMWmdPkAfgJKlSqd2yoC9+Nqb3P2fnpw8eZJLLyvD2+8Po+01Hen/+CPExcWRPVt2Xh/yQdCudyHuv/M2Fi6Yx769u2lQvRwPPz6APPny8cwTj7B3z2563Xwdl1e7glHfjOe2Xnfx6AN9aNWoNqpKt5t6cHnV6p7G/+ULN5E/d05Oxcfz0BvjOXD4OPd2a0jf65w+vrFz1jByorPG2/5Dx3l7zALmD7sLVZj6yx9M+eUPL8NPdEePm5k3bw57du+mUrnSPNV/IO+8/yGP93vY+ZnJnp233xvqdZgB2bF9O3f26kl8fDyn9TRdr7+B9td08DqsgAQ0PjQTEGcSmBBfxOmz/QFnNvDzdvzUrF1Hp8/JHMNFznT0pD+GE6VX5c7Pex3CBdk181mvQ0i3qMjMm04a1a9LbOzSoDUhi5SvpjcO/jbg+u9ce3lsKisReCZD/q+6C4LNAtpmxPWMMZlXhAS++VnIkquIFHJbrIhIDpybYf8L1fWMMeEhXJJrKJ87LAaMcPtdI4CvVXVCCK9njMnknFEAPs+aAQpkJQLBWealrKo+KyKlgaKqmuKYFFVdBdQKTpjGmItFJu6CTiaQj/E+0BC4yX1/CHgvZBEZYy5azpSD4fEQQSDdAvVVtbaILAdQ1X3uQl/GGBN0YdJwDSi5nnL7TRWcG1XA6ZBGZYy5aPm8QRqwQJLr2zhjVAuLyAs4s2T1D2lUxpiLkmSCr/uBSjW5qurnIhKLM+2gAF1UdW3IIzPGXJTCJLcGNFqgNHAUGJ+0TFX/DmVgxpiLk9/HrwYqkG6Bify7UGF2oAzwO1A1hHEZYy5CCaMFwkEg3QLJZgVxZ8S6J2QRGWMuamGSW9P+hJaqLhORzDGluTEmc8kEj7UGKpA+10eSvI0AagPbQhaRMeaiJoRHdg2k5Zp09bs4nD7Y70ITjjHmYub0uXodRXCkmFzdhweiVbVfBsVjjLnIhX1yFZEoVY0TkUYZGZAx5uIlQGSYZNeUWq6LcfpXV4jIOOAb4EjCTlX9PsSxGWMuNplg4cFABdLnmh3Yg7NmVsJ4VwUsuRpjgu5iGOda2B0p8Bv/JtUEGbKKqzHm4nKx3NCKBHLBOcdFWHI1xoREmDRcU0yu21U1Q5fUjBDhkmyhXHkmdKJzZPE6hAuy5sfMPdFZoRZPex1Cum2cknlXro07Hex2lhARJuNcU5qXNjw+oTEm0xAS1tEKbAvonCKRIrJcRCa478uIyCIRWS8iYxIm/xeRbO779e7+yy7ks6SUXFteyImNMSbN0rDyaxr6Zh8Ekk6T+grwpqqWB/YBvd3y3sA+t/xNt166nTe5qureCzmxMcakRzDX0BKRksA1wDD3veCMfPrWrTIC6OK+7uy+x93fUi5gKdpwWa7GGBMG0tEtUFBElibZ+pxxyreAx/h3aaoCwH5VjXPfbwFKuK9LAJsB3P0H3PrpkjnvHhljwlYax7nuVtW659ohIh2AnaoaKyLNgxBamlhyNcb4ShCHYjUCOolIe5yHoXIDQ4C8CY/3AyWBrW79rUApYIuIRAF5cB6gShfrFjDG+IYIRIoEvKVEVZ9U1ZKqehnQHfhJVW8BZuEstArQExjrvh7nvsfd/5OqpnusmSVXY4yvSBq2dHoceERE1uP0qQ53y4cDBdzyR4An0n8J6xYwxvhIqNbQUtXZwGz39V9AzDnqHAe6BeuallyNMb4SLk8vWXI1xvjKxTC3gDHGZDDhAsbt+4olV2OMbwjhc5fdkqsxxles5WqMMSEQHqnVkqsxxk8kfFqu4dK9kcxdfXpxacki1K1VPbHsqScepVb1y4mpU4Pu3a5j//793gUYoM2bN9Pm6hbUuqIKtWtU5d23h3gd0jk99kBf6l1emrZN6iSWvfHSINo1q8c1zetzW7cO/LNjGwCqyqAnH6FFvaq0a1aP31Yuz/B4hz7VlU0Tn2bp6AcTy/JF52DCW734dcz/MeGtXuSNzp647/WHO/Lb1/1YPPIBalYsnuxc0Tmzsf7HJ3jzkU4ZFv+5rF/3Oy0b103cypcswEfvv02f229OLKtbvQItG5/zMXzfSOhzDXTzM7/Hly639ridH8dPTlZ2VctWLFn+K4tjV1K+QgUGv/qSR9EFLioqipdffZ3lq9YwZ/5CPhz6HmvXrPE6rLNc370Hn341NlnZnfc9zOQ5S5g4exFXtWrH24Odv+/ZM6ay8a8/+Wnxb7z4+rsMeOyBDI931KRYOj/8abKyfj2aMTv2T6rf+DqzY/+kX4/mALRpWIlyJQtQ7YbB3PfKD7z9aJdkxw3s04r5KzZkUOTnV75CJWbOX8rM+UuZNmcROXLkpF2Hznz02ReJ5dd0upb2Hbt4HWqqRCTgzc/CMrk2btKU/PnyJyu7ulVroqKcXpCY+g3YunXruQ71lWLFilGrdm0AoqOjqVz5crZt81/cMVc2Ju8Zf9/R0bkTXx89ejTxH8KMKRO49sabERFq1a3PwQMH2Llje4bGu2DFRvYePJqsrEOTKoyetAyA0ZOW0bFJFbf8cr6Y4rSuF6/eTJ5c2SlaIBqAWpWKUzh/LmYsXpeB0adu3uyfuKxMWUqVvjSxTFUZ/8O3XHv9jR5GFpgMePw1Q4Rlck3NyM8+pXWbtl6HkSabNm5kxYrl1Iup73UoARv8wkAa1SjPuO++4uHHBwCwY/s2ihUvmVinaPES7HC7DLxUOH8uduw5BMCOPYconD8XAMUL5WHLP/sT623ddYDihXIjIrx8/zU8+c4kL8JN0Y/ff02XM5Lowp/nU7BQYcqWq+BRVIERgjdxi9dCnlzPXL/Ga6++/AJRUVF0v+kWr0MJ2OHDh7nphq689vpb5M6dO/UDfKLf04NYsHI9nbp2Z+TwoV6HkyapzYXU97oGTP3ld7buOpgxAQXo5MmTTJs0gU5duiYr/+HbMZmi1QrBX0PLKxkxWiBh/RrPs8KokZ8xedJEJk6Z4fv+mgSnTp3iphu6cuNNt9Dl2uu8DiddOl9/I71vupaHHx9A0WLF2b5tS+K+Hdu2UrRo8RSOzhg79x6maIFoduw5RNEC0ezadxiAbbsOULJIXmATACUK5WHbroPUr1aaRjUuo891DbgkR1ayZonk8LETDPhgqncfAvhp+hSq16hFocJFEsvi4uKYNP5Hps1Z6GFkgRLE91/4AxPSluuZ69d4adrUKbz1+mt8/d1YcubM6XU4AVFV7rqzN5UqX86DDz/idThpsuHP9YmvZ0yeQNnyFQFo2eYafhjzBarK8qWLiM6dm8JFi3kVZqKJ89dya3unf/vW9rWZMG9NYvnNbWsBEFO1FAePHGfHnkPcMWgMFa97hcpdX+XJdyfxxeTlnidWcFqoZ3YJzJ09k/IVK1G8RMnzHOUv1nINzFs469dEn6+Cu+ZNH4BSpUsH5aI9e9zMvLmz2bN7NxXKlqL/gGcY/OrLnDh5go7tWwMQE1Oft9/z91fVnxcs4IvPR1GtWnXq16kJwKDnX6Rtu/beBnaGB/rcxqIF89i3dzdXXlGOBx8bwOwZU9jw5zokIoISJUvz/OC3AWjRqi2zZ0ylRUxVsufIyatvf5jh8Y4Y1J0mtcpQMO8lrP/xCZ4bNoPBo+Yw+vmb6NmhLn/v2M+t/b8AYMrPv9OmYSVWf9OPo8dP0feFb1M5u3eOHDnC3Fkzee2t95OV//jd11zbNZN0CQARYdJylQuYaDvlEzvr17RX1Xvc9Wv6qWqHlI6pXaeuzv9lSUjiCbWINKzz60fb9x/3OoQLUqXTIK9DSLeNU571OoR0a92sASuXxwbth79itZr6ztfTA67ftmrh2POtoeW1ULZcz1q/RkRGq+qtIbymMSaT8/vX/UCFrM/1POvXWGI1xqRI0vCfn9ncAsYY33CWefE6iuDIkOSadP0aY4xJid9bpIGylqsxxlfCpc/Vkqsxxles5WqMMUEm+H/OgEBZcjXG+EcmePIqUJZcjTG+Eia51ZKrMcY/nKFY4ZFeLbkaY3wlPFKrJVdjjN+ESXa15GqM8RUbimWMMSEQJl2ullyNMf4SJrnVkqsxxmfCJLtacjXG+IazZHZ4ZFdLrsYY/7AntIwxJjTCJLdacjXG+IlkmmXvU2PJ1RjjK2GSW/2VXIXMv4pqZlUoOqvXIVyQPyY843UI6XZZy8e9DiHdTvyxJajnE4LbLSAipYCRQBFAgY9UdYiI5AfGAJcBG4EbVHWfOM3mIUB74Chwu6ouS8+1Q7ZAoTHGpIukYUtdHPB/qloFaADcKyJVgCeAmapaAZjpvgdoB1Rwtz7AB+n9GJZcjTG+EszVX1V1e0LLU1UPAWuBEkBnYIRbbQTQxX3dGRipjoVAXhEplp7P4atuAWOMSWOfa0ERWZrk/Ueq+tG5zyuXAbWARUARVd3u7tqB020ATuLdnOSwLW7ZdtLIkqsxxlfS2Oe6W1XrpnpOkVzAd8BDqnow6YgEVVUR0TSGmSrrFjDG+Eda+lsDzMIikgUnsX6uqt+7xf8kfN13/9zplm8FSiU5vKRblmaWXI0xvhLMPlf37v9wYK2qvpFk1zigp/u6JzA2Sflt4mgAHEjSfZAm1i1gjPENIejjXBsBPYBfRWSFW/YU8DLwtYj0BjYBN7j7JuEMw1qPMxTrjvRe2JKrMcZXgplbVXV+CqdseY76CtwbjGtbcjXG+EuYPEdkydUY4yu2+qsxxoRAeKRWS67GGL8Jk+xqydUY4xu2EoExxoSCrURgjDGhESa51ZKrMcZnwiS7WnI1xvhIYI+1ZgZhP7fA8ePHadwwhpjaNahdoyrPDRrodUgB27x5M22ubkGtK6pQu0ZV3n17iNchperuPr0pU6ooMbWvSCz7ddVKrmrWiPp1atDtuk4cPHjQwwiT63d/H2pVKsXVjWonlu3ft5ebr2tP03pVufm69uzfv88p37+PO3vcQOsmdel4dWN+X7s6w+MdOuBGNk0dxNKvHk0sy5c7JxPe7cuv3z3JhHf7kjc6BwDd29Zm8Rf9WPLlo8wafj/VKxRP8Tx+IRL45mdhn1yzZcvGlOk/sXjZShYtXcG0qVNYtHCh12EFJCoqipdffZ3lq9YwZ/5CPhz6HmvXrPE6rBTd0qMnP4yblKzsvrv78OxzL7IodiUdO3VhyBuDPYrubN1u6sHIr8clK3tvyGAaNW3B3CWradS0Be+/5cT73puvUqX6FUybt5Q33x/OwCf/L8PjHTVhCZ0fSD5dab+eVzF7yTqqd32J2UvW0a+n81Tnxm17ad33Perd9BovDZ/Oe091S/E8fhCCSbE8E/bJVUTIlSsXAKdOnSLu1KlMs7pksWLFqFXbaVFFR0dTufLlbNuWrtnPMkzjJk3Jly9/srL16/6gUZOmAFzVshVjf/z+XId6ov6VTcibL1+ysumTxnN991sBuL77rUyb5CTfdb+v5comzQEoX7ESWzZvYtfOfzI03gXL/2LvwaPJyjo0q8boCUsAGD1hCR2bVwNg4aqN7D90DIDFv26iROG8KZ7HN8Iku4Z9cgWIj4+nfp2alC5emKuubkVM/fpeh5RmmzZuZMWK5dSLyXyxV65SlQnjnRndfvj+W7Zu2ZzKEd7avWsnRYo6K3sULlKU3bucqT4vr1qdKROcz7EidglbN//Ndh/8siucP5odew4BsGPPIQrnjz6rzu2d6zP157UZHVq6BHPKQS+FNLmKyEYR+VVEVpyxFEOGioyMZFHsCtZv3MLSJYtZ/dtvXoWSLocPH+amG7ry2utvkTt3bq/DSbP3PxzGsA8/oEnDehw+dIgsWTPPSrOSpHPvngcf5eCB/bRtFsOnH79P1eo1iYyM9DjCszkTO/2raZ3y9OxUn/7vTvAoorQJlz7XjBgt0EJVd2fAdVKVN29emjVvwbRpU6harZrX4QTk1KlT3HRDV2686Ra6XHud1+GkS6VKlRk7cSoA69b9wdQpk1I5wlsFCxXmnx3bKVK0GP/s2E7BgoUAiM6dm9ff/RhwElijWpUofWkZL0MFYOfeQxQt4LReixaIZte+w4n7qpUvxgf9b6Dzgx+z94BPuwGSEojwedIMVNh3C+zatYv9+/cDcOzYMWbOmE6lSpW9DSpAqspdd/amUuXLefDhR7wOJ9127XS+Vp8+fZrXXnqBXv/p43FEKWvVrgPffjUagG+/Gk2r9h0BOHBgPydPngTgy1GfENOwMdE++CYxce5qbu1QD4BbO9Rjwhznm1mpInn56tU76D3wC9b/vcvLENMoPDpdQ91yVWCau/jXh+dalVFE+uCsD06p0qWDHsCO7du5s1dP4uPjOa2n6Xr9DbS/pkPQrxMKPy9YwBefj6JaterUr1MTgEHPv0jbdu29DSwFd/S4mXnz5rBn924qlSvNU/0HcuTIET4a+j4AnbpcS4+e6Z7cPejuu7MHvyyYx749u4mpVo5HnujPPQ/24+5etzDm888oUbI0H3zyOQDr//gfj9z7HwShYuUqvPr20AyPd8Tzt9KkTnkK5r2E9RP+y3MfTWXwiJmMfuk2enaqz9879nHrkyMBePI/rcmfJydvPd4VgLi40zTu+eZ5zzNi3KIM/zxnCsFKBJ6RM/tngnpykRKqulVECgPTgftVde756tepU1cXLPKsa/aiFhd/2usQLsi+I6e8DiHdKrZ50usQ0u3Ems85feSfoKXDGrXq6ORZvwRcv0S+bLGBrP7qhZB2C6jqVvfPncAPQEwor2eMyfzC5YZWyJKriFwiItEJr4HWQOa6TW+MyXDhMhQrlH2uRYAf3AH7UcAXqjolhNczxoQDf+fMgIUsuarqX0CNUJ3fGBOewiS32qxYxhj/yAx9qYGy5GqM8RW/96UGypKrMcZfwiO3WnI1xvhLmORWS67GGD8RIsKk09WSqzHGN8Lp8dewn7jFGGO8YC1XY4yvhEvL1ZKrMcZXbCiWMcYEmz1EYIwxwef/KbADZ8nVGOMvYZJdLbkaY3zF+lyNMSYEwqXP1ca5GmN8JdjLE4pIWxH5XUTWi8gTIQj5nCy5GmP8JYjZVUQigfeAdkAV4CYRqRKKsM9k3QLGGN8QCPbcAjHAenfyfkTkK6AzsCaYFzkXXyXXZctid+fIIptCdPqCwO4QnTsjZOb4LXbvhDr+S4N5smXLYqfmyCIF03BIdhFJumT0R6r6UZL3JYDNSd5vAepfSIyB8lVyVdVCoTq3iCz16xK8gcjM8Vvs3sls8atqW69jCBbrczXGhLOtQKkk70u6ZSFnydUYE86WABVEpIyIZAW6A+My4sK+6hYIsY9Sr+JrmTl+i907mT3+C6KqcSJyHzAViAQ+UdXVGXFtUdWMuI4xxlxUrFvAGGNCwJKrMcaEgCVXY4wJAUuuJuhEJEZE6rmvq4jIIyLS3uu40kNERnodg8mcLqbRApmGiFTGebJkkaoeTlLeVlWneBdZ6kRkIM5z3FEiMh3naZhZwBMiUktVX/A0wBSIyJlDdARoISJ5AVS1U4YHdQFEpDHO45+/qeo0r+O52Fx0owVE5A5V/dTrOM5HRB4A7gXWAjWBB1V1rLtvmarW9jC8VInIrzhxZwN2ACVV9aCI5MD5ZXGFl/GlRESW4TxzPgxQnOT6Jc7YSFR1jnfRpU5EFqtqjPv6Tpyfox+A1sB4VX3Zy/guNhdjt8AgrwNIxZ1AHVXtAjQHBojIg+6+zDDTZZyqxqvqUeBPVT0IoKrHgNPehpaqukAs8DRwQFVnA8dUdY7fE6srS5LXfYBWqjoIJ7ne4k1IF6+w7BYQkVXn2wUUychY0iEioStAVTeKSHPgWxG5lMyRXE+KSE43udZJKBSRPPg8uarqaeBNEfnG/fMfMte/kQgRyYfTaBJV3QWgqkdEJM7b0C4+mekHJy2KAG2AfWeUC/BzxoeTJv+ISE1VXQGgqodFpAPwCVDd08gC01RVT0BiskqQBejpTUhpo6pbgG4icg1w0Ot40iAPTstbABWRYqq6XURykTl+MYeVsOxzFZHhwKeqOv8c+75Q1Zs9CCsgIlIS56v1jnPsa6SqCzwIy2RiIpITKKKqG7yO5WISlsnVGGO8djHe0DLGmJCz5GqMMSFgyTUMiUi8iKwQkd9E5Bu3zy295/pMRK53Xw9LaXE3EWkuIlem4xobRc5e2uN85WfUOZzS/nPUf0ZE+qU1RmPSypJreDqmqjVVtRpwErgr6U4RSdcoEVX9j6qmtLBbcyDNydWYcGTJNfzNA8q7rcp57iOea0QkUkReE5ElIrJKRPoCiONdd533GUDhhBOJyGwRqeu+bisiy0RkpYjMFJHLcJL4w26ruYmIFBKR79xrLBGRRu6xBURkmoisFpFhBDBMSER+FJFY95g+Z+x70y2fKSKF3LJyIjLFPWae+0ixMRkmXMe5GhJbqO2AhPkIagPVVHWDm6AOqGo9EckGLBCRaUAtoBLOGu9FcB4H/eSM8xYCPsYZ07pBRPKr6l4RGQocVtXBbr0vgDdVdb6IlMaZDf5yYCAwX1WfdceS9g7g4/Ryr5EDWCIi36nqHuASYKmqPiwi/3XPfR/ODPx3qeo6EakPvA9clY6/RmPSxZJreMohIivc1/OA4Thf1xcnGevYGrgioT8VZwB6BaAp8KWqxgPbROSnc5y/ATA34Vyquvc8cVwNVJF/16HP7Q5obwpc5x47UUTOfNjjXB4QkWvd16XcWPfgPPU1xi0fDXzvXuNK4Jsk184WwDWMCRpLruHpmKrWTFrgJpkjSYuA+1V16hn1gjk1YATQQFWPnyOWgLmPAF8NNFTVoyIyG8h+nurqXnf/mX8HxmQk63O9eE0F7haRLAAiUlFELgHmAje6fbLFgBbnOHYh0FREyrjH5nfLDwHRSepNA+5PeCMiNd2Xc4Gb3bJ2QL5UYs0D7HMTa2WclnOCCCCh9X0zTnfDQWCDiHRzryEiUiOVaxgTVJZcL17DcPpTl4nIb8CHON9kfgDWuftGAr+ceaA7IUgfnK/gK/n3a/l44NqEG1rAA0Bd94bZGv4dtTAIJzmvxuke+DuVWKfgzA+7FngZJ7knOALEuJ/hKuBZt/wWoLcb32qgcwB/J8YEjT3+aowxIWAtV2OMCQFLrsYYEwKWXI0xJgQsuRpjTAhYcjXGmBCw5GqMMSFgydUYY0Lg/wGGzic3/i1OYQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Predict the values from the validation dataset\n",
+    "Y_pred = model4.predict(x_test)\n",
+    "# Convert predictions classes to one hot vectors \n",
+    "Y_pred_classes4 = np.argmax(Y_pred,axis = 1) \n",
+    "# Convert validation observations to one hot vectors\n",
+    "Y_true = np.argmax(y_test,axis = 1) \n",
+    "# compute the confusion matrix\n",
+    "confusion_mtx = confusion_matrix(Y_true, Y_pred_classes4) \n",
+    "# plot the confusion matrix\n",
+    "plot_confusion_matrix(confusion_mtx, \n",
+    "            classes = ['1','2','3','4','5'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fewer-character",
+   "metadata": {
+    "papermill": {
+     "duration": 1.391649,
+     "end_time": "2021-04-25T15:08:38.129104",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:36.737455",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2. Classification Report : "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "played-devon",
+   "metadata": {
+    "papermill": {
+     "duration": 1.390757,
+     "end_time": "2021-04-25T15:08:40.964927",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:39.574170",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "The classification report visualizer displays the precision, recall, F1, and support scores for the model.\n",
+    "\n",
+    "1. Precision :\n",
+    "    - Precision is the ability of a classiifer not to label an instance positive that is actually negative. \n",
+    "    - Basically, it is defined as as the ratio of true positives to the sum of true and false positives. “For all instances classified positive, what percent was correct?”\n",
+    "\n",
+    "2. Recall :\n",
+    "\n",
+    "    - Recall is the ability of a classifier to find all positive instances. \n",
+    "    - For each class it is defined as the ratio of true positives to the sum of true positives and false negatives. “For all instances that were actually positive, what percent was classified correctly?”\n",
+    "\n",
+    "3. F1 Score:\n",
+    "\n",
+    "    - The F1 score is a weighted harmonic mean of precision and recall such that the best score is 1.0 and the worst is 0.0 . \n",
+    "    - Generally speaking, F1 scores are lower than accuracy measures as they embed precision and recall into their computation.\n",
+    "\n",
+    "4. Supprt :\n",
+    "\n",
+    "    - Support is the number of actual occurrences of the class in the specified dataset. \n",
+    "    - Imbalanced support in the training data may indicate structural weaknesses in the reported scores of the classifier and could indicate the need for stratified sampling or rebalancing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "appropriate-wayne",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:08:44.038684Z",
+     "iopub.status.busy": "2021-04-25T15:08:44.037783Z",
+     "iopub.status.idle": "2021-04-25T15:08:44.055982Z",
+     "shell.execute_reply": "2021-04-25T15:08:44.056428Z"
+    },
+    "papermill": {
+     "duration": 1.424206,
+     "end_time": "2021-04-25T15:08:44.056570",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:42.632364",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "              precision    recall  f1-score   support\n",
+      "\n",
+      "           1       0.94      0.86      0.90      1221\n",
+      "           2       0.86      0.78      0.82      1197\n",
+      "           3       0.78      0.82      0.80      1203\n",
+      "           4       0.85      0.91      0.88      1225\n",
+      "           5       0.92      0.98      0.95      1154\n",
+      "\n",
+      "    accuracy                           0.87      6000\n",
+      "   macro avg       0.87      0.87      0.87      6000\n",
+      "weighted avg       0.87      0.87      0.87      6000\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "classes = ['1','2','3','4','5']\n",
+    "print(classification_report(Y_true, Y_pred_classes1, target_names = classes,zero_division=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "extraordinary-reference",
+   "metadata": {
+    "papermill": {
+     "duration": 1.406846,
+     "end_time": "2021-04-25T15:08:46.916129",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:45.509283",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6.12 Predicting on the Test Data ( Whichever model gives best accuracy on train and validation data )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "internal-enlargement",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-25T15:08:50.211618Z",
+     "iopub.status.busy": "2021-04-25T15:08:50.210432Z",
+     "iopub.status.idle": "2021-04-25T15:08:50.837988Z",
+     "shell.execute_reply": "2021-04-25T15:08:50.837461Z"
+    },
+    "papermill": {
+     "duration": 2.087132,
+     "end_time": "2021-04-25T15:08:50.838125",
+     "exception": false,
+     "start_time": "2021-04-25T15:08:48.750993",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "188/188 [==============================] - 1s 3ms/step - loss: 0.3076 - accuracy: 0.8697\n",
+      "Loss: 0.3076\n",
+      "Accuracy: 0.8697\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_score = model.evaluate(x_test, y_test)\n",
+    "#test_score_resnet = resmodel.evaluate(x_test, y_test) # For Resnet model ( Model 2)\n",
+    "#test_score_simple = model4.evaluate(x_test, y_test) # For Simple Neural network ( Model 4)\n",
+    "print(\"Loss: {:.4f}\".format(test_score[0]))\n",
+    "print(\"Accuracy: {:.4f}\".format(test_score[1]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "palestinian-exclusive",
+   "metadata": {},
+   "source": [
+    "### Reference Links for Fashion MNIST :\n",
+    "\n",
+    "- https://www.kaggle.com/fuzzywizard/fashion-mnist-cnn-keras-accuracy-93\n",
+    "- https://www.kaggle.com/girishgupta/fashion-mnist-using-resnet/data\n",
+    "- https://cv-tricks.com/keras/understand-implement-resnets/\n",
+    "- https://machinelearningmastery.com/adam-optimization-algorithm-for-deep-learning/\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3289.796604,
+   "end_time": "2021-04-25T15:08:55.368881",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "__notebook__.ipynb",
+   "output_path": "__notebook__.ipynb",
+   "parameters": {},
+   "start_time": "2021-04-25T14:14:05.572277",
+   "version": "2.3.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Fashion MNIST Dataset with custom labels
This is an image dataset based on publicly available Fashion MNIST Dataset dataset of small (28x28 pixels), grey-scale images of clothing items such as shoes, coats, pants, etc. The dataset was create to serve as a direct drop-in replacement for the well known MNIST dataset for benchmarking machine learning algorithms. It shares the same image size and structure. The target field was originally assigned a label for clothing type to each image as an integer from 0-9. The training set contains 60,000 examples and the test set 10,000 examples.

For this assignment, we are providing you the same input features, but the labels you will be using will be new. We have created a new label based on the data and calculated to be associated with each entry. The target is the modified label for the images obtained based on a formulation to categorize the fashion MNIST images to a new set of categories. The new categories are numbered 1-5, however, the detail regarding the categories is held out on purpose. The training dataset that you download from LEARN under Assignment 4 will have the "FashionMNIST with a Twist" dataset using these new labels.

The classification label is the feature target.